### PR TITLE
Create Layout component, reorder some CSS 

### DIFF
--- a/src/CalendarPage.js
+++ b/src/CalendarPage.js
@@ -1,65 +1,44 @@
 import React, { Component } from 'react'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
-import { H1, Content, CalHeader, CalReminder, Bold } from './styles'
-import PageHeader from './PageHeader'
-import AlphaBanner from './AlphaBanner'
-import FederalBanner from './FederalBanner'
-import Footer from './Footer'
+import { CalHeader, CalReminder, Bold } from './styles'
+import Layout from './Layout'
 import Button from './forms/Button'
 import Calendar from './Calendar'
 
 class CalendarPage extends Component {
   render() {
     return (
-      <div>
-        <AlphaBanner>
-          {' '}
-          <span>
-            <Trans>This is a new service we are constantly improving.</Trans>
-          </span>{' '}
-        </AlphaBanner>
-        <FederalBanner />
-        <main role="main">
-          <PageHeader>
-            <H1>
-              <Trans>Request a new Canadian Citizenship test date</Trans>
-            </H1>
-          </PageHeader>
-          <Content>
-            <NavLink to="/">
-              <p>
-                <Trans>← Go Back</Trans>
-              </p>
-            </NavLink>
+      <Layout>
+        <NavLink to="/">
+          <Trans>← Go Back</Trans>
+        </NavLink>
+        {/* TODO: add bottom spacing to Go Back links */}
+        <br />
+        <br />
 
-            <CalHeader>
-              <Trans>
-                Citizenship Tests are scheduled on <Bold>Tuesdays</Bold> and{' '}
-                <Bold>Fridays</Bold>. Use the calendar to select{' '}
-                <Bold>at least four days you’re available</Bold> in June and
-                July.
-              </Trans>
-            </CalHeader>
-            <Calendar />
-            <CalReminder>
-              <Trans>
-                Remember: make sure to stay available on all of the days you
-                select
-              </Trans>
-            </CalReminder>
-            <NavLink to="/confirmation">
-              <Button>
-                <Trans>Review →</Trans>
-              </Button>
-            </NavLink>
-            <NavLink to="/">
-              <Trans>Cancel</Trans>
-            </NavLink>
-          </Content>
-          <Footer topBarBackground="black" />
-        </main>
-      </div>
+        <CalHeader>
+          <Trans>
+            Citizenship Tests are scheduled on <Bold>Tuesdays</Bold> and{' '}
+            <Bold>Fridays</Bold>. Use the calendar to select{' '}
+            <Bold>at least four days you’re available</Bold> in June and July.
+          </Trans>
+        </CalHeader>
+        <Calendar />
+        <CalReminder>
+          <Trans>
+            Remember: make sure to stay available on all of the days you select
+          </Trans>
+        </CalReminder>
+        <NavLink to="/confirmation">
+          <Button>
+            <Trans>Review →</Trans>
+          </Button>
+        </NavLink>
+        <NavLink to="/">
+          <Trans>Cancel</Trans>
+        </NavLink>
+      </Layout>
     )
   }
 }

--- a/src/ConfirmationPage.js
+++ b/src/ConfirmationPage.js
@@ -1,13 +1,10 @@
 import React from 'react'
 import { css } from 'emotion'
-import { theme, H1, H2, Content } from './styles'
+import { theme, H1, H2 } from './styles'
 import { Trans } from 'lingui-react'
-import PageHeader from './PageHeader'
-import AlphaBanner from './AlphaBanner'
-import FederalBanner from './FederalBanner'
-import Footer from './Footer'
+import Layout from './Layout'
 
-const main = css`
+const mainClassName = css`
   section > h1 {
     margin-bottom: 0;
   }
