### PR TITLE
Save calendar dates

### DIFF
--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -231,7 +231,17 @@ const dateToISOString = date => {
   return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
 }
 
-const dateToHTMLString = date => date.toDateString()
+const dateToHTMLString = date => {
+  if (typeof date === 'string' || date instanceof String) {
+    /*
+      check if passed-in date is a string
+      source: https://stackoverflow.com/a/9436948/9728185
+    */
+    date = new Date(date)
+  }
+
+  return date.toDateString()
+}
 
 class Calendar extends Component {
   constructor(props) {

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -223,15 +223,6 @@ const dayPicker = css`
   }
 `
 
-const dateToISOString = date => {
-  /*
-    This function will standardize strings across timezones.
-    Source: https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
-  */
-  let tzOffset = date.getTimezoneOffset() * 60000 //offset in milliseconds
-  return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
-}
-
 class Calendar extends Component {
   constructor(props) {
     super(props)

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import FieldAdapterPropTypes from './_Field'
 import DayPicker, { DateUtils } from 'react-day-picker'
 import { css } from 'emotion'
-import Time from './Time'
+import Time, { makeGMTDate } from './Time'
 
 const dayPickerDefault = css`
   /* DayPicker styles */
@@ -238,6 +238,10 @@ class Calendar extends Component {
     if (disabled) {
       return
     }
+
+    /* Cast all Dates to 12 noon GMT */
+    day = makeGMTDate(day)
+
     const { selectedDays } = this.state
     if (selected) {
       const selectedIndex = selectedDays.findIndex(selectedDay =>

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -234,13 +234,28 @@ class Calendar extends Component {
     this.props.input.value = this.state.selectedDays
   }
 
-  handleDayClick(day, { selected, disabled }) {
+  async handleDayClick(day, { selected, disabled }) {
     if (disabled) {
       return
     }
 
     /* Cast all Dates to 12 noon GMT */
     day = makeGMTDate(day)
+
+    /*
+      The first time we return to this page with pre-populated dates,
+      - this.props.input.value will contain all of the pre-poulated dates
+      - this.state.selectedDates will be empty
+
+      So let's update the state with the prepopulated dates
+    */
+    if (
+      !this.state.selectedDays.length &&
+      this.props.input.value &&
+      this.props.input.value.length
+    ) {
+      await this.setState({ selectedDays: this.props.input.value })
+    }
 
     const { selectedDays } = this.state
     if (selected) {
@@ -251,7 +266,7 @@ class Calendar extends Component {
     } else {
       selectedDays.push(day)
     }
-    this.setState({ selectedDays })
+    await this.setState({ selectedDays })
     this.updateFieldParams()
   }
 

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -222,12 +222,22 @@ const dayPicker = css`
   }
 `
 
+const dateToISOString = date => {
+  /*
+    This function will standardize strings across timezones.
+    Source: https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
+  */
+  let tzOffset = date.getTimezoneOffset() * 60000 //offset in milliseconds
+  return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
+}
+
+const dateToHTMLString = date => date.toDateString()
+
 class Calendar extends Component {
   constructor(props) {
     super(props)
     this.handleDayClick = this.handleDayClick.bind(this)
     this.updateFieldParams = this.updateFieldParams.bind(this)
-    this.dateToHTML = this.dateToHTML.bind(this)
     this.state = {
       selectedDays: this.props.input.value || [],
     }
@@ -249,15 +259,6 @@ class Calendar extends Component {
     }
     this.setState({ selectedDays })
     this.updateFieldParams()
-  }
-
-  dateToHTML(date) {
-    /*
-      This function will standardize strings across timezones.
-      Source: https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
-    */
-    let tzOffset = date.getTimezoneOffset() * 60000 //offset in milliseconds
-    return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
   }
 
   updateFieldParams() {
@@ -293,7 +294,7 @@ class Calendar extends Component {
           {value && value.length > 0 ? (
             <ol>
               {value.map((v, i) => (
-                <li key={i}>{`${i + 1}. ${this.dateToHTML(v)}`}</li>
+                <li key={i}>{`${i + 1}. ${dateToHTMLString(v)}`}</li>
               ))}
             </ol>
           ) : (
@@ -306,4 +307,4 @@ class Calendar extends Component {
 }
 Calendar.propTypes = FieldAdapterPropTypes
 
-export { Calendar as CalendarAdapter }
+export { Calendar as CalendarAdapter, dateToISOString, dateToHTMLString }

--- a/web/src/Calendar.js
+++ b/web/src/Calendar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import FieldAdapterPropTypes from './_Field'
 import DayPicker, { DateUtils } from 'react-day-picker'
 import { css } from 'emotion'
+import Time from './Time'
 
 const dayPickerDefault = css`
   /* DayPicker styles */
@@ -231,18 +232,6 @@ const dateToISOString = date => {
   return new Date(date.valueOf() - tzOffset).toISOString().slice(0, -1)
 }
 
-const dateToHTMLString = date => {
-  if (typeof date === 'string' || date instanceof String) {
-    /*
-      check if passed-in date is a string
-      source: https://stackoverflow.com/a/9436948/9728185
-    */
-    date = new Date(date)
-  }
-
-  return date.toDateString()
-}
-
 class Calendar extends Component {
   constructor(props) {
     super(props)
@@ -303,8 +292,11 @@ class Calendar extends Component {
         <div id="selectedDays">
           {value && value.length > 0 ? (
             <ol>
-              {value.map((v, i) => (
-                <li key={i}>{`${i + 1}. ${dateToHTMLString(v)}`}</li>
+              {value.map((day, index) => (
+                <li key={index}>
+                  {`${index + 1}. `}
+                  <Time date={day} />
+                </li>
               ))}
             </ol>
           ) : (
@@ -317,4 +309,4 @@ class Calendar extends Component {
 }
 Calendar.propTypes = FieldAdapterPropTypes
 
-export { Calendar as CalendarAdapter, dateToISOString, dateToHTMLString }
+export { Calendar as CalendarAdapter }

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -20,7 +20,7 @@ import { FORM_ERROR } from 'final-form'
 import { withApollo } from 'react-apollo'
 import gql from 'graphql-tag'
 import { GET_USER_DATA } from './queries'
-import { makeDate } from './Time'
+import { makeGMTDate } from './Time'
 
 const DAY_LIMIT = 3
 
@@ -48,7 +48,7 @@ class CalendarPage extends Component {
 
       /* cast values to Date objects if selectedDays exists and has a length */
       if (data && data.selectedDays && data.selectedDays.length) {
-        let selectedDays = data.selectedDays.map(day => makeDate(day))
+        let selectedDays = data.selectedDays.map(day => makeGMTDate(day))
 
         this.setState({
           data: { calendar: selectedDays },

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -19,6 +19,8 @@ import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
 import { withApollo } from 'react-apollo'
 import gql from 'graphql-tag'
+import { GET_USER_DATA } from './queries'
+import { makeDate } from './Time'
 
 const DAY_LIMIT = 3
 
@@ -32,6 +34,29 @@ class CalendarPage extends Component {
   constructor(props) {
     super(props)
     this.onSubmit = this.onSubmit.bind(this)
+    this.state = { data: {} }
+  }
+
+  async componentDidMount() {
+    try {
+      // 'result' would also be to place to check for potential graphql errors
+      let result = await this.props.client.query({
+        query: GET_USER_DATA,
+      })
+
+      let { data } = result
+
+      /* cast values to Date objects if selectedDays exists and has a length */
+      if (data && data.selectedDays && data.selectedDays.length) {
+        let selectedDays = data.selectedDays.map(day => makeDate(day))
+
+        this.setState({
+          data: { calendar: selectedDays },
+        })
+      }
+    } catch (err) {
+      console.log(err) // eslint-disable-line no-console
+    }
   }
 
   async onSubmit(values, event) {
@@ -88,6 +113,7 @@ class CalendarPage extends Component {
         </CalHeader>
         <Form
           onSubmit={this.onSubmit}
+          initialValues={this.state.data}
           render={({
             handleSubmit,
             reset,
@@ -138,7 +164,8 @@ class CalendarPage extends Component {
   }
 }
 CalendarPage.propTypes = {
-  history: PropTypes.any,
+  history: PropTypes.object.isRequired,
+  client: PropTypes.object.isRequired,
 }
 
 export default withApollo(CalendarPage)

--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -17,6 +17,8 @@ import Button from './forms/Button'
 import { CalendarAdapter } from './Calendar'
 import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
+import { withApollo } from 'react-apollo'
+import gql from 'graphql-tag'
 
 const DAY_LIMIT = 3
 
@@ -43,6 +45,22 @@ class CalendarPage extends Component {
         ),
       }
     }
+
+    const { client } = this.props
+    try {
+      await client.mutate({
+        mutation: gql`
+          mutation($dates: [String]) {
+            selectDays(data: $dates) @client
+          }
+        `,
+        variables: { dates: values.calendar },
+      })
+    } catch (err) {
+      //should be a logger
+      console.log(err) // eslint-disable-line no-console
+    }
+
     await this.props.history.push('/review')
   }
 
@@ -123,4 +141,4 @@ CalendarPage.propTypes = {
   history: PropTypes.any,
 }
 
-export default CalendarPage
+export default withApollo(CalendarPage)

--- a/web/src/LinkStateDisplay.js
+++ b/web/src/LinkStateDisplay.js
@@ -4,20 +4,21 @@ import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
 const QUERY = gql`
-  query getUserData {
+  query {
     userRegistrationData @client {
       fullName
       paperFileNumber
       reason
       explanation
     }
+    selectedDays @client
   }
 `
 
 class LinkStateDisplay extends React.Component {
   render() {
     const {
-      data: { loading, error, userRegistrationData: values },
+      data: { loading, error, variables, networkStatus, ...values },
     } = this.props
     if (error) {
       return (

--- a/web/src/ReviewPage.js
+++ b/web/src/ReviewPage.js
@@ -55,6 +55,7 @@ class ReviewPage extends React.Component {
                 paperFileNumber={data.userRegistrationData.paperFileNumber}
                 explanation={data.userRegistrationData.explanation}
                 reason={this.translateReason(data.userRegistrationData.reason)}
+                selectedDays={data.selectedDays}
               />
             )
           }}

--- a/web/src/Summary.js
+++ b/web/src/Summary.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'react-emotion'
 import { H2, theme, TextLink, mediaQuery } from './styles'
 import { Trans } from 'lingui-react'
-import { dateToHTMLString } from './Calendar'
+import Time from './Time'
 
 const TableContainer = styled.div`
   width: 80%;
@@ -146,8 +146,10 @@ export const Summary = ({
       <Column2>
         {selectedDays && selectedDays.length > 0 ? (
           <ul>
-            {selectedDays.map((day, i) => (
-              <li key={i}>{`${dateToHTMLString(day)}`}</li>
+            {selectedDays.map((day, index) => (
+              <li key={index}>
+                <Time date={day} />
+              </li>
             ))}
           </ul>
         ) : (

--- a/web/src/Summary.js
+++ b/web/src/Summary.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'react-emotion'
 import { H2, theme, TextLink, mediaQuery } from './styles'
 import { Trans } from 'lingui-react'
+import { dateToHTMLString } from './Calendar'
 
 const TableContainer = styled.div`
   width: 80%;
@@ -64,7 +65,13 @@ const Column3 = styled.div`
   `)};
 `
 
-export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
+export const Summary = ({
+  fullName,
+  paperFileNumber,
+  reason,
+  explanation,
+  selectedDays,
+}) => (
   <TableContainer>
     <Row>
       <Column1>
@@ -137,17 +144,17 @@ export const Summary = ({ fullName, paperFileNumber, reason, explanation }) => (
         </H2>
       </Column1>
       <Column2>
-        <ul>
-          <li>
-            <Trans>Tuesday June 1, 2018</Trans>
-          </li>
-          <li>
-            <Trans>Friday June 11, 2018</Trans>
-          </li>
-          <li>
-            <Trans>Tuesday July 5, 2018</Trans>
-          </li>
-        </ul>
+        {selectedDays && selectedDays.length > 0 ? (
+          <ul>
+            {selectedDays.map((day, i) => (
+              <li key={i}>{`${dateToHTMLString(day)}`}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>
+            <Trans>No dates selected</Trans>
+          </p>
+        )}
       </Column2>
       <Column3>
         <TextLink className={change} href="#">
@@ -163,4 +170,5 @@ Summary.propTypes = {
   reason: PropTypes.object,
   explanation: PropTypes.string,
   paperFileNumber: PropTypes.string,
+  selectedDays: PropTypes.array,
 }

--- a/web/src/Time.js
+++ b/web/src/Time.js
@@ -7,13 +7,46 @@ import PropTypes from 'prop-types'
 */
 const _isString = v => typeof v === 'string' || v instanceof String
 
+/*
+  Unbelievably, we need to do this to get javascript's Date string functions
+  to reliably print out the days that we've selected on the calendar.
+  When dates are selected, a timezone is automatically created for the date,
+  based on the Locale.
+  Once you print the date, it will apply the timezone transformation and
+  possibly return a different date as a string representation.
+
+  For example, you might get:
+  var d = new Date("2018-06-05").toString()
+  Mon Jun 04 2018 20:00:00 GMT-0400 (EDT)
+
+  So by converting to UTC time, we offset the local timezone and can reliably
+  call string methods on our Date object. Amazing.
+
+  eg:
+  var d = _convertDateToUTC(new Date("2018-06-05")).toString()
+  Tue Jun 05 2018 00:00:00 GMT-0400 (EDT)
+
+  source: https://stackoverflow.com/a/14006555/9728185
+*/
+const _convertDateToUTC = date => {
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+  )
+}
+
 const dateToHTMLString = date => {
-  date = _isString(date) ? new Date(date) : date
+  date = _isString(date) ? _convertDateToUTC(new Date(date)) : date
+
   return date.toDateString()
 }
 
 const dateToISODateString = date => {
-  date = _isString(date) ? new Date(date) : date
+  date = _isString(date) ? _convertDateToUTC(new Date(date)) : date
 
   /*
   YYYY-MM-DD from "a valid date string"

--- a/web/src/Time.js
+++ b/web/src/Time.js
@@ -39,14 +39,17 @@ const _convertDateToUTC = date => {
   )
 }
 
+const makeDate = date =>
+  _isString(date) ? _convertDateToUTC(new Date(date)) : date
+
 const dateToHTMLString = date => {
-  date = _isString(date) ? _convertDateToUTC(new Date(date)) : date
+  date = makeDate(date)
 
   return date.toDateString()
 }
 
 const dateToISODateString = date => {
-  date = _isString(date) ? _convertDateToUTC(new Date(date)) : date
+  date = makeDate(date)
 
   /*
   YYYY-MM-DD from "a valid date string"
@@ -64,4 +67,4 @@ Time.propTypes = {
     .isRequired,
 }
 
-export { Time as default, dateToISODateString }
+export { Time as default, makeDate, dateToISODateString }

--- a/web/src/Time.js
+++ b/web/src/Time.js
@@ -2,61 +2,35 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 /*
-  check if passed-in variable is a string
-  source: https://stackoverflow.com/a/9436948/9728185
+  Convert all dates casted to 12:00:00 for the DayPicker
+  https://github.com/gpbl/react-day-picker/issues/199
 */
-const _isString = v => typeof v === 'string' || v instanceof String
-
-/*
-  Unbelievably, we need to do this to get javascript's Date string functions
-  to reliably print out the days that we've selected on the calendar.
-  When dates are selected, a timezone is automatically created for the date,
-  based on the Locale.
-  Once you print the date, it will apply the timezone transformation and
-  possibly return a different date as a string representation.
-
-  For example, you might get:
-  var d = new Date("2018-06-05").toString()
-  Mon Jun 04 2018 20:00:00 GMT-0400 (EDT)
-
-  So by converting to UTC time, we offset the local timezone and can reliably
-  call string methods on our Date object. Amazing.
-
-  eg:
-  var d = _convertDateToUTC(new Date("2018-06-05")).toString()
-  Tue Jun 05 2018 00:00:00 GMT-0400 (EDT)
-
-  source: https://stackoverflow.com/a/14006555/9728185
-*/
-const _convertDateToUTC = date => {
+const makeGMTDate = date => {
   return new Date(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds(),
+    new Date(date).toISOString().slice(0, 'YYYY-MM-DD'.length) +
+      'T12:00:00.000Z',
   )
 }
 
-const makeDate = date =>
-  _isString(date) ? _convertDateToUTC(new Date(date)) : date
-
 const dateToHTMLString = date => {
-  date = makeDate(date)
-
-  return date.toDateString()
+  /*
+    For now we are relying on a JS Date object toString method
+    but we will want to create our own
+  */
+  return makeGMTDate(date)
+    .toUTCString()
+    .slice(0, 'Day, DD Mon YYYY'.length)
 }
 
 const dateToISODateString = date => {
-  date = makeDate(date)
-
   /*
-  YYYY-MM-DD from "a valid date string"
-  ie, 2011-11-18
-  source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+    YYYY-MM-DD from "a valid date string"
+    ie, 2011-11-18
+    source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
   */
-  return date.toISOString().slice(0, 'YYYY-MM-DD'.length)
+  return makeGMTDate(date)
+    .toISOString()
+    .slice(0, 'YYYY-MM-DD'.length)
 }
 
 const Time = ({ date }) => (
@@ -67,4 +41,4 @@ Time.propTypes = {
     .isRequired,
 }
 
-export { Time as default, makeDate, dateToISODateString }
+export { Time as default, makeGMTDate, dateToISODateString }

--- a/web/src/Time.js
+++ b/web/src/Time.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+/*
+  check if passed-in variable is a string
+  source: https://stackoverflow.com/a/9436948/9728185
+*/
+const _isString = v => typeof v === 'string' || v instanceof String
+
+const dateToHTMLString = date => {
+  date = _isString(date) ? new Date(date) : date
+  return date.toDateString()
+}
+
+const dateToISODateString = date => {
+  date = _isString(date) ? new Date(date) : date
+
+  /*
+  YYYY-MM-DD from "a valid date string"
+  ie, 2011-11-18
+  source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#Valid_datetime_Values
+  */
+  return date.toISOString().slice(0, 'YYYY-MM-DD'.length)
+}
+
+const Time = ({ date }) => (
+  <time dateTime={dateToISODateString(date)}>{dateToHTMLString(date)}</time>
+)
+Time.propTypes = {
+  date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
+    .isRequired,
+}
+
+export { Time as default, dateToISODateString }

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -29,9 +29,7 @@ describe('<CalendarAdapter />', () => {
       />,
     )
 
-    expect(wrapper.find('#selectedDays').text()).toEqual(
-      '1. 2018-06-01T12:00:00.000',
-    )
+    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri Jun 01 2018')
   })
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
@@ -47,7 +45,7 @@ describe('<CalendarAdapter />', () => {
     )
 
     expect(wrapper.find('#selectedDays').text()).toEqual(
-      '1. 2018-06-01T12:00:00.0002. 2018-06-05T12:00:00.000',
+      '1. Fri Jun 01 20182. Tue Jun 05 2018',
     )
   })
 
@@ -59,9 +57,7 @@ describe('<CalendarAdapter />', () => {
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
 
-    expect(wrapper.find('#selectedDays').text()).toEqual(
-      '1. 2018-06-01T12:00:00.000',
-    )
+    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri Jun 01 2018')
   })
 
   it('unselects a date when it is clicked twice', () => {

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -71,4 +71,52 @@ describe('<CalendarAdapter />', () => {
 
     expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
   })
+
+  it('will keep pre-filled dates when clicking new ones', () => {
+    const wrapper = mount(
+      <CalendarAdapter
+        {...defaultProps({
+          value: [
+            new Date('2018-06-05T12:00:00.000'),
+            new Date('2018-06-08T12:00:00.000'),
+          ],
+        })}
+      />,
+    )
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. Tue, 05 Jun 20182. Fri, 08 Jun 2018',
+    )
+
+    // click the first available day (June 1st, 2018)
+    clickFirstDate(wrapper)
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. Tue, 05 Jun 20182. Fri, 08 Jun 20183. Fri, 01 Jun 2018',
+    )
+  })
+
+  it('will un-click pre-filled dates when clicking new ones', () => {
+    const wrapper = mount(
+      <CalendarAdapter
+        {...defaultProps({
+          value: [
+            new Date('2018-06-05T12:00:00.000'),
+            new Date('2018-06-08T12:00:00.000'),
+          ],
+        })}
+      />,
+    )
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. Tue, 05 Jun 20182. Fri, 08 Jun 2018',
+    )
+
+    // click the first available day (June 1st, 2018)
+    clickFirstDate(wrapper)
+
+    expect(wrapper.find('#selectedDays').text()).toEqual(
+      '1. Tue, 05 Jun 20182. Fri, 08 Jun 20183. Fri, 01 Jun 2018',
+    )
+  })
 })

--- a/web/src/__tests__/Calendar.test.js
+++ b/web/src/__tests__/Calendar.test.js
@@ -29,7 +29,7 @@ describe('<CalendarAdapter />', () => {
       />,
     )
 
-    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri Jun 01 2018')
+    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri, 01 Jun 2018')
   })
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
@@ -45,7 +45,7 @@ describe('<CalendarAdapter />', () => {
     )
 
     expect(wrapper.find('#selectedDays').text()).toEqual(
-      '1. Fri Jun 01 20182. Tue Jun 05 2018',
+      '1. Fri, 01 Jun 20182. Tue, 05 Jun 2018',
     )
   })
 
@@ -57,7 +57,7 @@ describe('<CalendarAdapter />', () => {
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
 
-    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri Jun 01 2018')
+    expect(wrapper.find('#selectedDays').text()).toEqual('1. Fri, 01 Jun 2018')
   })
 
   it('unselects a date when it is clicked twice', () => {

--- a/web/src/__tests__/Time.test.js
+++ b/web/src/__tests__/Time.test.js
@@ -14,13 +14,13 @@ describe('<Time />', () => {
   it('renders correctly from a Date object', () => {
     const time = shallow(<Time date={date} />)
     expect(time.props().dateTime).toEqual('1870-04-22')
-    expect(time.text()).toEqual('Fri Apr 22 1870')
+    expect(time.text()).toEqual('Fri, 22 Apr 1870')
   })
 
   it('renders correctly from a date string', () => {
     const time = shallow(<Time date={dateString} />)
     expect(time.props().dateTime).toEqual('1870-04-22')
-    expect(time.text()).toEqual('Fri Apr 22 1870')
+    expect(time.text()).toEqual('Fri, 22 Apr 1870')
   })
 })
 

--- a/web/src/__tests__/Time.test.js
+++ b/web/src/__tests__/Time.test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Time, { dateToISODateString } from '../Time'
+
+describe('<Time />', () => {
+  let dateString = 'Fri Apr 22 1870'
+  let date = new Date(dateString)
+
+  it('renders a <time> element', () => {
+    const time = shallow(<Time date={date} />)
+    expect(time.find('time').length).toEqual(1)
+  })
+
+  it('renders correctly from a Date object', () => {
+    const time = shallow(<Time date={date} />)
+    expect(time.props().dateTime).toEqual('1870-04-22')
+    expect(time.text()).toEqual('Fri Apr 22 1870')
+  })
+
+  it('renders correctly from a date string', () => {
+    const time = shallow(<Time date={dateString} />)
+    expect(time.props().dateTime).toEqual('1870-04-22')
+    expect(time.text()).toEqual('Fri Apr 22 1870')
+  })
+})
+
+describe('dateToISODateString returns a correctly-formatted ISO date string', () => {
+  let dateStrings = {
+    'Fri Apr 22 1870': '1870-04-22',
+    'Wed Nov 07 1917': '1917-11-07',
+    'Sun Jan 02 2000': '2000-01-02',
+    'Fri Dec 31 1999': '1999-12-31',
+  }
+
+  it('from a string', () => {
+    Object.entries(dateStrings).map(strings => {
+      expect(dateToISODateString(strings[0])).toEqual(strings[1])
+    })
+  })
+
+  it('from a Date object', () => {
+    Object.entries(dateStrings).map(strings => {
+      expect(dateToISODateString(new Date(strings[0]))).toEqual(strings[1])
+    })
+  })
+})

--- a/web/src/queries.js
+++ b/web/src/queries.js
@@ -18,5 +18,6 @@ export const GET_USER_DATA = gql`
       reason
       explanation
     }
+    selectedDays @client
   }
 `

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -3,7 +3,7 @@ import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { withClientState } from 'apollo-link-state'
 import gql from 'graphql-tag'
-import { dateToISOString } from '../Calendar'
+import { dateToISODateString } from '../Time'
 
 const cache = new InMemoryCache()
 
@@ -76,7 +76,7 @@ const stateLink = withClientState({
           }
         `
         const data = {
-          selectedDays: args.data.map(d => dateToISOString(d)),
+          selectedDays: args.data.map(d => dateToISODateString(d)),
         }
         cache.writeQuery({ data, query })
         return null

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -3,6 +3,7 @@ import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { withClientState } from 'apollo-link-state'
 import gql from 'graphql-tag'
+import { dateToISOString } from '../Calendar'
 
 const cache = new InMemoryCache()
 
@@ -17,11 +18,13 @@ const typeDefs = `
   type Mutation {
     switchLanguage: String
     registerUser(data: UserData)
+    selectDays(data: [String]!)
   }
 
   type Query {
     language: String
     userRegistrationData: UserData
+    selectedDays: [String]!
   }
 `
 
@@ -66,6 +69,18 @@ const stateLink = withClientState({
         cache.writeQuery({ data, query })
         return null
       },
+      selectDays: (_, args, { cache }) => {
+        let query = gql`
+          {
+            selectedDays @client
+          }
+        `
+        const data = {
+          selectedDays: args.data.map(d => dateToISOString(d)),
+        }
+        cache.writeQuery({ data, query })
+        return null
+      },
     },
   },
   defaults: {
@@ -77,6 +92,7 @@ const stateLink = withClientState({
       reason: '',
       explanation: '',
     },
+    selectedDays: [],
   },
   typeDefs,
 })


### PR DESCRIPTION
This pull request:
- Saves dates (as date strings) to the cache
- Displays saved dates on the `/review` page 
  - resolves #88 
- Creates a `Time` component that returns an [HTML `<time>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) 
  - partially addresses, but does not resolve, #86
- Adds some date parsing utility methods
- Returns selected dates to the calendar when the user clicks 'Go back →' from the review page
- Adds tests around returning dates and then clicking new ones
