### PR TITLE
Revert CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,15 @@ jobs:
   deploy_web:
     docker:
       - image: docker
+    working_directory: ~/repo/web
     steps:
       - checkout:
-          path: ~/repo/web
+          path: ~/repo
       - setup_remote_docker
       - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run: docker build  -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}" -t "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest" .
       - run: docker push "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
       - run: docker push "${DOCKER_REGISTRY}/${NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:latest"
-    working_directory: ~/repo
 
   deploy_api:
     docker:


### PR DESCRIPTION
Back to how it used to be when we had green checkmarks. 

If the branch is called `add-deploy`, it will run through the whole deploy process for us so we don't have to merge this change to master to see how it will turn out.