### PR TITLE
Decouple our form components from react-final-form

### DIFF
--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -6,7 +6,7 @@ import PageHeader from './PageHeader'
 import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
-import TextInput from './forms/TextInput'
+import { TextInputAdapter } from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
 import { Radio } from './forms/MultipleChoice'
 import Button from './forms/Button'
@@ -133,7 +133,8 @@ class HomePage extends React.Component {
                 >
                   {submitError && <div className="error">{submitError}</div>}
                   <div>
-                    <TextInput
+                    <Field
+                      component={TextInputAdapter}
                       name="fullName"
                       id="fullName"
                       labelledby="fullName-label fullName-details fullName-error"
@@ -149,10 +150,11 @@ class HomePage extends React.Component {
                         application.
                       </p>
                       {validationField({ touched, errors, attr: 'fullName' })}
-                    </TextInput>
+                    </Field>
                   </div>
                   <div>
-                    <TextInput
+                    <Field
+                      component={TextInputAdapter}
                       name="uciNumber"
                       id="uciNumber"
                       labelledby="uciNumber-label uciNumber-details uciNumber-error"
@@ -167,7 +169,7 @@ class HomePage extends React.Component {
                         This number is at the top of the email we sent you
                       </p>
                       {validationField({ touched, errors, attr: 'uciNumber' })}
-                    </TextInput>
+                    </Field>
                   </div>
                   <div>
                     <FieldSet legendHidden={false}>

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -8,7 +8,7 @@ import FederalBanner from './FederalBanner'
 import Footer from './Footer'
 import { TextInputAdapter } from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
-import { Radio } from './forms/MultipleChoice'
+import { RadioAdapter } from './forms/MultipleChoice'
 import Button from './forms/Button'
 import { Form, Field } from 'react-final-form'
 
@@ -184,31 +184,36 @@ class HomePage extends React.Component {
                         </TextLink>{' '}
                       </p>
                       {validationField({ touched, errors, attr: 'reason' })}
-                      <Radio
+                      <Field
+                        component={RadioAdapter}
                         label={<span>Travel</span>}
                         value="travel"
                         name="reason"
                         id="reason-0"
                       />
-                      <Radio
+                      <Field
+                        component={RadioAdapter}
                         label={<span>Medical</span>}
                         value="medical"
                         name="reason"
                         id="reason-1"
                       />
-                      <Radio
+                      <Field
+                        component={RadioAdapter}
                         label={<span>Work or School</span>}
                         value="workOrSchool"
                         name="reason"
                         id="reason-2"
                       />
-                      <Radio
+                      <Field
+                        component={RadioAdapter}
                         label={<span>Family</span>}
                         value="family"
                         name="reason"
                         id="reason-3"
                       />
-                      <Radio
+                      <Field
+                        component={RadioAdapter}
                         label={<span>Other</span>}
                         value="other"
                         name="reason"

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -185,6 +185,7 @@ class HomePage extends React.Component {
                       </p>
                       {validationField({ touched, errors, attr: 'reason' })}
                       <Field
+                        type="radio"
                         component={RadioAdapter}
                         label={<span>Travel</span>}
                         value="travel"
@@ -192,6 +193,7 @@ class HomePage extends React.Component {
                         id="reason-0"
                       />
                       <Field
+                        type="radio"
                         component={RadioAdapter}
                         label={<span>Medical</span>}
                         value="medical"
@@ -199,6 +201,7 @@ class HomePage extends React.Component {
                         id="reason-1"
                       />
                       <Field
+                        type="radio"
                         component={RadioAdapter}
                         label={<span>Work or School</span>}
                         value="workOrSchool"
@@ -206,6 +209,7 @@ class HomePage extends React.Component {
                         id="reason-2"
                       />
                       <Field
+                        type="radio"
                         component={RadioAdapter}
                         label={<span>Family</span>}
                         value="family"
@@ -213,6 +217,7 @@ class HomePage extends React.Component {
                         id="reason-3"
                       />
                       <Field
+                        type="radio"
                         component={RadioAdapter}
                         label={<span>Other</span>}
                         value="other"

--- a/src/forms/MultipleChoice.js
+++ b/src/forms/MultipleChoice.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Field } from 'react-final-form'
 import { css } from 'react-emotion'
 import { theme, roundedEdges, mediaQuery } from '../styles'
 
@@ -208,9 +207,20 @@ const MultipleChoice = ({
   children,
   className,
   type,
+  onBlur,
+  onChange,
+  onFocus,
 }) => (
   <div className={className}>
-    <Field type={type} component="input" name={name} id={id} value={value} />
+    <input
+      type={type}
+      name={name}
+      id={id}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      onFocus={onFocus}
+    />
     <label htmlFor={id} className={govuk_label_pseudo_elements}>
       {label}
     </label>
@@ -226,11 +236,20 @@ MultipleChoice.propTypes = {
   name: PropTypes.string,
   id: PropTypes.string,
   children: PropTypes.any,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
 }
 
 const Radio = ({ ...props }) => (
   <MultipleChoice type="radio" className={radio} {...props} />
 )
+
+const RadioAdapter = ({ input, ...rest }) => <Radio {...input} {...rest} />
+
+RadioAdapter.propTypes = {
+  input: PropTypes.object.isRequired,
+}
 
 const checkbox = css`
   ${govuk_multiple_choice};
@@ -258,4 +277,12 @@ const Checkbox = ({ ...props }) => (
   <MultipleChoice type="checkbox" className={checkbox} {...props} />
 )
 
-export { Radio, Checkbox }
+const CheckboxAdapter = ({ input, ...rest }) => (
+  <CheckboxAdapter {...input} {...rest} />
+)
+
+CheckboxAdapter.propTypes = {
+  input: PropTypes.object.isRequired,
+}
+
+export { Radio, RadioAdapter, Checkbox, CheckboxAdapter }

--- a/src/forms/MultipleChoice.js
+++ b/src/forms/MultipleChoice.js
@@ -170,6 +170,7 @@ const cds_multiple_choice = css`
 `
 
 const radio = css`
+  ${govuk_multiple_choice};
   ${cds_multiple_choice};
 
   input[type='radio'] + label::before {
@@ -199,13 +200,17 @@ const radio = css`
   `)};
 `
 
-const Radio = ({ label, value, name, id, children }) => (
-  <div
-    className={css`
-      ${govuk_multiple_choice} ${radio};
-    `}
-  >
-    <Field type="radio" component="input" name={name} id={id} value={value} />
+const MultipleChoice = ({
+  label,
+  value,
+  name,
+  id,
+  children,
+  className,
+  type,
+}) => (
+  <div className={className}>
+    <Field type={type} component="input" name={name} id={id} value={value} />
     <label htmlFor={id} className={govuk_label_pseudo_elements}>
       {label}
     </label>
@@ -213,7 +218,22 @@ const Radio = ({ label, value, name, id, children }) => (
   </div>
 )
 
+MultipleChoice.propTypes = {
+  type: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  label: PropTypes.element.isRequired,
+  value: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  id: PropTypes.string,
+  children: PropTypes.any,
+}
+
+const Radio = ({ ...props }) => (
+  <MultipleChoice type="radio" className={radio} {...props} />
+)
+
 const checkbox = css`
+  ${govuk_multiple_choice};
   ${cds_multiple_choice};
 
   input[type='checkbox'] + label::before {
@@ -234,35 +254,8 @@ const checkbox = css`
   }
 `
 
-const Checkbox = ({ label, value, name, id, children }) => (
-  <div
-    className={css`
-      ${govuk_multiple_choice} ${checkbox};
-    `}
-  >
-    <Field
-      type="checkbox"
-      component="input"
-      name={name}
-      id={id}
-      value={value}
-    />
-    <label htmlFor={id} className={govuk_label_pseudo_elements}>
-      {label}
-      {children}
-    </label>
-  </div>
+const Checkbox = ({ ...props }) => (
+  <MultipleChoice type="checkbox" className={checkbox} {...props} />
 )
-
-let defaultProps = {
-  label: PropTypes.element.isRequired,
-  value: PropTypes.string.isRequired,
-  name: PropTypes.string,
-  id: PropTypes.string,
-  children: PropTypes.any,
-}
-
-Radio.propTypes = defaultProps
-Checkbox.propTypes = defaultProps
 
 export { Radio, Checkbox }

--- a/src/forms/TextInput.js
+++ b/src/forms/TextInput.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Field } from 'react-final-form'
 import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 
@@ -21,15 +20,27 @@ const text_input = css`
   `)};
 `
 
-const TextInput = ({ name, id, labelledby, children }) => (
+const TextInput = ({
+  name,
+  id,
+  labelledby,
+  value,
+  children,
+  onBlur,
+  onChange,
+  onFocus,
+}) => (
   <div>
     {children}
-    <Field
+    <input
       type="text"
-      component="input"
       name={name}
       id={id}
       aria-labelledby={labelledby}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      onFocus={onFocus}
       className={text_input}
     />
   </div>
@@ -40,6 +51,18 @@ TextInput.propTypes = {
   id: PropTypes.string.isRequired,
   labelledby: PropTypes.string,
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  value: PropTypes.string,
 }
 
-export default TextInput
+const TextInputAdapter = ({ input, ...rest }) => (
+  <TextInput {...input} {...rest} />
+)
+
+TextInputAdapter.propTypes = {
+  input: PropTypes.object.isRequired,
+}
+
+export { TextInput, TextInputAdapter }


### PR DESCRIPTION
Currently our `TextInput` component returns a `<Field>`, which is part of react-final-form. This means our components are tightly coupled to the react-final-form library (ie, they depend on it), and it makes them harder to test.

This pull request creates `*Adapter` components that make it so that we can pass in our custom components to a top-level Field (ie, `<Field component={TextInputAdapter}>`) and replicate the same behaviour.

This means our components are decoupled from the final-form ones. 

No visible or functional changes, but our codebase is cleaner.