### PR TITLE
Fix the console warning that would occur in development

### DIFF
--- a/web/src/client.js
+++ b/web/src/client.js
@@ -31,6 +31,7 @@ ensureReady(routes).then(data =>
         `}
       >
         {({ loading, error, data }) => {
+          //If you are getting SSR warnings, comment out the ifs to debug further
           if (loading) return <p>loading... </p>
           if (error) return <p>Error</p>
 

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -80,14 +80,13 @@ const stateLink = withClientState({
   },
   typeDefs,
 })
-function createApolloClient({ ssrMode }) {
-  return new ApolloClient({
+const createApolloClient = ({ ssrMode }) =>
+  new ApolloClient({
     ssrMode,
     link: ApolloLink.from([stateLink]),
     cache: ssrMode
       ? new InMemoryCache()
       : new InMemoryCache().restore(window.__APOLLO_STATE__),
   })
-}
 
 export default createApolloClient

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -80,13 +80,14 @@ const stateLink = withClientState({
   },
   typeDefs,
 })
-const createApolloClient = ssrMode =>
-  new ApolloClient({
+function createApolloClient({ ssrMode }) {
+  return new ApolloClient({
     ssrMode,
     link: ApolloLink.from([stateLink]),
     cache: ssrMode
       ? new InMemoryCache()
       : new InMemoryCache().restore(window.__APOLLO_STATE__),
   })
+}
 
 export default createApolloClient


### PR DESCRIPTION
-issue stems from the server side rendering of the application being desynched from the client side. Issue stemmed from the createApolloClient function using a fat arrow syntax, not sure why that mattered. 

-Also added a comment as a reminder that any SSR warnings will be easier to debug if the two statements proceeding the comment get removed.