### PR TITLE
Add hidden page titles to describe registration and calendar pages

### DIFF
--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
 import {
+  visuallyhidden,
   CalHeader,
   CalReminder,
   Bold,
@@ -16,6 +17,9 @@ class CalendarPage extends Component {
   render() {
     return (
       <Layout>
+        <h1 className={visuallyhidden}>
+          Now use the calendar to tell us when you’re available.
+        </h1>
         <TopContainer>
           <nav>
             <NavLink to="/register">

--- a/web/src/FederalBanner.js
+++ b/web/src/FederalBanner.js
@@ -45,7 +45,7 @@ const container = css`
 `
 
 const FederalBanner = () => (
-  <section className={container}>
+  <div className={container}>
     <Query query={GET_LANGUAGE_QUERY}>
       {({ data: { language } }) => (
         <div>
@@ -59,7 +59,7 @@ const FederalBanner = () => (
       )}
     </Query>
     <LanguageSwitcher />
-  </section>
+  </div>
 )
 
 export default FederalBanner

--- a/web/src/Footer.js
+++ b/web/src/Footer.js
@@ -64,13 +64,13 @@ const TopBar = styled.hr(
   {
     height: '0.4em',
     border: 'none',
-    marginTop: 0,
+    margin: 0,
   },
   props => ({ background: props.background }),
 )
 
 const Footer = ({ topBarBackground }) => (
-  <section>
+  <div>
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
     <footer className={footer}>
       <WordMark
@@ -90,7 +90,7 @@ const Footer = ({ topBarBackground }) => (
         </a>
       </div>
     </footer>
-  </section>
+  </div>
 )
 Footer.propTypes = {
   topBarBackground: PropTypes.string,

--- a/web/src/LanguageSwitcher.js
+++ b/web/src/LanguageSwitcher.js
@@ -25,7 +25,17 @@ export const LanguageSwitcher = () => (
       {({ data: { language } }) => (
         <Mutation mutation={CHANGE_LANGUAGE_MUTATION}>
           {switchLanguage => (
-            <a className={link} onClick={() => switchLanguage()}>
+            <a
+              tabIndex="0"
+              className={link}
+              onClick={() => switchLanguage()}
+              onKeyPress={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  switchLanguage()
+                }
+              }}
+            >
               {language === 'en' ? 'Français' : 'English'}
             </a>
           )}

--- a/web/src/RegistrationPage.js
+++ b/web/src/RegistrationPage.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Trans } from 'lingui-react'
 import { css } from 'react-emotion'
-import { theme, mediaQuery, TextLink } from './styles'
+import { theme, visuallyhidden, mediaQuery, TextLink } from './styles'
 import Layout from './Layout'
 import { TextFieldAdapter, TextAreaAdapter } from './forms/TextInput'
 import FieldSet from './forms/FieldSet'
@@ -166,6 +166,9 @@ class RegistrationPage extends React.Component {
   render() {
     return (
       <Layout contentClass={contentClass}>
+        <h1 className={visuallyhidden}>
+          First verify your identity and tell us why you need a new appointment.
+        </h1>
         <Form
           onSubmit={this.onSubmit}
           validate={validate}

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -232,7 +232,7 @@ export const H3 = styled.h3`
   font-family: ${theme.weight.s};
 `
 
-export const Content = styled.section`
+export const Content = styled.div`
   padding: ${theme.spacing.xl} ${theme.spacing.xxxl} ${theme.spacing.xxl}
     ${theme.spacing.xxxl};
   width: 100%;


### PR DESCRIPTION
This pull request does a few little things.

1. Adds hidden `<h1>`s to registration and calendar page so that a screenreader will tell you what the point of the page is. Resolves #80.
2. Changes some `<section>`s into `<div>`s. Addresses some of the concerns in #78.
3. Adds a tabindex and some keypress stuff to the language switcher. You wouldn't be able to find/use it with a keyboard otherwise.