### PR TITLE
Avoid JSDOM test environment for the API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -39,6 +39,7 @@
     "i18next-express-middleware": "^1.1.1"
   },
   "jest": {
-    "verbose": true
+    "verbose": true,
+    "testEnvironment": "jest-environment-node"
   }
 }


### PR DESCRIPTION
By default, Jest helpfully creates a document object to help testing of UI
components. For a strictly node.js project like the api, that work is unneeded and
can be skipped to save some time. This change reduces the time to run the test
suite from 1.437s to 0.834s.