### PR TITLE
Clean up some words and radio styling

### DIFF
--- a/web/src/RegistrationPage.js
+++ b/web/src/RegistrationPage.js
@@ -66,7 +66,7 @@ const validate = values => {
   if (!values.paperFileNumber) {
     errors.paperFileNumber = (
       <Trans>
-        You need to tell us your Paper File Number so we can confirm your
+        You need to tell us your Paper file number so we can confirm your
         identity.
       </Trans>
     )

--- a/web/src/ReviewPage.js
+++ b/web/src/ReviewPage.js
@@ -43,7 +43,7 @@ class ReviewPage extends React.Component {
           </NavLink>
         </TopContainer>
         <H1>
-          <Trans>Review your request before sending it:</Trans>
+          <Trans>Review your request before sending it</Trans>
         </H1>
         <Query query={GET_USER_DATA}>
           {({ loading, error, data }) => {

--- a/web/src/ReviewPage.js
+++ b/web/src/ReviewPage.js
@@ -38,7 +38,7 @@ class ReviewPage extends React.Component {
     return (
       <Layout contentClass={contentClass}>
         <TopContainer>
-          <NavLink to="/">
+          <NavLink to="/calendar">
             <Trans>← Go Back</Trans>
           </NavLink>
         </TopContainer>

--- a/web/src/Summary.js
+++ b/web/src/Summary.js
@@ -69,7 +69,7 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
     <Row>
       <Column1>
         <H2>
-          <Trans>Full name:</Trans>
+          <Trans>Full name</Trans>
         </H2>
       </Column1>
       <Column2>
@@ -85,7 +85,7 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
     <Row>
       <Column1>
         <H2>
-          <Trans>Paper file number:</Trans>
+          <Trans>Paper file number</Trans>
         </H2>
       </Column1>
       <Column2>
@@ -101,7 +101,7 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
     <Row>
       <Column1>
         <H2>
-          <Trans>Reason:</Trans>
+          <Trans>Reason</Trans>
         </H2>
       </Column1>
       <Column2>
@@ -117,7 +117,7 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
     <Row>
       <Column1>
         <H2>
-          <Trans>Explanation:</Trans>
+          <Trans>Explanation</Trans>
         </H2>
       </Column1>
       <Column2>
@@ -133,7 +133,7 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
     <Row>
       <Column1>
         <H2>
-          <Trans>Availability:</Trans>
+          <Trans>Availability</Trans>
         </H2>
       </Column1>
       <Column2>

--- a/web/src/forms/MultipleChoice.js
+++ b/web/src/forms/MultipleChoice.js
@@ -128,8 +128,8 @@ const govuk_label_pseudo_elements = css`
 `
 
 const cds_multiple_choice = css`
-  padding: 0 0 0 ${theme.spacing.xl}px;
-  margin-bottom: ${theme.spacing.sm}px;
+  padding: 0 0 0 ${theme.spacing.xl};
+  margin-bottom: ${theme.spacing.sm};
   input {
     width: 24px;
     height: 24px;
@@ -137,14 +137,14 @@ const cds_multiple_choice = css`
   label {
     display: inline-block;
     padding: 0;
-    height: ${theme.spacing.xl}px;
+    height: initial;
     font-size: ${theme.font.lg};
     > span {
-      padding: 0 ${theme.spacing.sm}px 0 ${theme.spacing.xs}px;
+      padding: 0 ${theme.spacing.sm} 0 ${theme.spacing.xs};
     }
   }
   ${mediaQuery.small(css`
-    margin-bottom: ${theme.spacing.md}px;
+    margin-bottom: ${theme.spacing.md};
     input {
       width: 22px;
       height: 22px;

--- a/web/src/forms/MultipleChoice.js
+++ b/web/src/forms/MultipleChoice.js
@@ -164,6 +164,7 @@ const radio = css`
 
   input[type='radio'] + label::before {
     border: 2px solid ${theme.colour.black};
+    background-color: ${theme.colour.white};
     width: 22px;
     height: 22px;
     top: 6px;

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -18,14 +18,14 @@ describe('Server Side Rendering', () => {
     expect(response.text).toMatch(/Full name/)
   })
 
-  it('renders the calendar at /calendar', async () => {
+  it('renders the calendar page at /calendar', async () => {
     let response = await request(server).get('/calendar')
     expect(response.text).toMatch(/Use the calendar to select./)
   })
 
-  it('renders the calendar at /review', async () => {
+  it('renders the review page at /review', async () => {
     let response = await request(server).get('/review')
-    expect(response.text).toMatch(/Review your request before sending it:/)
+    expect(response.text).toMatch(/Review your request before sending it/)
   })
 
   it('renders a reassuring confirmation message at /confirmation', async () => {


### PR DESCRIPTION
Noticed a few little problems while demoing the app.

- radio inputs didn't have a white background
- some of the radio CSS was a bit mangled from a merge conflict or something
- colons for all form headings on review page
- "go back" on review page wasn't returning to the calendar