### PR TITLE
Add form to homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "express": "^4.16.3",
+    "final-form": "^4.4.0",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.8.0",
     "isomorphic-fetch": "^2.2.1",
@@ -31,6 +32,7 @@
     "react-apollo": "^2.1.2",
     "react-day-picker": "^7.1.4",
     "react-dom": "16.3.1",
+    "react-final-form": "^3.1.5",
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.2.2"
   },

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -83,6 +83,7 @@ const validate = values => {
 }
 
 const validationField = ({ touched, errors, attr }) => {
+  /* eslint-disable security/detect-object-injection */
   if (touched[attr] && errors[attr]) {
     return (
       <p className={`form-error ${attr}-error`}>
@@ -90,6 +91,7 @@ const validationField = ({ touched, errors, attr }) => {
       </p>
     )
   }
+  /* eslint-enable security/detect-object-injection */
 }
 
 class HomePage extends React.Component {
@@ -121,6 +123,7 @@ class HomePage extends React.Component {
                 <form
                   onSubmit={event => {
                     handleSubmit(event).then(() => {
+                      // eslint-disable-next-line react/prop-types
                       this.props.history.push('/calendar')
                     })
                   }}

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -7,6 +7,8 @@ import PageHeader from './PageHeader'
 import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
+import FieldSet from './forms/FieldSet'
+import { Radio } from './forms/MultipleChoice'
 import Button from './forms/Button'
 import { Form, Field } from 'react-final-form'
 
@@ -38,36 +40,6 @@ input[type="text"] {
     border: solid 0.2em black;
     width: 50%;
     height: 2em;
-}
-
-input[type="radio"] {
-    display: none;
-}
-
-input[type="radio"] + label {
-    color: ${theme.font.black};
-    font-family: ${theme.weight.m};
-    font-size: ${theme.font.md};
-
-}
-input[type="radio"] + label span {
-    display: inline-block;
-    width: 22px;
-    height: 22px;
-    vertical-align: middle;
-    cursor: pointer;
-    margin-right: ${theme.spacing.sm};
-    margin-bottom: ${theme.spacing.sm};
-    border-radius: 50%;
-}
-
-input[type="radio"] + label span {
-  background: url('https://cdn.rawgit.com/nmakuch/60034bd0d4b98c57dd90776b9816731f/raw/4dd00e085a17b996d8a7b6e9ffde14f02e7aae0a/empty.svg');
-  margin-top: ${theme.spacing.sm};
-}
-
-input[type="radio"]:checked + label span{
-  background: url('https://cdn.rawgit.com/nmakuch/e3cd68811dbc645d5c93e2b1626ddb2e/raw/6a1cd0e9541615fd3316063487bd6d702ad88a5d/checked.svg');
 }
 
 textarea {
@@ -168,26 +140,48 @@ class HomePage extends React.Component {
                   </div>
 
                   <div>
-                    <H2>
-                      <label htmlFor="reason" id="reason-label">
-                        Reason for rescheduling
-                      </label>
-                    </H2>
-                    <p id="reason-details">
-                      {' '}
-                      If you’re not sure if you can reschedule,{' '}
-                      <TextLink href="#">
-                        read the guidelines for rescheduling.
-                      </TextLink>{' '}
-                    </p>
-
-                    <Field
-                      name="reason"
-                      id="reason"
-                      component="input"
-                      type="text"
-                      placeholder="reason"
-                    />
+                    <FieldSet legendHidden={false}>
+                      <legend>
+                        <H2>Reason for rescheduling</H2>
+                      </legend>
+                      <p id="reason-details">
+                        {' '}
+                        If you’re not sure if you can reschedule,{' '}
+                        <TextLink href="#">
+                          read the guidelines for rescheduling.
+                        </TextLink>{' '}
+                      </p>
+                      <Radio
+                        label={<span>Travel</span>}
+                        value="travel"
+                        name="reason"
+                        id="reason-0"
+                      />
+                      <Radio
+                        label={<span>Medical</span>}
+                        value="medical"
+                        name="reason"
+                        id="reason-1"
+                      />
+                      <Radio
+                        label={<span>Work or School</span>}
+                        value="workOrSchool"
+                        name="reason"
+                        id="reason-2"
+                      />
+                      <Radio
+                        label={<span>Family</span>}
+                        value="family"
+                        name="reason"
+                        id="reason-3"
+                      />
+                      <Radio
+                        label={<span>Other</span>}
+                        value="other"
+                        name="reason"
+                        id="reason-4"
+                      />
+                    </FieldSet>
                   </div>
 
                   <div>

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -66,17 +66,7 @@ injectGlobal`
   }
 `
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
-
 const onSubmit = async values => {
-  await sleep(300)
-  let errors = {}
-  if (!values['last-name']) {
-    errors['last-name'] = 'Last name is required'
-  }
-  if (errors) {
-    return errors
-  }
   window.alert(JSON.stringify(values, 0, 2))
 }
 
@@ -108,16 +98,16 @@ class HomePage extends React.Component {
 
                   <div>
                     <TextInput
-                      name="last-name"
-                      id="last-name"
-                      labelledby="last-name-label last-name-details"
+                      name="fullName"
+                      id="fullName"
+                      labelledby="fullName-label fullName-details"
                     >
                       <H2>
-                        <label htmlFor="last-name" id="last-name-label">
+                        <label htmlFor="fullName" id="fullName-label">
                           Full name
                         </label>
                       </H2>
-                      <p id="last-name-details">
+                      <p id="fullName-details">
                         This is the full name you used on your citizenship
                         application.
                       </p>
@@ -126,17 +116,17 @@ class HomePage extends React.Component {
 
                   <div>
                     <TextInput
-                      name="uci-number"
-                      id="uci-number"
-                      labelledby="uci-number-label uci-number-details"
+                      name="uciNumber"
+                      id="uciNumber"
+                      labelledby="uciNumber-label uciNumber-details"
                     >
                       <H2>
-                        <label htmlFor="uci-number" id="uci-number-label">
+                        <label htmlFor="uciNumber" id="uciNumber-label">
                           UCI number
                         </label>{' '}
                         (A123456)
                       </H2>
-                      <p id="uci-number-details">
+                      <p id="uciNumber-details">
                         This number is at the top of the email we sent you
                       </p>
                     </TextInput>

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -67,17 +67,20 @@ injectGlobal`
 const validate = values => {
   const errors = {}
   if (!values.fullName) {
-    errors.fullName = 'Please enter your name'
+    errors.fullName =
+      'You need to tell us your full name so we can confirm your identity.'
   }
   if (!values.uciNumber) {
-    errors.uciNumber = 'Please enter your UCI Number'
+    errors.uciNumber =
+      'You need to tell us your paper file number so we can confirm your identity.'
   }
   if (!values.reason) {
-    errors.reason = 'Please select a reason you cannot attend'
+    errors.reason =
+      'Please tell us why you need to reschedule your test. If none of the options fit your situation, choose ‘Other’.'
   }
   if (!values.explanation) {
     errors.explanation =
-      'Please write a short explanation about why you can’t attend'
+      'Please tell us a bit more about why you need to reschedule your test.'
   }
   return errors
 }

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -8,6 +8,7 @@ import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
 import Button from './forms/Button'
+import { Form, Field } from 'react-final-form'
 
 injectGlobal`
 html, body {
@@ -79,6 +80,20 @@ textarea {
 
 `
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const onSubmit = async values => {
+  await sleep(300)
+  let errors = {}
+  if (!values['last-name']) {
+    errors['last-name'] = 'Last name is required'
+  }
+  if (errors) {
+    return errors
+  }
+  window.alert(JSON.stringify(values, 0, 2))
+}
+
 class HomePage extends React.Component {
   render() {
     return (
@@ -92,104 +107,116 @@ class HomePage extends React.Component {
           <PageHeader>
             <H1>Request a new Canadian Citizenship test date</H1>
           </PageHeader>
-
           <Content>
-            <form>
-              <H2>
-                <label htmlFor="last-name" id="last-name-label">
-                  Full name
-                </label>
-              </H2>
-              <p id="name-details">
-                This is the full name you used on your citizenship application.
-              </p>
-              <input type="text" name="last-name" id="last-name" />
-              <H2>
-                <label htmlFor="uci-number" id="uci-number-label">
-                  UCI number
-                </label>{' '}
-                (A123456)
-              </H2>
-              <p id="uci-number-details">
-                This number is at the top of the email we sent you.
-              </p>
-              <input
-                type="text"
-                name="uci-number"
-                id="uci-number"
-                aria-labelledby="uci-number-label uci-number-details"
-              />
-              <H2>
-                <label htmlFor="reason" id="reason-label">
-                  Reason for rescheduling
-                </label>
-              </H2>
-              <p id="reason-details">
-                {' '}
-                If you’re not sure if you can reschedule,{' '}
-                <TextLink href="#">
-                  read the guidelines for rescheduling.
-                </TextLink>{' '}
-              </p>
+            <Form
+              onSubmit={onSubmit}
+              render={({
+                handleSubmit,
+                submitError,
+                submitting,
+                pristine,
+                values,
+              }) => (
+                <form onSubmit={handleSubmit}>
+                  <pre>{JSON.stringify(values, 0, 2)}</pre>
+                  {submitError && <div className="error">{submitError}</div>}
 
-              <ul>
-                <li>
-                  <input type="radio" name="reason-travel" id="reason-travel" />{' '}
-                  <label htmlFor="reason-travel" id="travel-label">
-                    <span /> Travel
-                  </label>
-                </li>
+                  <Field name="last-name">
+                    {({ input, meta }) => (
+                      <div>
+                        <H2>
+                          <label htmlFor="last-name" id="last-name-label">
+                            Full name
+                          </label>
+                        </H2>
+                        <p id="last-name-details">
+                          This is the full name you used on your citizenship
+                          application.
+                        </p>
+                        <input
+                          {...input}
+                          id="last-name"
+                          type="text"
+                          placeholder="Full name"
+                          aria-labelledby="last-name-label last-name-details"
+                        />
+                        {(meta.error || meta.submitError) && (
+                          <span>{meta.error || meta.submitError}</span>
+                        )}
+                      </div>
+                    )}
+                  </Field>
 
-                <li>
-                  <input
-                    type="radio"
-                    name="reason-medical"
-                    id="reason-medical"
-                  />{' '}
-                  <label htmlFor="reason-medical" id="medical-label">
-                    <span /> Medical
-                  </label>
-                </li>
+                  <div>
+                    <H2>
+                      <label htmlFor="uci-number" id="uci-number-label">
+                        UCI number
+                      </label>{' '}
+                      (A123456)
+                    </H2>
+                    <p id="uci-number-details">
+                      This number is at the top of the email we sent you
+                    </p>
+                    <Field
+                      name="uci-number"
+                      id="uci-number"
+                      component="input"
+                      type="text"
+                      placeholder="UCI number"
+                      aria-labelledby="uci-number-label uci-number-details"
+                    />
+                  </div>
 
-                <li>
-                  <input type="radio" name="reason-work" id="reason-work" />{' '}
-                  <label htmlFor="reason-work" id="work-label">
-                    <span /> Work or school
-                  </label>
-                </li>
+                  <div>
+                    <H2>
+                      <label htmlFor="reason" id="reason-label">
+                        Reason for rescheduling
+                      </label>
+                    </H2>
+                    <p id="reason-details">
+                      {' '}
+                      If you’re not sure if you can reschedule,{' '}
+                      <TextLink href="#">
+                        read the guidelines for rescheduling.
+                      </TextLink>{' '}
+                    </p>
 
-                <li>
-                  <input type="radio" name="reason-family" id="reason-family" />{' '}
-                  <label htmlFor="reason-family" id="family-label">
-                    <span /> Family
-                  </label>
-                </li>
+                    <Field
+                      name="reason"
+                      id="reason"
+                      component="input"
+                      type="text"
+                      placeholder="reason"
+                    />
+                  </div>
 
-                <li>
-                  <input type="radio" name="reason-other" id="reason-other" />{' '}
-                  <label htmlFor="reason-other" id="other-label">
-                    <span /> Other
-                  </label>
-                </li>
-              </ul>
-              <H2>
-                <label
-                  className="explanation-header"
-                  htmlFor="explanation"
-                  id="explanation-label"
-                >
-                  Briefly tell us why you cant attend your test
-                </label>
-              </H2>
+                  <div>
+                    <H2>
+                      <label
+                        className="explanation-header"
+                        htmlFor="explanation"
+                        id="explanation-label"
+                      >
+                        Briefly tell us why you can’t attend your test
+                      </label>
+                    </H2>
+                    <p id="explanation-details">
+                      If you’re not sure that you can reschedule, read the
+                      guidelines for scheduling.
+                    </p>
+                    <Field
+                      name="explanation"
+                      id="explanation"
+                      component="textarea"
+                      aria-labelledby="explanation-label explanation-details"
+                    />
+                  </div>
 
-              <textarea
-                name="explanation"
-                id="explanation"
-                className="explanation-input"
-                aria-labelledby="explanation-label explanation-details"
-              />
-            </form>
-            <br />
+                  <Button disabled={submitting || pristine}>Next →</Button>
+                </form>
+              )}
+            />
+
             <NavLink to="/calendar">
               <Button>Next →</Button>
             </NavLink>

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -7,49 +7,63 @@ import PageHeader from './PageHeader'
 import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
+import TextInput from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
 import { Radio } from './forms/MultipleChoice'
 import Button from './forms/Button'
 import { Form, Field } from 'react-final-form'
 
 injectGlobal`
-html, body {
+  html, body {
     padding: 0;
-		margin: 0;
-		background: ${theme.colour.white};
-		height: 100%;
+    margin: 0;
+    background: ${theme.colour.white};
+    height: 100%;
     font-family: ${theme.weight.l};
     font-size: ${theme.font.md};
 
     ${mediaQuery.small(css`
       font-size: ${theme.font.xs};
     `)};
-	}
+  }
 
-#name-details, #uci-number-details,
-#explanation-details, #reason-details {
-    margin-top: ${theme.spacing.xs};
-}
+  form {
+    > div {
+      margin-bottom: ${theme.spacing.xl};
+    }
 
-ul {
-  padding-left: 0em;
-  list-style: none;
-}
+    legend > h2 {
+      margin-top: 0 !important;
+    }
 
-input[type="text"] {
-    border: solid 0.2em black;
-    width: 50%;
-    height: 2em;
-}
+    h2 + p,
+    legend + p {
+      margin-top: 0;
+    }
+  }
 
-textarea {
-  width: 60%;
-  height: 15em;
-  border: solid 0.2em black;
-  margin-top: ${theme.spacing.md};
-  resize: none;
-}
+  ul {
+    padding-left: 0em;
+    list-style: none;
+  }
 
+  textarea {
+    height: 10em;
+    resize: none;
+    width: 550px;
+    margin-top: ${theme.spacing.sm};
+
+    /* cribbed from TextInput */
+    font-size: ${theme.font.lg};
+    border: 3px solid ${theme.colour.grey}};
+    outline: 0;
+    padding: ${theme.spacing.xs};
+
+    &:focus {
+      outline: 3px solid ${theme.colour.focus};
+      outline-offset: 0px;
+    }
+  }
 `
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
@@ -90,53 +104,42 @@ class HomePage extends React.Component {
                 values,
               }) => (
                 <form onSubmit={handleSubmit}>
-                  <pre>{JSON.stringify(values, 0, 2)}</pre>
                   {submitError && <div className="error">{submitError}</div>}
 
-                  <Field name="last-name">
-                    {({ input, meta }) => (
-                      <div>
-                        <H2>
-                          <label htmlFor="last-name" id="last-name-label">
-                            Full name
-                          </label>
-                        </H2>
-                        <p id="last-name-details">
-                          This is the full name you used on your citizenship
-                          application.
-                        </p>
-                        <input
-                          {...input}
-                          id="last-name"
-                          type="text"
-                          placeholder="Full name"
-                          aria-labelledby="last-name-label last-name-details"
-                        />
-                        {(meta.error || meta.submitError) && (
-                          <span>{meta.error || meta.submitError}</span>
-                        )}
-                      </div>
-                    )}
-                  </Field>
+                  <div>
+                    <TextInput
+                      name="last-name"
+                      id="last-name"
+                      labelledby="last-name-label last-name-details"
+                    >
+                      <H2>
+                        <label htmlFor="last-name" id="last-name-label">
+                          Full name
+                        </label>
+                      </H2>
+                      <p id="last-name-details">
+                        This is the full name you used on your citizenship
+                        application.
+                      </p>
+                    </TextInput>
+                  </div>
 
                   <div>
-                    <H2>
-                      <label htmlFor="uci-number" id="uci-number-label">
-                        UCI number
-                      </label>{' '}
-                      (A123456)
-                    </H2>
-                    <p id="uci-number-details">
-                      This number is at the top of the email we sent you
-                    </p>
-                    <Field
+                    <TextInput
                       name="uci-number"
                       id="uci-number"
-                      component="input"
-                      type="text"
-                      placeholder="UCI number"
-                      aria-labelledby="uci-number-label uci-number-details"
-                    />
+                      labelledby="uci-number-label uci-number-details"
+                    >
+                      <H2>
+                        <label htmlFor="uci-number" id="uci-number-label">
+                          UCI number
+                        </label>{' '}
+                        (A123456)
+                      </H2>
+                      <p id="uci-number-details">
+                        This number is at the top of the email we sent you
+                      </p>
+                    </TextInput>
                   </div>
 
                   <div>
@@ -194,15 +197,11 @@ class HomePage extends React.Component {
                         Briefly tell us why you can’t attend your test
                       </label>
                     </H2>
-                    <p id="explanation-details">
-                      If you’re not sure that you can reschedule, read the
-                      guidelines for scheduling.
-                    </p>
                     <Field
                       name="explanation"
                       id="explanation"
                       component="textarea"
-                      aria-labelledby="explanation-label explanation-details"
+                      aria-labelledby="explanation-label"
                     />
                   </div>
 

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { NavLink } from 'react-router-dom'
 import { injectGlobal } from 'emotion'
 import { css } from 'react-emotion'
 import { mediaQuery, theme, H1, H2, Content, TextLink } from './styles'
@@ -40,11 +39,10 @@ injectGlobal`
     legend + p {
       margin-top: 0;
     }
-  }
 
-  ul {
-    padding-left: 0em;
-    list-style: none;
+    .form-error {
+      color: red;
+    }
   }
 
   textarea {
@@ -66,8 +64,32 @@ injectGlobal`
   }
 `
 
-const onSubmit = async values => {
-  window.alert(JSON.stringify(values, 0, 2))
+const validate = values => {
+  const errors = {}
+  if (!values.fullName) {
+    errors.fullName = 'Please enter your name'
+  }
+  if (!values.uciNumber) {
+    errors.uciNumber = 'Please enter your UCI Number'
+  }
+  if (!values.reason) {
+    errors.reason = 'Please select a reason you cannot attend'
+  }
+  if (!values.explanation) {
+    errors.explanation =
+      'Please write a short explanation about why you can’t attend'
+  }
+  return errors
+}
+
+const validationField = ({ touched, errors, attr }) => {
+  if (touched[attr] && errors[attr]) {
+    return (
+      <p className={`form-error ${attr}-error`}>
+        <strong>{errors[attr]}</strong>
+      </p>
+    )
+  }
 }
 
 class HomePage extends React.Component {
@@ -85,40 +107,49 @@ class HomePage extends React.Component {
           </PageHeader>
           <Content>
             <Form
-              onSubmit={onSubmit}
+              onSubmit={async values => {}}
+              validate={validate}
               render={({
                 handleSubmit,
                 submitError,
                 submitting,
                 pristine,
                 values,
+                errors,
+                touched,
               }) => (
-                <form onSubmit={handleSubmit}>
+                <form
+                  onSubmit={event => {
+                    handleSubmit(event).then(() => {
+                      this.props.history.push('/calendar')
+                    })
+                  }}
+                >
                   {submitError && <div className="error">{submitError}</div>}
-
                   <div>
                     <TextInput
                       name="fullName"
                       id="fullName"
-                      labelledby="fullName-label fullName-details"
+                      labelledby="fullName-label fullName-details fullName-error"
                     >
                       <H2>
                         <label htmlFor="fullName" id="fullName-label">
                           Full name
                         </label>
                       </H2>
+
                       <p id="fullName-details">
                         This is the full name you used on your citizenship
                         application.
                       </p>
+                      {validationField({ touched, errors, attr: 'fullName' })}
                     </TextInput>
                   </div>
-
                   <div>
                     <TextInput
                       name="uciNumber"
                       id="uciNumber"
-                      labelledby="uciNumber-label uciNumber-details"
+                      labelledby="uciNumber-label uciNumber-details uciNumber-error"
                     >
                       <H2>
                         <label htmlFor="uciNumber" id="uciNumber-label">
@@ -129,9 +160,9 @@ class HomePage extends React.Component {
                       <p id="uciNumber-details">
                         This number is at the top of the email we sent you
                       </p>
+                      {validationField({ touched, errors, attr: 'uciNumber' })}
                     </TextInput>
                   </div>
-
                   <div>
                     <FieldSet legendHidden={false}>
                       <legend>
@@ -144,6 +175,7 @@ class HomePage extends React.Component {
                           read the guidelines for rescheduling.
                         </TextLink>{' '}
                       </p>
+                      {validationField({ touched, errors, attr: 'reason' })}
                       <Radio
                         label={<span>Travel</span>}
                         value="travel"
@@ -176,7 +208,6 @@ class HomePage extends React.Component {
                       />
                     </FieldSet>
                   </div>
-
                   <div>
                     <H2>
                       <label
@@ -187,22 +218,33 @@ class HomePage extends React.Component {
                         Briefly tell us why you can’t attend your test
                       </label>
                     </H2>
+                    {validationField({ touched, errors, attr: 'explanation' })}
                     <Field
                       name="explanation"
                       id="explanation"
                       component="textarea"
-                      aria-labelledby="explanation-label"
+                      aria-labelledby="explanation-label explanation-error"
                     />
                   </div>
-
-                  <Button disabled={submitting || pristine}>Next →</Button>
+                  {/*
+                      Button is disabled if:
+                      - form has not been touched (ie, pristine)
+                      - form has been submitted (and is waiting)
+                      - the number of values entries is less than the total number of fields
+                    */}
+                  <Button
+                    disabled={
+                      pristine ||
+                      submitting ||
+                      Object.values(values).filter(v => v !== undefined)
+                        .length < Object.keys(touched).length
+                    }
+                  >
+                    Next →
+                  </Button>
                 </form>
               )}
             />
-
-            <NavLink to="/calendar">
-              <Button>Next →</Button>
-            </NavLink>
           </Content>
         </main>
         <Footer topBarBackground="black" />

--- a/src/forms/FieldSet.js
+++ b/src/forms/FieldSet.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'react-emotion'
+import { theme, visuallyhidden, mediaQuery } from '../styles'
+
+const fieldset = css`
+  border: none;
+  padding: 0;
+  margin: 0;
+  margin-bottom: ${theme.spacing.xl};
+
+  legend {
+    padding: 0;
+  }
+
+  ${mediaQuery.small(css`
+    margin-bottom: ${theme.spacing.md};
+  `)};
+`
+
+const legendHidden = css`
+  legend {
+    ${visuallyhidden};
+  }
+`
+
+class FieldSet extends React.Component {
+  constructor() {
+    super()
+    // Bind the method to the component context
+    this.renderChildren = this.renderChildren.bind(this)
+  }
+
+  renderChildren() {
+    return React.Children.map(this.props.children, (child, i) => {
+      return child
+    })
+  }
+
+  render() {
+    return (
+      <fieldset
+        className={css`
+          ${fieldset} ${this.props.legendHidden
+            ? css`
+                ${legendHidden};
+              `
+            : ``};
+        `}
+      >
+        {this.renderChildren()}
+      </fieldset>
+    )
+  }
+}
+
+FieldSet.propTypes = {
+  children: PropTypes.any.isRequired,
+  legendHidden: PropTypes.bool,
+}
+
+FieldSet.defaultProps = {
+  legendHidden: false,
+}
+
+export default FieldSet

--- a/src/forms/MultipleChoice.js
+++ b/src/forms/MultipleChoice.js
@@ -1,0 +1,267 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Field } from 'react-final-form'
+import { css } from 'react-emotion'
+import { theme, roundedEdges, mediaQuery } from '../styles'
+
+const govuk_multiple_choice = css`
+  display: block;
+  float: none;
+  clear: left;
+  position: relative;
+  padding: 0 0 0 38px;
+  margin-bottom: 10px;
+
+  input {
+    position: absolute;
+    cursor: pointer;
+    left: 0;
+    top: 0;
+    width: 38px;
+    height: 38px;
+    z-index: 1;
+    margin: 0;
+    zoom: 1;
+    filter: alpha(opacity=0);
+    opacity: 0;
+  }
+
+  label {
+    cursor: pointer;
+    padding: 8px 10px 9px 12px;
+    display: block;
+    -ms-touch-action: manipulation;
+    touch-action: manipulation;
+  }
+
+  input:disabled {
+    cursor: default;
+  }
+
+  input:disabled + label {
+    zoom: 1;
+    filter: alpha(opacity=50);
+    opacity: 0.5;
+    cursor: default;
+  }
+`
+
+const govuk_label_pseudo_elements = css`
+  input[type='radio'] + &::before {
+    content: '';
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    -webkit-border-radius: 50%;
+    -moz-border-radius: 50%;
+    border-radius: 50%;
+  }
+
+  input[type='radio'] + &::after {
+    content: '';
+    border: 10px solid;
+    width: 0;
+    height: 0;
+    position: absolute;
+    top: 9px;
+    left: 9px;
+    -webkit-border-radius: 50%;
+    -moz-border-radius: 50%;
+    border-radius: 50%;
+    zoom: 1;
+    filter: alpha(opacity=0);
+    opacity: 0;
+  }
+
+  input[type='checkbox'] + &::before {
+    content: '';
+    border: 2px solid;
+    background: transparent;
+    width: 34px;
+    height: 34px;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  input[type='checkbox'] + &::after {
+    content: '';
+    border: solid;
+    border-width: 0 0 5px 5px;
+    background: transparent;
+    border-top-color: transparent;
+    width: 17px;
+    height: 7px;
+    position: absolute;
+    top: 10px;
+    left: 8px;
+    -moz-transform: rotate(-45deg);
+    -o-transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg);
+    zoom: 1;
+    filter: alpha(opacity=0);
+    opacity: 0;
+  }
+
+  input[type='radio']:focus + &::before {
+    -webkit-box-shadow: 0 0 0 4px #ffbf47;
+    -moz-box-shadow: 0 0 0 4px #ffbf47;
+    box-shadow: 0 0 0 4px #ffbf47;
+  }
+
+  input[type='checkbox']:focus + &::before {
+    -webkit-box-shadow: 0 0 0 3px #ffbf47;
+    -moz-box-shadow: 0 0 0 3px #ffbf47;
+    box-shadow: 0 0 0 3px #ffbf47;
+  }
+
+  input:checked + &::after {
+    zoom: 1;
+    filter: alpha(opacity=100);
+    opacity: 1;
+  }
+`
+
+const cds_multiple_choice = css`
+  padding: 0 0 0 ${theme.spacing.xl};
+  margin-bottom: ${theme.spacing.sm};
+
+  input {
+    width: 24px;
+    height: 24px;
+  }
+
+  label {
+    display: inline-block;
+    padding: 0;
+    height: ${theme.spacing.xl};
+    font-size: ${theme.font.lg};
+    /* this is a bit of a hack */
+    line-height: 1.8;
+
+    > span {
+      padding: 0 ${theme.spacing.sm} 0 ${theme.spacing.xs};
+    }
+  }
+
+  ${mediaQuery.small(css`
+    margin-bottom: ${theme.spacing.md};
+
+    input {
+      width: 22px;
+      height: 22px;
+    }
+
+    label {
+      font-size: ${theme.font.md};
+
+      > span {
+        padding-left: 0;
+      }
+    }
+  `)};
+`
+
+const radio = css`
+  ${cds_multiple_choice};
+
+  input[type='radio'] + label::before {
+    border: 2px solid ${theme.colour.grey};
+    width: 22px;
+    height: 22px;
+    top: 2px;
+    left: 0;
+  }
+
+  input[type='radio'] + label::after {
+    border: 6px solid ${theme.colour.black};
+    top: 9px;
+    left: 7px;
+  }
+
+  ${mediaQuery.small(css`
+    input[type='radio'] + label::before {
+      width: 20px;
+      height: 20px;
+    }
+
+    input[type='radio'] + label::after {
+      top: 8px;
+      left: 6px;
+    }
+  `)};
+`
+
+const Radio = ({ label, value, name, id, children }) => (
+  <div
+    className={css`
+      ${govuk_multiple_choice} ${radio};
+    `}
+  >
+    <Field type="radio" component="input" name={name} id={id} value={value} />
+    <label htmlFor={id} className={govuk_label_pseudo_elements}>
+      {label}
+    </label>
+    {children}
+  </div>
+)
+
+const checkbox = css`
+  ${cds_multiple_choice};
+
+  input[type='checkbox'] + label::before {
+    border: 2px solid ${theme.colour.grey};
+    width: 22px;
+    height: 22px;
+    top: 2px;
+    left: 0;
+    ${roundedEdges};
+  }
+
+  input[type='checkbox'] + label::after {
+    border-width: 0 0 3px 3px;
+    width: 14px;
+    height: 7px;
+    top: 8px;
+    left: 4px;
+  }
+`
+
+const Checkbox = ({ label, value, name, id, children }) => (
+  <div
+    className={css`
+      ${govuk_multiple_choice} ${checkbox};
+    `}
+  >
+    <Field
+      type="checkbox"
+      component="input"
+      name={name}
+      id={id}
+      value={value}
+    />
+    <label htmlFor={id} className={govuk_label_pseudo_elements}>
+      {label}
+      {children}
+    </label>
+  </div>
+)
+
+let defaultProps = {
+  label: PropTypes.element.isRequired,
+  value: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  children: PropTypes.any,
+}
+
+Radio.propTypes = defaultProps
+Checkbox.propTypes = defaultProps
+
+export { Radio, Checkbox }

--- a/src/forms/MultipleChoice.js
+++ b/src/forms/MultipleChoice.js
@@ -131,6 +131,7 @@ const govuk_label_pseudo_elements = css`
 const cds_multiple_choice = css`
   padding: 0 0 0 ${theme.spacing.xl};
   margin-bottom: ${theme.spacing.sm};
+  font-family: ${theme.weight.m};
 
   input {
     width: 24px;

--- a/src/forms/TextInput.js
+++ b/src/forms/TextInput.js
@@ -2,16 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Field } from 'react-final-form'
 import { css } from 'react-emotion'
-import { theme, roundedEdges, mediaQuery } from '../styles'
+import { theme, mediaQuery } from '../styles'
 
 const text_input = css`
-  font-size: ${theme.font.md};
-  border: 3px solid ${theme.colour.grey}};
+  font-size: ${theme.font.lg};
+  border: 3px solid ${theme.colour.black}};
   outline: 0;
-  padding: ${theme.spacing.sm}px;
-  width: 300px;
-  margin-bottom: ${theme.spacing.xl}px;
-  ${roundedEdges};
+  padding: ${theme.spacing.xs};
+  width: 400px;
 
   &:focus {
     outline: 3px solid ${theme.colour.focus};

--- a/src/forms/TextInput.js
+++ b/src/forms/TextInput.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Field } from 'react-final-form'
+import { css } from 'react-emotion'
+import { theme, roundedEdges, mediaQuery } from '../styles'
+
+const text_input = css`
+  font-size: ${theme.font.md};
+  border: 3px solid ${theme.colour.grey}};
+  outline: 0;
+  padding: ${theme.spacing.sm}px;
+  width: 300px;
+  margin-bottom: ${theme.spacing.xl}px;
+  ${roundedEdges};
+
+  &:focus {
+    outline: 3px solid ${theme.colour.focus};
+    outline-offset: 0px;
+  }
+
+  ${mediaQuery.xs(css`
+    width: 100%;
+  `)};
+`
+
+const TextInput = ({ name, id, labelledby, children }) => (
+  <div>
+    {children}
+    <Field
+      type="text"
+      component="input"
+      name={name}
+      id={id}
+      aria-labelledby={labelledby}
+      className={text_input}
+    />
+  </div>
+)
+
+TextInput.propTypes = {
+  children: PropTypes.any.isRequired,
+  id: PropTypes.string.isRequired,
+  labelledby: PropTypes.string,
+  name: PropTypes.string.isRequired,
+}
+
+export default TextInput

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,7 +1897,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.5:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
@@ -3182,6 +3182,10 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+final-form@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.4.0.tgz#3eaa1305d7b03d1e5698ace5ff361d4d20d44ac0"
 
 finalhandler@1.1.1:
   version "1.1.1"
@@ -6380,6 +6384,10 @@ react-error-overlay@^2.0.0, react-error-overlay@^2.0.2:
 react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
+
+react-final-form@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-3.1.5.tgz#6fa0e4c61e49b691b679ef4c8a5ad3fe92df0956"
 
 react-helmet@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Form on homepage now looks way better than before.

Among the many changes in this PR are:

- using [react-final-form](https://github.com/final-form/react-final-form) form library
- added `MultipleChoice` component from NRCan PoC (ie, radio buttons)
- added `TextInput` component from NRCan PoC (ie, <input type="text" />)
- added `FieldSet` component from NRCan PoC (for wrapping radios)
- added inline client-side validation
  - if you leave a field empty, an error message pops up
- added good error messages
- removed Button link and now we just have a proper `<button>`

Still TODO: 

- Create form error component
- Add tests for new components
- Remove `Field` from radio and text box components
- Make `textarea` a component
- See if you can use `React.children` to give `id` and `name` attributes to radio buttons