### PR TITLE
Page Titles + Removed client.css

### DIFF
--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -24,9 +24,6 @@ class Document extends React.Component {
           {helmet.title.toComponent()}
           {helmet.meta.toComponent()}
           {helmet.link.toComponent()}
-          {assets.client.css && (
-            <link rel="stylesheet" href={assets.client.css} />
-          )}
         </head>
         <body {...bodyAttrs}>
           <AfterRoot />

--- a/web/src/client.css
+++ b/web/src/client.css
@@ -1,6 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-}

--- a/web/src/client.js
+++ b/web/src/client.js
@@ -6,11 +6,9 @@ import { ensureReady, After } from '@jaredpalmer/after'
 import { ApolloProvider, Query } from 'react-apollo'
 import { I18nProvider } from 'lingui-react'
 import { unpackCatalog } from 'lingui-i18n'
-import './client.css'
 import routes from './routes'
 import createApolloClient from './utils/createApolloClient'
 import gql from 'graphql-tag'
-
 import en from '../locale/en/messages.js'
 import fr from '../locale/fr/messages.js'
 


### PR DESCRIPTION
Removed client.css file as well as the import within client.js

    body {
      margin: 0;
      padding: 0;
      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
    }

After our css resets, I'm pretty sure this wasn't doing anything