### PR TITLE
Fix SVG size, make fonts for text-based input elements sans-serif

### DIFF
--- a/web/src/FederalBanner.js
+++ b/web/src/FederalBanner.js
@@ -18,6 +18,12 @@ const container = css`
   display: -moz-box;
   display: flex;
 
+  .svg-container {
+    /* same as the width value in our svg */
+    width: 250px;
+    height: 30px;
+  }
+
   ${mediaQuery.small(css`
     padding-left: ${theme.spacing.xl};
     padding-right: ${theme.spacing.xl};
@@ -48,9 +54,9 @@ const FederalBanner = () => (
   <div className={container}>
     <Query query={GET_LANGUAGE_QUERY}>
       {({ data: { language } }) => (
-        <div>
+        <div className="svg-container">
           <GoCSignature
-            width="13rem"
+            width="250px"
             lang={language}
             flag={theme.colour.black}
             text={theme.colour.black}

--- a/web/src/Footer.js
+++ b/web/src/Footer.js
@@ -23,6 +23,16 @@ const footer = css`
   position: relative;
   font-size: ${theme.font.md};
 
+  .svg-container {
+    width: 150px;
+    height: 40px;
+
+    ${mediaQuery.small(css`
+      width: 140px;
+      height: 36px;
+    `)};
+  }
+
   ${mediaQuery.medium(css`
     flex-direction: column;
     align-items: center;
@@ -73,12 +83,14 @@ const Footer = ({ topBarBackground }) => (
   <div>
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
     <footer className={footer}>
-      <WordMark
-        width="8.375em"
-        height="2em"
-        flag={theme.colour.black}
-        text={theme.colour.black}
-      />
+      <div className="svg-container">
+        <WordMark
+          width="150px"
+          height="40px"
+          flag={theme.colour.black}
+          text={theme.colour.black}
+        />
+      </div>
 
       <div className={bottomLinks}>
         <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>

--- a/web/src/forms/TextInput.js
+++ b/web/src/forms/TextInput.js
@@ -6,6 +6,7 @@ import { theme, mediaQuery } from '../styles'
 
 const text_input = css`
   font-size: ${theme.font.lg};
+  font-family: Helvetica, Arial, sans-serif;
   border: 3px solid ${theme.colour.black}};
   outline: 0;
   padding: ${theme.spacing.xs};


### PR DESCRIPTION
Between Firefox and IE, we were getting a few CSS inconsistencies.

## 1. SVGs were the wrong size

| ie11 | firefox |
|------|---------|
|  ![image](https://user-images.githubusercontent.com/2454380/39776907-22e99326-52d0-11e8-9ef7-de7828b28c4f.png)    |   <img width="1221" alt="screen shot 2018-05-08 at 2 55 58 pm" src="https://user-images.githubusercontent.com/2454380/39776996-5159bcfe-52d0-11e8-8f92-0f173a2664e1.png"> |

**Solution**
Fixed sizes for svgs. We don't really change their size anyway.

## 2. Fonts in input elements were inconsistent

| ie11 | firefox |
|------|---------|
|  ![image](https://user-images.githubusercontent.com/2454380/39777097-a353e03e-52d0-11e8-9939-101e493393e3.png)  |  ![image](https://user-images.githubusercontent.com/2454380/39777159-cc40bfa8-52d0-11e8-875f-6c7da0d59317.png) |

**Solution**
Explicit font-family rules for text inputs and textareas.


