### PR TITLE
Update `toBeTruthy` unit tests

### DIFF
--- a/web/src/__tests__/FederalBanner.test.js
+++ b/web/src/__tests__/FederalBanner.test.js
@@ -4,14 +4,13 @@ import FederalBanner from '../FederalBanner'
 import React from 'react'
 import { testClient } from '../utils/createTestClient'
 
-
 describe('<FederalBanner />', () => {
   it('renders', () => {
     const federalBanner = mount(
-      <ApolloProvider client={testClient({language: 'en'})}>
+      <ApolloProvider client={testClient({ language: 'en' })}>
         <FederalBanner />
       </ApolloProvider>,
     )
-    expect(federalBanner.find('svg')).toBeTruthy()
+    expect(federalBanner.find('svg').length).toBe(1)
   })
 })

--- a/web/src/__tests__/Footer.test.js
+++ b/web/src/__tests__/Footer.test.js
@@ -5,7 +5,7 @@ import React from 'react'
 describe('<Footer />', () => {
   it('renders footer', () => {
     const footer = shallow(<Footer />)
-    expect(footer.find('footer')).toBeTruthy()
+    expect(footer.find('footer').length).toBe(1)
   })
 
   it('renders footer with topBar', () => {

--- a/web/src/__tests__/Footer.test.js
+++ b/web/src/__tests__/Footer.test.js
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme'
+import { shallow, render } from 'enzyme'
 import Footer from '../Footer'
 import React from 'react'
 
@@ -6,10 +6,13 @@ describe('<Footer />', () => {
   it('renders footer', () => {
     const footer = shallow(<Footer />)
     expect(footer.find('footer').length).toBe(1)
+    expect(footer.find('hr').length).toBe(0)
   })
 
   it('renders footer with topBar', () => {
-    const topBar = shallow(<Footer topBarBackground="black" />)
-    expect(topBar).toMatchObject(topBar)
+    // have to use 'render' instead of 'shallow' to render nested components
+    const footer = render(<Footer topBarBackground="black" />)
+    expect(footer.find('footer').length).toBe(1)
+    expect(footer.find('hr').length).toBe(1)
   })
 })

--- a/web/src/__tests__/PageHeader.js
+++ b/web/src/__tests__/PageHeader.js
@@ -9,7 +9,7 @@ describe('<PageHeader />', () => {
         <h1>Title</h1>
       </PageHeader>,
     )
-    expect(pageHeader.find('header')).toBeTruthy()
+    expect(pageHeader.find('header').length).toBe(1)
     expect(pageHeader.find('h1').text()).toMatch(/Title/)
   })
 })

--- a/web/src/forms/__tests__/Button.test.js
+++ b/web/src/forms/__tests__/Button.test.js
@@ -5,7 +5,7 @@ import Button from '../Button'
 describe('<Button>', () => {
   it('Renders the Button component', () => {
     const button = shallow(<Button disabled={true}>Next</Button>)
-    expect(button.find('button')).toBeTruthy()
+    expect(button.find('button').length).toBe(1)
   })
 
   it('Renders the Button component and also tests to make sure disabled = true', () => {

--- a/web/src/forms/__tests__/MultipleChoice.test.js
+++ b/web/src/forms/__tests__/MultipleChoice.test.js
@@ -23,13 +23,13 @@ const getAdapterAttrib = (adapter, attr) =>
 describe('<Radio> component', () => {
   it('has props assigned correctly', () => {
     const radio = shallow(<Radio {...defaultProps} />)
-    expect(radio.find('input')).toBeTruthy()
     expect(radio.props().type).toEqual('radio')
     expect(radio.props().value).toEqual('option')
   })
 
   it('renders label correctly', () => {
     const radio = render(<Radio {...defaultProps} />)
+    expect(radio.find('input').length).toBe(1)
     expect(radio.find('label > span').text()).toMatch(/Option/)
   })
 })
@@ -37,7 +37,7 @@ describe('<Radio> component', () => {
 describe('<RadioAdapter> component', () => {
   it('has props assigned directly through input object', () => {
     const radioAdapter = render(<RadioAdapter {...defaultAdapterProps} />)
-    expect(radioAdapter.find('input')).toBeTruthy()
+    expect(radioAdapter.find('input').length).toBe(1)
 
     const radio = shallow(<Radio {...defaultProps} />)
     expect(getAdapterAttrib(radioAdapter, 'type')).toEqual(radio.props().type)
@@ -48,13 +48,13 @@ describe('<RadioAdapter> component', () => {
 describe('<Checkbox> component', () => {
   it('has props assigned correctly', () => {
     const checkbox = shallow(<Checkbox {...defaultProps} />)
-    expect(checkbox.find('input')).toBeTruthy()
     expect(checkbox.props().type).toEqual('checkbox')
     expect(checkbox.props().value).toEqual('option')
   })
 
   it('renders label correctly', () => {
     const checkbox = render(<Checkbox {...defaultProps} />)
+    expect(checkbox.find('input').length).toBe(1)
     expect(checkbox.find('label > span').text()).toMatch(/Option/)
   })
 })
@@ -62,7 +62,7 @@ describe('<Checkbox> component', () => {
 describe('<CheckboxAdapter> component', () => {
   it('has props assigned directly through input object', () => {
     const cbAdapter = render(<CheckboxAdapter {...defaultAdapterProps} />)
-    expect(cbAdapter.find('input')).toBeTruthy()
+    expect(cbAdapter.find('input').length).toBe(1)
 
     const checkbox = shallow(<Checkbox {...defaultProps} />)
     expect(getAdapterAttrib(cbAdapter, 'type')).toEqual(checkbox.props().type)

--- a/web/src/forms/__tests__/TextInput.test.js
+++ b/web/src/forms/__tests__/TextInput.test.js
@@ -22,7 +22,7 @@ describe('<TextField> component', () => {
   it('has props assigned correctly', () => {
     const textField = shallow(<TextField {...defaultProps} />)
     const tfInput = textField.find('input')
-    expect(tfInput).toBeTruthy()
+    expect(tfInput.length).toBe(1)
     expect(tfInput.props().type).toEqual('text')
     expect(tfInput.props().id).toEqual('id')
     expect(tfInput.props().name).toEqual('name')
@@ -40,7 +40,7 @@ describe('<TextFieldAdapter> component', () => {
 
   it('has props assigned directly through input object', () => {
     const tfAdapter = render(<TextFieldAdapter {...defaultAdapterProps} />)
-    expect(tfAdapter.find('input')).toBeTruthy()
+    expect(tfAdapter.find('input').length).toBe(1)
 
     const tfInput = shallow(<TextField {...defaultProps} />).find('input')
     expect(getAdapterAttrib(tfAdapter, 'type')).toEqual(tfInput.props().type)
@@ -53,7 +53,7 @@ describe('<TextArea> component', () => {
   it('has props assigned correctly', () => {
     const textArea = shallow(<TextArea {...defaultProps} />)
     const taInput = textArea.find('textarea')
-    expect(taInput).toBeTruthy()
+    expect(taInput.length).toBe(1)
     expect(taInput.props().id).toEqual('id')
     expect(taInput.props().name).toEqual('name')
   })
@@ -70,7 +70,7 @@ describe('<TextAreaAdapter> component', () => {
 
   it('has props assigned directly through input object', () => {
     const taAdapter = render(<TextAreaAdapter {...defaultAdapterProps} />)
-    expect(taAdapter.find('textarea')).toBeTruthy()
+    expect(taAdapter.find('textarea').length).toBe(1)
 
     const taInput = shallow(<TextArea {...defaultProps} />).find('textarea')
     expect(getAdapterAttrib(taAdapter, 'id')).toEqual(taInput.props().id)


### PR DESCRIPTION
The way we were writing these tests, they would always return true.
Now we are explicitly looking for how many elements we expect.

Also rewrote one of our footer tests so that it's no longer comparing itself to itself.