@@ -25,45 +22,28 @@ const main = css`
 class ConfirmationPage extends React.Component {
   render() {
     return (
-      <div>
-        <AlphaBanner>
-          {' '}
-          <span>
-            <Trans>This is a new service we are constantly improving.</Trans>
-          </span>{' '}
-        </AlphaBanner>
-        <FederalBanner />
-        <main role="main" className={main}>
-          <PageHeader>
-            <H1>
-              <Trans>Request a new Canadian Citizenship test date</Trans>
-            </H1>
-          </PageHeader>
-          <Content>
-            <H1>
-              <Trans>Thank you! Your request has been received.</Trans>
-            </H1>
-            <p>
-              <Trans>We’ve sent you a confirmation email.</Trans>
-            </p>
-            <H2>
-              <Trans>What happens next?</Trans>
-            </H2>
-            <p>
-              <Trans>
-                Within six weeks, your local Immigration office will send you a
-                new appointment, or email you to ask for more information.
-              </Trans>
-            </p>
-            <H2>
-              <Trans>If you have any questions, please contact:</Trans>
-            </H2>
-            <p>vancouverIRCC@cic.gc.ca</p>
-            <p>1-888-242-2100</p>
-          </Content>
-          <Footer topBarBackground="black" />
-        </main>
-      </div>
+      <Layout mainClassName={mainClassName}>
+        <H1>
+          <Trans>Thank you! Your request has been received.</Trans>
+        </H1>
+        <p>
+          <Trans>We’ve sent you a confirmation email.</Trans>
+        </p>
+        <H2>
+          <Trans>What happens next?</Trans>
+        </H2>
+        <p>
+          <Trans>
+            Within six weeks, your local Immigration office will send you a new
+            appointment, or email you to ask for more information.
+          </Trans>
+        </p>
+        <H2>
+          <Trans>If you have any questions, please contact:</Trans>
+        </H2>
+        <p>vancouverIRCC@cic.gc.ca</p>
+        <p>1-888-242-2100</p>
+      </Layout>
     )
   }
 }

--- a/src/ConfirmationPage.js
+++ b/src/ConfirmationPage.js
@@ -4,7 +4,7 @@ import { theme, H1, H2 } from './styles'
 import { Trans } from 'lingui-react'
 import Layout from './Layout'
 
-const mainClassName = css`
+const mainClass = css`
   section > h1 {
     margin-bottom: 0;
   }
@@ -22,7 +22,7 @@ const mainClassName = css`
 class ConfirmationPage extends React.Component {
   render() {
     return (
-      <Layout mainClassName={mainClassName}>
+      <Layout mainClass={mainClass}>
         <H1>
           <Trans>Thank you! Your request has been received.</Trans>
         </H1>

--- a/src/ConfirmationPage.js
+++ b/src/ConfirmationPage.js
@@ -4,16 +4,16 @@ import { theme, H1, H2 } from './styles'
 import { Trans } from 'lingui-react'
 import Layout from './Layout'
 
-const mainClass = css`
-  section > h1 {
+const contentClass = css`
+  h1 {
     margin-bottom: 0;
   }
 
-  section > p + h2 {
+  p + h2 {
     margin-top: ${theme.spacing.xl};
   }
 
-  section > p {
+  p {
     margin-top: ${theme.spacing.xs};
     margin-bottom: ${theme.spacing.xs};
   }
@@ -22,7 +22,7 @@ const mainClass = css`
 class ConfirmationPage extends React.Component {
   render() {
     return (
-      <Layout mainClass={mainClass}>
+      <Layout contentClass={contentClass}>
         <H1>
           <Trans>Thank you! Your request has been received.</Trans>
         </H1>

--- a/src/FourOhFourPage.js
+++ b/src/FourOhFourPage.js
@@ -4,18 +4,16 @@ import { NavLink } from 'react-router-dom'
 import { H1, H2, theme } from './styles'
 import Layout from './Layout'
 
-const mainClass = css`
-  section {
-    p {
-      padding-bottom: ${theme.spacing.lg};
-    }
+const contentClass = css`
+  p {
+    padding-bottom: ${theme.spacing.lg};
   }
 `
 
 class FourOhFourPage extends React.Component {
   render() {
     return (
-      <Layout mainClass={mainClass}>
+      <Layout contentClass={contentClass}>
         <H1>404: Page not found</H1>
         <H2>Oops! We can’t seem to find the page you are looking for:</H2>
         <p>

--- a/src/FourOhFourPage.js
+++ b/src/FourOhFourPage.js
@@ -1,18 +1,27 @@
 import React from 'react'
-import { H1, H2, ErrorMessage } from './styles'
+import { css } from 'react-emotion'
 import { NavLink } from 'react-router-dom'
+import { H1, H2, theme } from './styles'
 import Layout from './Layout'
+
+const mainClass = css`
+  section {
+    p {
+      padding-bottom: ${theme.spacing.lg};
+    }
+  }
+`
 
 class FourOhFourPage extends React.Component {
   render() {
     return (
-      <Layout>
+      <Layout mainClass={mainClass}>
         <H1>404: Page not found</H1>
         <H2>Oops! We can’t seem to find the page you are looking for:</H2>
-        <ErrorMessage>
+        <p>
           If you wish to restart the rescheduling process, please navigate to
           the Home Page and start the process again.
-        </ErrorMessage>
+        </p>
         <NavLink to="/">← Go Back</NavLink>
       </Layout>
     )

--- a/src/FourOhFourPage.js
+++ b/src/FourOhFourPage.js
@@ -1,40 +1,20 @@
 import React from 'react'
-import { H1, H2, ErrorContent, ErrorMessage } from './styles'
+import { H1, H2, ErrorMessage } from './styles'
 import { NavLink } from 'react-router-dom'
-import PageHeader from './PageHeader'
-import AlphaBanner from './AlphaBanner'
-import FederalBanner from './FederalBanner'
-import Footer from './Footer'
+import Layout from './Layout'
 
 class FourOhFourPage extends React.Component {
   render() {
     return (
-      <div>
-        <AlphaBanner>
-          {' '}
-          <span>This is a new service we are constantly improving.</span>{' '}
-        </AlphaBanner>
-        <FederalBanner />
-        <main role="main">
-          <PageHeader>
-            <H1>Request a new Canadian Citizenship test date</H1>
-          </PageHeader>
-
-          <ErrorContent>
-            <H1>404: Page not found</H1>
-            <H2>Oops! We cant seem to find the page you are looking for:</H2>
-            <ErrorMessage>
-              If you wish to restart the rescheduling process, please navigate
-              to the Home Page and start the process again.
-            </ErrorMessage>
-            <NavLink to="/">
-              <p>← Go Back</p>
-            </NavLink>
-          </ErrorContent>
-
-          <Footer topBarBackground="black" />
-        </main>
-      </div>
+      <Layout>
+        <H1>404: Page not found</H1>
+        <H2>Oops! We can’t seem to find the page you are looking for:</H2>
+        <ErrorMessage>
+          If you wish to restart the rescheduling process, please navigate to
+          the Home Page and start the process again.
+        </ErrorMessage>
+        <NavLink to="/">← Go Back</NavLink>
+      </Layout>
     )
   }
 }

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Trans } from 'lingui-react'
-import { injectGlobal } from 'emotion'
 import { css } from 'react-emotion'
-import { mediaQuery, theme, H2, TextLink } from './styles'
+import { theme, H2, TextLink } from './styles'
 import Layout from './Layout'
 import { TextFieldAdapter, TextAreaAdapter } from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
@@ -10,20 +9,7 @@ import { RadioAdapter } from './forms/MultipleChoice'
 import Button from './forms/Button'
 import { Form, Field } from 'react-final-form'
 
-injectGlobal`
-  html, body {
-    padding: 0;
-    margin: 0;
-    background: ${theme.colour.white};
-    height: 100%;
-    font-family: ${theme.weight.l};
-    font-size: ${theme.font.md};
-
-    ${mediaQuery.small(css`
-      font-size: ${theme.font.xs};
-    `)};
-  }
-
+const contentClass = css`
   form {
     > div {
       margin-bottom: ${theme.spacing.xl};
@@ -94,7 +80,7 @@ const validationField = ({ touched, errors, attr }) => {
 class HomePage extends React.Component {
   render() {
     return (
-      <Layout>
+      <Layout contentClass={contentClass}>
         <Form
           onSubmit={async values => {}}
           validate={validate}

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -2,11 +2,8 @@ import React from 'react'
 import { Trans } from 'lingui-react'
 import { injectGlobal } from 'emotion'
 import { css } from 'react-emotion'
-import { mediaQuery, theme, H1, H2, Content, TextLink } from './styles'
-import PageHeader from './PageHeader'
-import AlphaBanner from './AlphaBanner'
-import FederalBanner from './FederalBanner'
-import Footer from './Footer'
+import { mediaQuery, theme, H2, TextLink } from './styles'
+import Layout from './Layout'
 import { TextFieldAdapter, TextAreaAdapter } from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
 import { RadioAdapter } from './forms/MultipleChoice'
@@ -45,7 +42,6 @@ injectGlobal`
       color: red;
     }
   }
-
 `
 
 const validate = values => {
@@ -98,214 +94,174 @@ const validationField = ({ touched, errors, attr }) => {
 class HomePage extends React.Component {
   render() {
     return (
-      <div>
-        <AlphaBanner>
-          {' '}
-          <span>
-            <Trans>This is a new service we are constantly improving.</Trans>
-          </span>{' '}
-        </AlphaBanner>
-        <FederalBanner />
-        <main role="main">
-          <PageHeader>
-            <H1>
-              <Trans>Request a new Canadian Citizenship test date</Trans>
-            </H1>
-          </PageHeader>
-          <Content>
-            <Form
-              onSubmit={async values => {}}
-              validate={validate}
-              render={({
-                handleSubmit,
-                submitError,
-                submitting,
-                pristine,
-                values,
-                errors,
-                touched,
-              }) => (
-                <form
-                  onSubmit={event => {
-                    handleSubmit(event).then(() => {
-                      // eslint-disable-next-line react/prop-types
-                      this.props.history.push('/calendar')
-                    })
-                  }}
+      <Layout>
+        <Form
+          onSubmit={async values => {}}
+          validate={validate}
+          render={({
+            handleSubmit,
+            submitError,
+            submitting,
+            pristine,
+            values,
+            errors,
+            touched,
+          }) => (
+            <form
+              onSubmit={event => {
+                handleSubmit(event).then(() => {
+                  // eslint-disable-next-line react/prop-types
+                  this.props.history.push('/calendar')
+                })
+              }}
+            >
+              {submitError && <div className="error">{submitError}</div>}
+              <div>
+                <Field
+                  component={TextFieldAdapter}
+                  name="fullName"
+                  id="fullName"
+                  labelledby="fullName-label fullName-details fullName-error"
                 >
-                  {submitError && <div className="error">{submitError}</div>}
-                  <div>
-                    <Field
-                      component={TextFieldAdapter}
-                      name="fullName"
-                      id="fullName"
-                      labelledby="fullName-label fullName-details fullName-error"
-                    >
-                      <H2>
-                        <label htmlFor="fullName" id="fullName-label">
-                          <Trans>Full name</Trans>
-                        </label>
-                      </H2>
+                  <H2>
+                    <label htmlFor="fullName" id="fullName-label">
+                      <Trans>Full name</Trans>
+                    </label>
+                  </H2>
 
-                      <p id="fullName-details">
-                        <Trans>
-                          This is the full name you used on your citizenship
-                          application.
-                        </Trans>
-                      </p>
-                      {validationField({ touched, errors, attr: 'fullName' })}
-                    </Field>
-                  </div>
-                  <div>
-                    <Field
-                      component={TextFieldAdapter}
-                      name="uciNumber"
-                      id="uciNumber"
-                      labelledby="uciNumber-label uciNumber-details uciNumber-error"
+                  <p id="fullName-details">
+                    <Trans>
+                      This is the full name you used on your citizenship
+                      application.
+                    </Trans>
+                  </p>
+                  {validationField({ touched, errors, attr: 'fullName' })}
+                </Field>
+              </div>
+              <div>
+                <Field
+                  component={TextFieldAdapter}
+                  name="uciNumber"
+                  id="uciNumber"
+                  labelledby="uciNumber-label uciNumber-details uciNumber-error"
+                >
+                  <H2>
+                    <label htmlFor="uciNumber" id="uciNumber-label">
+                      <Trans>Paper file number</Trans>
+                    </label>{' '}
+                    (123456)
+                  </H2>
+                  <p id="uciNumber-details">
+                    <Trans>
+                      This number is at the top of the email we sent you
+                    </Trans>
+                  </p>
+                  {validationField({ touched, errors, attr: 'uciNumber' })}
+                </Field>
+              </div>
+              <div>
+                <FieldSet legendHidden={false}>
+                  <legend>
+                    <H2>
+                      <Trans>Reason for rescheduling</Trans>
+                    </H2>
+                  </legend>
+                  <p id="reason-details">
+                    <Trans>If you’re not sure if you can reschedule,</Trans>{' '}
+                    <TextLink href="#">
+                      <Trans>read the guidelines for rescheduling</Trans>
+                    </TextLink>.
+                  </p>
+                  {validationField({ touched, errors, attr: 'reason' })}
+                  <Field
+                    type="radio"
+                    component={RadioAdapter}
+                    label={<Trans>Travel</Trans>}
+                    value="travel"
+                    name="reason"
+                    id="reason-0"
+                  />
+                  <Field
+                    type="radio"
+                    component={RadioAdapter}
+                    label={<Trans>Medical</Trans>}
+                    value="medical"
+                    name="reason"
+                    id="reason-1"
+                  />
+                  <Field
+                    type="radio"
+                    component={RadioAdapter}
+                    label={<Trans>Work or School</Trans>}
+                    value="workOrSchool"
+                    name="reason"
+                    id="reason-2"
+                  />
+                  <Field
+                    type="radio"
+                    component={RadioAdapter}
+                    label={<Trans>Family</Trans>}
+                    value="family"
+                    name="reason"
+                    id="reason-3"
+                  />
+                  <Field
+                    type="radio"
+                    component={RadioAdapter}
+                    label={<Trans>Other</Trans>}
+                    value="other"
+                    name="reason"
+                    id="reason-4"
+                  />
+                </FieldSet>
+              </div>
+              <div>
+                {validationField({ touched, errors, attr: 'explanation' })}
+                <Field
+                  name="explanation"
+                  id="explanation"
+                  component={TextAreaAdapter}
+                  aria-labelledby="explanation-label explanation-error"
+                >
+                  <H2>
+                    <label
+                      className="explanation-header"
+                      htmlFor="explanation"
+                      id="explanation-label"
                     >
-                      <H2>
-                        <label htmlFor="uciNumber" id="uciNumber-label">
-                          <Trans>Paper file number</Trans>
-                        </label>{' '}
-                        (123456)
-                      </H2>
-                      <p id="uciNumber-details">
-                        <Trans>
-                          This number is at the top of the email we sent you
-                        </Trans>
-                      </p>
-                      {validationField({ touched, errors, attr: 'uciNumber' })}
-                    </Field>
-                  </div>
-                  <div>
-                    <FieldSet legendHidden={false}>
-                      <legend>
-                        <H2>
-                          <Trans>Reason for rescheduling</Trans>
-                        </H2>
-                      </legend>
-                      <p id="reason-details">
-                        {' '}
-                        <Trans>
-                          If you’re not sure if you can reschedule,
-                        </Trans>{' '}
-                        <TextLink href="#">
-                          <Trans>read the guidelines for rescheduling.</Trans>
-                        </TextLink>{' '}
-                      </p>
-                      {validationField({ touched, errors, attr: 'reason' })}
-                      <Field
-                        type="radio"
-                        component={RadioAdapter}
-                        label={
-                          <span>
-                            <Trans>Travel</Trans>
-                          </span>
-                        }
-                        value="travel"
-                        name="reason"
-                        id="reason-0"
-                      />
-                      <Field
-                        type="radio"
-                        component={RadioAdapter}
-                        label={
-                          <span>
-                            <Trans>Medical</Trans>
-                          </span>
-                        }
-                        value="medical"
-                        name="reason"
-                        id="reason-1"
-                      />
-                      <Field
-                        type="radio"
-                        component={RadioAdapter}
-                        label={
-                          <span>
-                            <Trans>Work or School</Trans>
-                          </span>
-                        }
-                        value="workOrSchool"
-                        name="reason"
-                        id="reason-2"
-                      />
-                      <Field
-                        type="radio"
-                        component={RadioAdapter}
-                        label={
-                          <span>
-                            <Trans>Family</Trans>
-                          </span>
-                        }
-                        value="family"
-                        name="reason"
-                        id="reason-3"
-                      />
-                      <Field
-                        type="radio"
-                        component={RadioAdapter}
-                        label={
-                          <span>
-                            <Trans>Other</Trans>
-                          </span>
-                        }
-                        value="other"
-                        name="reason"
-                        id="reason-4"
-                      />
-                    </FieldSet>
-                  </div>
-                  <div>
-                    {validationField({ touched, errors, attr: 'explanation' })}
-                    <Field
-                      name="explanation"
-                      id="explanation"
-                      component={TextAreaAdapter}
-                      aria-labelledby="explanation-label explanation-error"
-                    >
-                      <H2>
-                        <label
-                          className="explanation-header"
-                          htmlFor="explanation"
-                          id="explanation-label"
-                        >
-                          <Trans>
-                            Briefly tell us why you can’t attend your test
-                          </Trans>
-                        </label>
-                      </H2>
-                    </Field>
-                  </div>
-                  {/*
+                      <Trans>
+                        Briefly tell us why you can’t attend your test
+                      </Trans>
+                    </label>
+                  </H2>
+                </Field>
+              </div>
+              {/*
                       Button is disabled if:
                       - form has not been touched (ie, pristine)
                       - form has been submitted (and is waiting)
                       - the number of values entries is less than the total number of fields
                     */}
-                  <p>
-                    <strong>
-                      By submitting this request you are forfeiting your
-                      original test date.
-                    </strong>
-                  </p>
-                  <Button
-                    disabled={
-                      pristine ||
-                      submitting ||
-                      Object.values(values).filter(v => v !== undefined)
-                        .length < Object.keys(touched).length
-                    }
-                  >
-                    <Trans>Next →</Trans>
-                  </Button>
-                </form>
-              )}
-            />
-          </Content>
-        </main>
-        <Footer topBarBackground="black" />
-      </div>
+              <p>
+                <strong>
+                  By submitting this request you are forfeiting your original
+                  test date.
+                </strong>
+              </p>
+              <Button
+                disabled={
+                  pristine ||
+                  submitting ||
+                  Object.values(values).filter(v => v !== undefined).length <
+                    Object.keys(touched).length
+                }
+              >
+                <Trans>Next →</Trans>
+              </Button>
+            </form>
+          )}
+        />
+      </Layout>
     )
   }
 }

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { injectGlobal } from 'emotion'
 import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
@@ -42,5 +43,9 @@ const Layout = ({ children, contentClass = '' }) => (
     </main>
   </div>
 )
+Layout.propTypes = {
+  children: PropTypes.any.isRequired,
+  contentClass: PropTypes.string,
+}
 
 export default Layout

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,12 +1,29 @@
 import React from 'react'
+import { injectGlobal } from 'emotion'
+import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
-import { H1, Content } from './styles'
+import { theme, mediaQuery, H1, Content } from './styles'
 import PageHeader from './PageHeader'
 import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
 
-const Layout = ({ children, mainClass = '' }) => (
+injectGlobal`
+  html, body {
+    padding: 0;
+    margin: 0;
+    background: ${theme.colour.white};
+    height: 100%;
+    font-family: ${theme.weight.l};
+    font-size: ${theme.font.md};
+
+    ${mediaQuery.small(css`
+      font-size: ${theme.font.xs};
+    `)};
+  }
+`
+
+const Layout = ({ children, contentClass = '' }) => (
   <div>
     <AlphaBanner>
       <span>
@@ -14,13 +31,13 @@ const Layout = ({ children, mainClass = '' }) => (
       </span>
     </AlphaBanner>
     <FederalBanner />
-    <main role="main" className={mainClass}>
+    <main role="main">
       <PageHeader>
         <H1>
           <Trans>Request a new Canadian Citizenship test date</Trans>
         </H1>
       </PageHeader>
-      <Content>{children}</Content>
+      <Content className={contentClass}>{children}</Content>
       <Footer topBarBackground="black" />
     </main>
   </div>

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -6,7 +6,7 @@ import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
 
-const Layout = ({ children, mainClassName = '' }) => (
+const Layout = ({ children, mainClass = '' }) => (
   <div>
     <AlphaBanner>
       <span>
@@ -14,7 +14,7 @@ const Layout = ({ children, mainClassName = '' }) => (
       </span>
     </AlphaBanner>
     <FederalBanner />
-    <main role="main" className={mainClassName}>
+    <main role="main" className={mainClass}>
       <PageHeader>
         <H1>
           <Trans>Request a new Canadian Citizenship test date</Trans>

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Trans } from 'lingui-react'
+import { H1, Content } from './styles'
+import PageHeader from './PageHeader'
+import AlphaBanner from './AlphaBanner'
+import FederalBanner from './FederalBanner'
+import Footer from './Footer'
+
+const Layout = ({ children, mainClassName = '' }) => (
+  <div>
+    <AlphaBanner>
+      <span>
+        <Trans>This is a new service we are constantly improving.</Trans>
+      </span>
+    </AlphaBanner>
+    <FederalBanner />
+    <main role="main" className={mainClassName}>
+      <PageHeader>
+        <H1>
+          <Trans>Request a new Canadian Citizenship test date</Trans>
+        </H1>
+      </PageHeader>
+      <Content>{children}</Content>
+      <Footer topBarBackground="black" />
+    </main>
+  </div>
+)
+
+export default Layout

--- a/src/forms/__tests__/MultipleChoice.test.js
+++ b/src/forms/__tests__/MultipleChoice.test.js
@@ -18,7 +18,7 @@ const defaultAdapterProps = {
 }
 
 const getAdapterAttrib = (adapter, attr) =>
-  adapter.find('input')[0].attribs[attr]
+  adapter.find('input')[0].attribs[attr] // eslint-disable-line  security/detect-object-injection
 
 describe('<Radio> component', () => {
   it('has props assigned correctly', () => {

--- a/src/forms/__tests__/TextInput.test.js
+++ b/src/forms/__tests__/TextInput.test.js
@@ -36,7 +36,7 @@ describe('<TextField> component', () => {
 
 describe('<TextFieldAdapter> component', () => {
   const getAdapterAttrib = (adapter, attr) =>
-    adapter.find('input')[0].attribs[attr]
+    adapter.find('input')[0].attribs[attr] // eslint-disable-line  security/detect-object-injection
 
   it('has props assigned directly through input object', () => {
     const tfAdapter = render(<TextFieldAdapter {...defaultAdapterProps} />)
@@ -66,7 +66,7 @@ describe('<TextArea> component', () => {
 
 describe('<TextAreaAdapter> component', () => {
   const getAdapterAttrib = (adapter, attr) =>
-    adapter.find('textarea')[0].attribs[attr]
+    adapter.find('textarea')[0].attribs[attr] // eslint-disable-line  security/detect-object-injection
 
   it('has props assigned directly through input object', () => {
     const taAdapter = render(<TextAreaAdapter {...defaultAdapterProps} />)

--- a/src/styles.js
+++ b/src/styles.js
@@ -198,7 +198,3 @@ export const CalReminder = styled.div`
   font-family: ${theme.weight.s};
   padding: ${theme.spacing.xl} 0 ${theme.spacing.lg} 0;
 `
-
-export const ErrorMessage = styled.p`
-  padding-bottom: ${theme.spacing.lg};
-`

--- a/src/styles.js
+++ b/src/styles.js
@@ -160,11 +160,6 @@ export const Content = styled.section`
   box-sizing: border-box;
 `
 
-export const ErrorContent = styled.section`
-  padding: ${theme.spacing.xl} 0 ${theme.spacing.xxxl} ${theme.spacing.xxxl};
-  width: 35em;
-`
-
 export const Bold = styled.strong`
   font-family: ${theme.weight.b};
 `


### PR DESCRIPTION
Our pages all have common headers and footers, so some kind of Layout abstraction will help us maintain that consistency.

Also helps us move some of that global CSS, which means that we can move away from creating a ton of global styling on the Home page.

**Note**

I didn't put this is as a post-it note earlier today because I forgot about it. But I had been working on this since Friday (ie, I was already halfway through it), so I figured I should push on.
