### PR TITLE
Add calendar validation logic

### DIFF
--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -221,13 +221,15 @@ const dayPicker = css`
   }
 `
 
-export default class Calendar extends Component {
+class Calendar extends Component {
   constructor(props) {
     super(props)
     this.handleDayClick = this.handleDayClick.bind(this)
+    this.updateFieldParams = this.updateFieldParams.bind(this)
     this.state = {
       selectedDays: [],
     }
+    this.props.input.value = this.state.selectedDays
   }
   handleDayClick(day, { selected, disabled }) {
     if (disabled) {
@@ -243,22 +245,39 @@ export default class Calendar extends Component {
       selectedDays.push(day)
     }
     this.setState({ selectedDays })
+    this.updateFieldParams()
+  }
+
+  updateFieldParams() {
+    this.props.input.value = this.state.selectedDays
+    this.props.input.onChange(this.props.input.value)
   }
 
   render() {
+    /* TODO: pass in dates as values */
+    let {
+      input: { onBlur, onFocus },
+    } = this.props
     return (
-      <DayPicker
-        className={css`
-          ${dayPickerDefault} ${dayPicker};
-        `}
-        month={new Date(2018, 5)}
-        fromMonth={new Date(2018, 5)}
-        toMonth={new Date(2018, 6)}
-        numberOfMonths={2}
-        disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
-        selectedDays={this.state.selectedDays}
-        onDayClick={this.handleDayClick}
-      />
+      <div>
+        <DayPicker
+          className={css`
+            ${dayPickerDefault} ${dayPicker};
+          `}
+          month={new Date(2018, 5)}
+          fromMonth={new Date(2018, 5)}
+          toMonth={new Date(2018, 6)}
+          numberOfMonths={2}
+          disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
+          onDayClick={this.handleDayClick}
+          selectedDays={this.state.selectedDays}
+          onFocus={v => onFocus(v)}
+          onBlur={v => onBlur(v)}
+        />
+      </div>
     )
   }
 }
+Calendar.defaultProps = {}
+
+export { Calendar }

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -306,4 +306,4 @@ class Calendar extends Component {
 }
 Calendar.propTypes = FieldAdapterPropTypes
 
-export { Calendar }
+export { Calendar as CalendarAdapter }

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -226,11 +226,13 @@ class Calendar extends Component {
     super(props)
     this.handleDayClick = this.handleDayClick.bind(this)
     this.updateFieldParams = this.updateFieldParams.bind(this)
+    this.dateToHTML = this.dateToHTML.bind(this)
     this.state = {
       selectedDays: [],
     }
     this.props.input.value = this.state.selectedDays
   }
+
   handleDayClick(day, { selected, disabled }) {
     if (disabled) {
       return
@@ -248,6 +250,15 @@ class Calendar extends Component {
     this.updateFieldParams()
   }
 
+  dateToHTML(date) {
+    /*
+      This function will standardize strings across timezones.
+      Source: https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
+    */
+    let tzOffset = date.getTimezoneOffset() * 60000 //offset in milliseconds
+    return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
+  }
+
   updateFieldParams() {
     this.props.input.value = this.state.selectedDays
     this.props.input.onChange(this.props.input.value)
@@ -256,7 +267,7 @@ class Calendar extends Component {
   render() {
     /* TODO: pass in dates as values */
     let {
-      input: { onBlur, onFocus },
+      input: { onBlur, onFocus, value },
     } = this.props
     return (
       <div>
@@ -274,6 +285,21 @@ class Calendar extends Component {
           onFocus={v => onFocus(v)}
           onBlur={v => onBlur(v)}
         />
+        {/*
+          This code demonstrates how to update the page as dates are selected.
+          It should be replaced as we fine-tune the interaction.
+        */}
+        <div id="selectedDays">
+          {value && value.length > 0 ? (
+            <ol>
+              {value.map((v, i) => (
+                <li key={i}>{`${i + 1}. ${this.dateToHTML(v)}`}</li>
+              ))}
+            </ol>
+          ) : (
+            'No dates selected'
+          )}
+        </div>
       </div>
     )
   }

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -229,7 +229,10 @@ export default class Calendar extends Component {
       selectedDays: [],
     }
   }
-  handleDayClick(day, { selected }) {
+  handleDayClick(day, { selected, disabled }) {
+    if (disabled) {
+      return
+    }
     const { selectedDays } = this.state
     if (selected) {
       const selectedIndex = selectedDays.findIndex(selectedDay =>

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -229,7 +229,7 @@ class Calendar extends Component {
     this.updateFieldParams = this.updateFieldParams.bind(this)
     this.dateToHTML = this.dateToHTML.bind(this)
     this.state = {
-      selectedDays: [],
+      selectedDays: this.props.input.value || [],
     }
     this.props.input.value = this.state.selectedDays
   }
@@ -266,7 +266,6 @@ class Calendar extends Component {
   }
 
   render() {
-    /* TODO: pass in dates as values */
     let {
       input: { onBlur, onFocus, value },
     } = this.props
@@ -282,7 +281,7 @@ class Calendar extends Component {
           numberOfMonths={2}
           disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
           onDayClick={this.handleDayClick}
-          selectedDays={this.state.selectedDays}
+          selectedDays={value || []}
           onFocus={v => onFocus(v)}
           onBlur={v => onBlur(v)}
         />

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import FieldAdapterPropTypes from './_Field'
 import DayPicker, { DateUtils } from 'react-day-picker'
 import { css } from 'emotion'
 
@@ -304,6 +305,6 @@ class Calendar extends Component {
     )
   }
 }
-Calendar.defaultProps = {}
+Calendar.propTypes = FieldAdapterPropTypes
 
 export { Calendar }

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
 import { css } from 'react-emotion'
@@ -117,6 +118,9 @@ class CalendarPage extends Component {
       </Layout>
     )
   }
+}
+CalendarPage.propTypes = {
+  history: PropTypes.any,
 }
 
 export default CalendarPage

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -24,7 +24,7 @@ const DAY_LIMIT = 3
 const onSubmit = async values => {
   await sleep(300)
 
-  if (!values.calendar || values.calendar.length === 0) {
+  if (!values.calendar || values.calendar.length < DAY_LIMIT) {
     return {
       [FORM_ERROR]: (
         <Trans>
@@ -32,12 +32,6 @@ const onSubmit = async values => {
           for you.
         </Trans>
       ),
-    }
-  } else if (values.calendar.length < DAY_LIMIT) {
-    let datesRemaining = DAY_LIMIT - values.calendar.length
-    let dateString = datesRemaining === 1 ? 'date' : 'dates'
-    return {
-      [FORM_ERROR]: `Please pick ${datesRemaining} more ${dateString} so we can schedule your test when it’s convenient for you.`,
     }
   }
   window.alert('CALENDAR SUCCESS!')

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -17,25 +17,7 @@ import { Calendar } from './Calendar'
 import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
-
 const DAY_LIMIT = 3
-
-const onSubmit = async values => {
-  await sleep(300)
-
-  if (!values.calendar || values.calendar.length < DAY_LIMIT) {
-    return {
-      [FORM_ERROR]: (
-        <Trans>
-          Please pick three (3) dates so we can schedule your test when it’s
-          convenient for you.
-        </Trans>
-      ),
-    }
-  }
-  window.alert('CALENDAR SUCCESS!')
-}
 
 const errorClass = css`
   display: block;
@@ -44,6 +26,25 @@ const errorClass = css`
 `
 
 class CalendarPage extends Component {
+  constructor(props) {
+    super(props)
+    this.onSubmit = this.onSubmit.bind(this)
+  }
+
+  async onSubmit(values, event) {
+    if (!values.calendar || values.calendar.length < DAY_LIMIT) {
+      return {
+        [FORM_ERROR]: (
+          <Trans>
+            Please select three (3) dates so we can schedule an appointment when
+            you are available.
+          </Trans>
+        ),
+      }
+    }
+    await this.props.history.push('/review')
+  }
+
   render() {
     return (
       <Layout>
@@ -67,7 +68,7 @@ class CalendarPage extends Component {
           </Trans>
         </CalHeader>
         <Form
-          onSubmit={onSubmit}
+          onSubmit={this.onSubmit}
           render={({
             handleSubmit,
             reset,

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -28,8 +28,8 @@ const onSubmit = async values => {
     return {
       [FORM_ERROR]: (
         <Trans>
-          Please pick 3 dates so we can schedule your test when it’s convenient
-          for you.
+          Please pick three (3) dates so we can schedule your test when it’s
+          convenient for you.
         </Trans>
       ),
     }
@@ -62,7 +62,8 @@ class CalendarPage extends Component {
           <Trans>
             Citizenship Tests are scheduled on <Bold>Tuesdays</Bold> and{' '}
             <Bold>Fridays</Bold>. Use the calendar to select{' '}
-            <Bold>at least four days you’re available</Bold> in June and July.
+            <Bold>at least three (3) days you’re available</Bold> in June and
+            July.
           </Trans>
         </CalHeader>
         <Form

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
+import { css } from 'react-emotion'
 import {
+  theme,
   visuallyhidden,
   CalHeader,
   CalReminder,
@@ -11,7 +13,41 @@ import {
 } from './styles'
 import Layout from './Layout'
 import Button from './forms/Button'
-import Calendar from './Calendar'
+import { Calendar } from './Calendar'
+import { Form, Field } from 'react-final-form'
+import { FORM_ERROR } from 'final-form'
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const DAY_LIMIT = 3
+
+const onSubmit = async values => {
+  await sleep(300)
+
+  if (!values.calendar || values.calendar.length === 0) {
+    return {
+      [FORM_ERROR]: (
+        <Trans>
+          Please pick 3 dates so we can schedule your test when it’s convenient
+          for you.
+        </Trans>
+      ),
+    }
+  } else if (values.calendar.length < DAY_LIMIT) {
+    let datesRemaining = DAY_LIMIT - values.calendar.length
+    let dateString = datesRemaining === 1 ? 'date' : 'dates'
+    return {
+      [FORM_ERROR]: `Please pick ${datesRemaining} more ${dateString} so we can schedule your test when it’s convenient for you.`,
+    }
+  }
+  window.alert('CALENDAR SUCCESS!')
+}
+
+const errorClass = css`
+  display: block;
+  color: red;
+  margin-bottom: ${theme.spacing.sm};
+`
 
 class CalendarPage extends Component {
   render() {
@@ -35,25 +71,53 @@ class CalendarPage extends Component {
             <Bold>at least four days you’re available</Bold> in June and July.
           </Trans>
         </CalHeader>
-        <Calendar />
-        <CalReminder>
-          <Trans>
-            Remember: make sure to stay available on all of the days you select
-          </Trans>
-        </CalReminder>
-        <BottomContainer>
-          <NavLink to="/review">
-            <Button>
-              <Trans>Review →</Trans>
-            </Button>
-          </NavLink>
+        <Form
+          onSubmit={onSubmit}
+          render={({
+            handleSubmit,
+            reset,
+            submitting,
+            pristine,
+            values,
+            errors,
+            submitError,
+          }) => (
+            <form onSubmit={handleSubmit}>
+              <div>
+                {submitError ? (
+                  <span className={errorClass}>
+                    <strong>{submitError}</strong>
+                  </span>
+                ) : (
+                  ''
+                )}
+                <Field
+                  name="calendar"
+                  component={Calendar}
+                  dayLimit={DAY_LIMIT}
+                />
+              </div>
 
-          <div>
-            <NavLink to="/">
-              <Trans>Cancel</Trans>
-            </NavLink>
-          </div>
-        </BottomContainer>
+              <CalReminder>
+                <Trans>
+                  Remember: make sure to stay available on all of the days you
+                  select
+                </Trans>
+              </CalReminder>
+              <BottomContainer>
+                <Button disabled={submitting}>
+                  <Trans>Review →</Trans>
+                </Button>
+
+                <div>
+                  <NavLink to="/">
+                    <Trans>Cancel</Trans>
+                  </NavLink>
+                </div>
+              </BottomContainer>
+            </form>
+          )}
+        />
       </Layout>
     )
   }

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -14,7 +14,7 @@ import {
 } from './styles'
 import Layout from './Layout'
 import Button from './forms/Button'
-import { Calendar } from './Calendar'
+import { CalendarAdapter } from './Calendar'
 import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
 
@@ -90,7 +90,7 @@ class CalendarPage extends Component {
                 )}
                 <Field
                   name="calendar"
-                  component={Calendar}
+                  component={CalendarAdapter}
                   dayLimit={DAY_LIMIT}
                 />
               </div>

--- a/web/src/RegistrationPage.js
+++ b/web/src/RegistrationPage.js
@@ -335,7 +335,6 @@ class RegistrationPage extends React.Component {
 RegistrationPage.propTypes = {
   client: PropTypes.object.isRequired,
   history: PropTypes.any,
-  push: PropTypes.any,
 }
 
 export default withApollo(RegistrationPage)

--- a/web/src/_Field.js
+++ b/web/src/_Field.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+
+const FieldAdapterPropTypes = {
+  input: PropTypes.shape({
+    value: PropTypes.any.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func,
+    onFocus: PropTypes.func,
+  }),
+}
+
+export default FieldAdapterPropTypes

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { Calendar } from '../Calendar'
+import { CalendarAdapter } from '../Calendar'
 
 const clickFirstDate = wrapper => {
   return wrapper
@@ -15,16 +15,16 @@ const defaultProps = ({ value = '' } = {}) => {
   }
 }
 
-describe('<Calendar />', () => {
+describe('<CalendarAdapter />', () => {
   it('renders June and July 2018', () => {
-    const wrapper = mount(<Calendar {...defaultProps()} />)
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
     expect(wrapper.text()).toMatch(/June 2018/)
     expect(wrapper.text()).toMatch(/July 2018/)
   })
 
   it('will prefill a date if an initial value is provided', () => {
     const wrapper = mount(
-      <Calendar
+      <CalendarAdapter
         {...defaultProps({ value: [new Date('2018-06-01T12:00:00.000')] })}
       />,
     )
@@ -36,7 +36,7 @@ describe('<Calendar />', () => {
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
     const wrapper = mount(
-      <Calendar
+      <CalendarAdapter
         {...defaultProps({
           value: [
             new Date('2018-06-01T12:00:00.000'),
@@ -52,7 +52,7 @@ describe('<Calendar />', () => {
   })
 
   it('selects a date when it is clicked', () => {
-    const wrapper = mount(<Calendar {...defaultProps()} />)
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
 
     expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
 
@@ -65,7 +65,7 @@ describe('<Calendar />', () => {
   })
 
   it('unselects a date when it is clicked twice', () => {
-    const wrapper = mount(<Calendar {...defaultProps()} />)
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
 
     expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
 

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -9,21 +9,21 @@ const clickFirstDate = wrapper => {
     .simulate('click')
 }
 
-const defaultProps = {
-  input: { value: '', onChange: () => {} },
+const defaultProps = ({ value = '' } = {}) => {
+  return {
+    input: { value: value, onChange: () => {} },
+  }
 }
 
 describe('<Calendar />', () => {
   it('renders June and July 2018', () => {
-    /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(<Calendar {...defaultProps} />)
+    const wrapper = mount(<Calendar {...defaultProps()} />)
     expect(wrapper.text()).toMatch(/June 2018/)
     expect(wrapper.text()).toMatch(/July 2018/)
   })
 
   it('selects a date when it is clicked', () => {
-    /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(<Calendar {...defaultProps} />)
+    const wrapper = mount(<Calendar {...defaultProps()} />)
 
     expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
 
@@ -36,8 +36,7 @@ describe('<Calendar />', () => {
   })
 
   it('unselects a date when it is clicked twice', () => {
-    /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(<Calendar {...defaultProps} />)
+    const wrapper = mount(<Calendar {...defaultProps()} />)
 
     expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
 

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -9,19 +9,22 @@ const clickFirstDate = wrapper => {
     .simulate('click')
 }
 
+const defaultProps = {
+  input: { value: '', onChange: () => {} },
+}
+
 describe('<Calendar />', () => {
   it('renders June and July 2018', () => {
     /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(<Calendar input={{ value: '', onChange: {} }} />)
+    const wrapper = mount(<Calendar {...defaultProps} />)
     expect(wrapper.text()).toMatch(/June 2018/)
     expect(wrapper.text()).toMatch(/July 2018/)
   })
 
   it('selects a date when it is clicked', () => {
     /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(
-      <Calendar input={{ value: '', onChange: () => {} }} />,
-    )
+    const wrapper = mount(<Calendar {...defaultProps} />)
+
     expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
 
     // click the first available day (June 1st, 2018)
@@ -34,9 +37,8 @@ describe('<Calendar />', () => {
 
   it('unselects a date when it is clicked twice', () => {
     /* TODO: create a calendar adaptor so that we don't need input */
-    const wrapper = mount(
-      <Calendar input={{ value: '', onChange: () => {} }} />,
-    )
+    const wrapper = mount(<Calendar {...defaultProps} />)
+
     expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
 
     // click the first available day (June 1st, 2018) twice

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Calendar } from '../Calendar'
+
+const clickFirstDate = wrapper => {
+  return wrapper
+    .find('.DayPicker-Day[aria-disabled=false]')
+    .first()
+    .simulate('click')
+}
+
+describe('<Calendar />', () => {
+  it('renders June and July 2018', () => {
+    /* TODO: create a calendar adaptor so that we don't need input */
+    const wrapper = mount(<Calendar input={{ value: '', onChange: {} }} />)
+    expect(wrapper.text()).toMatch(/June 2018/)
+    expect(wrapper.text()).toMatch(/July 2018/)
+  })
+
+  it('selects a date when it is clicked', () => {
+    /* TODO: create a calendar adaptor so that we don't need input */
+    const wrapper = mount(
+      <Calendar input={{ value: '', onChange: () => {} }} />,
+    )
+    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+
+    // click the first available day (June 1st, 2018)
+    clickFirstDate(wrapper)
+
+    expect(wrapper.find('#selectedDays').text()).toMatch(
+      '1. 2018-06-01T12:00:00.000',
+    )
+  })
+
+  it('unselects a date when it is clicked twice', () => {
+    /* TODO: create a calendar adaptor so that we don't need input */
+    const wrapper = mount(
+      <Calendar input={{ value: '', onChange: () => {} }} />,
+    )
+    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+
+    // click the first available day (June 1st, 2018) twice
+    clickFirstDate(wrapper)
+    clickFirstDate(wrapper)
+
+    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+  })
+})

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -22,15 +22,44 @@ describe('<Calendar />', () => {
     expect(wrapper.text()).toMatch(/July 2018/)
   })
 
+  it('will prefill a date if an initial value is provided', () => {
+    const wrapper = mount(
+      <Calendar
+        {...defaultProps({ value: [new Date('2018-06-01T12:00:00.000')] })}
+      />,
+    )
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. 2018-06-01T12:00:00.000',
+    )
+  })
+
+  it('will prefill multiple dates if multiple initial values are provided', () => {
+    const wrapper = mount(
+      <Calendar
+        {...defaultProps({
+          value: [
+            new Date('2018-06-01T12:00:00.000'),
+            new Date('2018-06-05T12:00:00.000'),
+          ],
+        })}
+      />,
+    )
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. 2018-06-01T12:00:00.0002. 2018-06-05T12:00:00.000',
+    )
+  })
+
   it('selects a date when it is clicked', () => {
     const wrapper = mount(<Calendar {...defaultProps()} />)
 
-    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
 
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
 
-    expect(wrapper.find('#selectedDays').text()).toMatch(
+    expect(wrapper.find('#selectedDays').text()).toEqual(
       '1. 2018-06-01T12:00:00.000',
     )
   })
@@ -38,12 +67,12 @@ describe('<Calendar />', () => {
   it('unselects a date when it is clicked twice', () => {
     const wrapper = mount(<Calendar {...defaultProps()} />)
 
-    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
 
     // click the first available day (June 1st, 2018) twice
     clickFirstDate(wrapper)
     clickFirstDate(wrapper)
 
-    expect(wrapper.find('#selectedDays').text()).toMatch('No dates selected')
+    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
   })
 })

--- a/web/src/forms/MultipleChoice.js
+++ b/web/src/forms/MultipleChoice.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import FieldAdapterPropTypes from '../_Field'
 import { css } from 'react-emotion'
 import { theme, roundedEdges, mediaQuery } from '../styles'
 
@@ -233,17 +234,13 @@ MultipleChoice.propTypes = {
   checked: PropTypes.bool,
 }
 
-const adapterPropTypes = {
-  input: PropTypes.object.isRequired,
-}
-
 const Radio = ({ ...props }) => (
   <MultipleChoice type="radio" className={radio} {...props} />
 )
 
 const RadioAdapter = ({ input, ...rest }) => <Radio {...input} {...rest} />
 
-RadioAdapter.propTypes = adapterPropTypes
+RadioAdapter.propTypes = FieldAdapterPropTypes
 
 const checkbox = css`
   ${govuk_multiple_choice};
@@ -276,6 +273,6 @@ const CheckboxAdapter = ({ input, ...rest }) => (
   <Checkbox {...input} {...rest} />
 )
 
-CheckboxAdapter.propTypes = adapterPropTypes
+CheckboxAdapter.propTypes = FieldAdapterPropTypes
 
 export { Radio, RadioAdapter, Checkbox, CheckboxAdapter }

--- a/web/src/forms/TextInput.js
+++ b/web/src/forms/TextInput.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import FieldAdapterPropTypes from '../_Field'
 import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 
@@ -73,9 +74,7 @@ const TextFieldAdapter = ({ input, ...rest }) => (
   <TextField {...input} {...rest} />
 )
 
-TextFieldAdapter.propTypes = {
-  input: PropTypes.object.isRequired,
-}
+TextFieldAdapter.propTypes = FieldAdapterPropTypes
 
 const TextArea = ({
   name,
@@ -108,6 +107,6 @@ const TextAreaAdapter = ({ input, ...rest }) => (
   <TextArea {...input} {...rest} />
 )
 
-TextAreaAdapter.propTypes = TextFieldAdapter.propTypes
+TextAreaAdapter.propTypes = FieldAdapterPropTypes
 
 export { TextField, TextFieldAdapter, TextArea, TextAreaAdapter }

--- a/web/src/forms/__tests__/MultipleChoice.test.js
+++ b/web/src/forms/__tests__/MultipleChoice.test.js
@@ -13,7 +13,7 @@ const defaultProps = {
 }
 
 const defaultAdapterProps = {
-  input: { value: defaultProps.value },
+  input: { value: defaultProps.value, onChange: () => {} },
   label: defaultProps.label,
 }
 

--- a/web/src/forms/__tests__/TextInput.test.js
+++ b/web/src/forms/__tests__/TextInput.test.js
@@ -14,7 +14,7 @@ const defaultProps = {
 }
 
 const defaultAdapterProps = {
-  input: {},
+  input: { value: '', onChange: () => {} },
   ...defaultProps,
 }
 


### PR DESCRIPTION
## tech cash 👇 
This pull request:
- Adds calendar validation
  - Navigates to the review page if 3 or more dates are selected
  - Shows an error if less than 3 dates are selected
- integrates our `Calendar` with `react-final-form`, so that we can use `onSubmit` to get the calendar values
- adds @zakkain's error message from #79 
- adds some basic unit tests for the `Calendar`
- resolves #52, although more work needs to be done on saving dates and making it a nice interaction
- allow dates to be pre-populated in the rendered calendar

## tech debt 👇 
This pull request does not:
- save dates to state (so they can be queried on the review page, for example)
- ~create a `CalendarAdaptor` component to separate our `Calendar` from `react-final-form`~
  - I don't think I want to do this anymore, actually.
- add unit tests for `CalendarPage`