### PR TITLE
Add makefile with docker-compose dev file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+dev:
+	docker-compose -f dev.yml -p dev up
+test:
+	jest --projects web/ api/
+

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,48 @@
+version: '3.6'
+services:
+  api:
+    environment:
+      - SENDING_ADDRESS
+      - IRCC_RECEIVING_ADDRESS
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_REGION
+    image: 'cdssnc/ircc-rescheduler-api:latest'
+    labels:
+      traefik.backend: api
+      traefik.frontend.entryPoints: dev
+      traefik.frontend.rule: 'PathPrefix:/graphql'
+      traefik.port: '3001'
+    ports:
+      - '3001'
+    volumes:
+      - ./api:/app
+  proxy:
+    command: >
+      --docker
+      --entryPoints="Name:dev Address::3004"
+    image: 'traefik:1.6'
+    ports:
+      - '3004:3004'
+      - '8080:8080'
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+  web:
+    image: 'cdssnc/ircc-rescheduler:latest'
+    user: irccapp
+    working_dir: /app
+    environment:
+      - RAZZLE_PUBLIC_DIR=/app/build/public
+      - NODE_ENV=development
+      - PORT=3004
+    labels:
+      traefik.backend: web
+      traefik.dev.frontend.rule: 'PathPrefix:/'
+      traefik.dev.frontend.entryPoints: dev
+      traefik.dev.port: '3004'
+    ports:
+      - '3004'
+      - '3005:3005'
+    volumes:
+      - ./web:/app:rw
+    command: yarn dev

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  modify: (config, { target, dev }, webpack) => {
+    if (config.devServer) {
+      config.devServer.host = '0.0.0.0'
+    }
+    return config
+  },
+}


### PR DESCRIPTION
Start the app in development mode with `make dev`.
If jest is installed globally you can also run `make test`.

Minor change to web service to get webpack-dev-server listening on all ports
rather than just locally so that it works in a container.

You will notice that port 3005 is mapped directly to the host rather than going
through the proxy like 3004. This is a workaround for fact that I couldn't
figure out how to get Traefik to properly route to both 3004 & 3005. I will
fight that battle again another day.

Also note the environmental variables that are expected to exist.