### PR TITLE
Redesign landing page for beta

### DIFF
--- a/web/src/AlphaBanner.js
+++ b/web/src/AlphaBanner.js
@@ -28,10 +28,10 @@ const horizontalAlign = css`
 const badge = css`
   text-transform: uppercase;
   line-height: 1.8;
-  color: ${theme.colour.black};
+  color: ${theme.colour.white};
+  background-color: ${theme.colour.alpha};
   padding: 2px ${theme.spacing.md};
   margin-right: ${theme.spacing.md};
-  background-color: ${theme.colour.white};
   ${roundedEdges};
   ${horizontalAlign};
   ${mediaQuery.small(css`
@@ -42,10 +42,12 @@ const badge = css`
 
 const message = css`
   ${horizontalAlign};
+  font-weight: 600;
 
   ${mediaQuery.small(css`
     display: block;
     bottom: 0;
+    font-weight: 400;
   `)};
 `
 

--- a/web/src/FederalBanner.js
+++ b/web/src/FederalBanner.js
@@ -7,7 +7,7 @@ import { theme, mediaQuery } from './styles'
 import { LanguageSwitcher } from './LanguageSwitcher'
 
 const container = css`
-  padding: ${theme.spacing.md} ${theme.spacing.xxxl} ${theme.spacing.sm}
+  padding: ${theme.spacing.lg} ${theme.spacing.xxxl} ${theme.spacing.lg}
     ${theme.spacing.xxxl};
   width: auto;
   justify-content: space-between;
@@ -40,10 +40,8 @@ const container = css`
   context of the Banner segment, not on the switcher by itself.
   */
   section {
-    margin-top: -${theme.spacing.xs};
-
     ${mediaQuery.xs(css`
-      margin-top: 0;
+      margin-top: ${theme.spacing.sm};
       /* this means the "Français" link looks aligned with the flag */
       margin-left: -2px;
     `)};
@@ -58,7 +56,7 @@ const FederalBanner = () => (
           <GoCSignature
             width="250px"
             lang={language}
-            flag={theme.colour.black}
+            flag={theme.colour.redFIP}
             text={theme.colour.black}
           />
         </div>

--- a/web/src/LandingPage.js
+++ b/web/src/LandingPage.js
@@ -57,7 +57,7 @@ class LandingPage extends React.Component {
     return (
       <Layout contentClass={contentClass}>
         <Helmet>
-          <title>Request a new Canadian Citizenship test date</title>
+          <title>Request a new Canadian Citizenship appointment</title>
         </Helmet>
         <section className={landingSection}>
           <H1>

--- a/web/src/LandingPage.js
+++ b/web/src/LandingPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { css } from 'react-emotion'
+import styled, { css } from 'react-emotion'
 import { NavLink } from 'react-router-dom'
 import { H1, H2, H3, theme, mediaQuery } from './styles'
 import Layout from './Layout'
@@ -8,48 +8,43 @@ import { Trans } from 'lingui-react'
 import { Helmet } from 'react-helmet'
 
 const contentClass = css`
+  section {
+    width: 80%;
+    margin-bottom: ${theme.spacing.lg};
+
+    ${mediaQuery.small(css`
+      width: 100%;
+    `)};
+  }
+
   p {
-    padding-bottom: ${theme.spacing.lg};
-  }
-
-  li p:first-of-type {
-    padding-bottom: 0rem;
-  }
-
-  li p:last-of-type {
-    padding-bottom: 0rem;
-  }
-
-  li {
-    padding-bottom: ${theme.spacing.sm};
-  }
-
-  li:last-of-type {
-    padding-bottom: ${theme.spacing.lg};
+    font-size: ${theme.font.lg};
+    margin-bottom: ${theme.spacing.lg};
   }
 `
 
 const list = css`
   list-style: disc;
   margin-left: ${theme.spacing.lg};
-  font-size: ${theme.font.lg};
-`
-
-const landingSection = css`
+  margin-top: ${theme.spacing.sm};
   margin-bottom: ${theme.spacing.lg};
-  width: 70%;
 
-  ${mediaQuery.medium(css`
-    width: 100%;
-  `)};
+  li {
+    margin-bottom: ${theme.spacing.sm};
+
+    p {
+      margin-bottom: 0;
+    }
+
+    p + p {
+      font-size: ${theme.font.md};
+    }
+  }
 `
 
-const moreInfo = css`
-  font-size: ${theme.font.md};
-`
-const href = css`
-  text-decoration: underline;
-  color: ${theme.colour.black};
+const H1Landing = styled(H1)`
+  font-size: ${theme.font.xl};
+  line-height: 1;
 `
 
 class LandingPage extends React.Component {
@@ -59,13 +54,14 @@ class LandingPage extends React.Component {
         <Helmet>
           <title>Request a new Canadian Citizenship appointment</title>
         </Helmet>
-        <section className={landingSection}>
-          <H1>
+        <section>
+          <H1Landing>
             <Trans>
-              Use this service to notify IRCC that you can’t attend your
-              Citizenship test, and you need a new appointment.
+              Use this service to notify Immigration, Refugees and Citizenship
+              Canada that you cannot attend your Citizenship test, and you need
+              a new appointment.
             </Trans>
-          </H1>
+          </H1Landing>
         </section>
 
         <section>
@@ -75,9 +71,11 @@ class LandingPage extends React.Component {
           <ul className={list}>
             <li>
               <p>
-                <Trans>your paper file number</Trans>
+                <Trans>
+                  Your <strong>paper file number</strong>
+                </Trans>
               </p>
-              <p className={moreInfo}>
+              <p>
                 <Trans>
                   This is found at the top of your test notice email.
                 </Trans>
@@ -85,38 +83,38 @@ class LandingPage extends React.Component {
             </li>
 
             <li>
-              <Trans>your full name, as it appears on your application</Trans>
+              <p>
+                <Trans>Your full name</Trans>
+              </p>
+              <p>
+                <Trans>This should match the name on your application.</Trans>
+              </p>
             </li>
+
             <li>
               <p>
-                <Trans>to explain your reason for rescheduling</Trans>
+                <Trans>To describe your reason for rescheduling</Trans>
               </p>
-              <span className={moreInfo}>
-                <Trans>for more information on rescheduling,</Trans>{' '}
-              </span>
-              <span className={moreInfo}>
-                <a
-                  href="http://www.cic.gc.ca/english/helpcentre/answer.asp?qnum=786&amp;top=5"
-                  className={href}
-                >
-                  <Trans>read the guidelines</Trans>
-                </a>
-              </span>
+              <p>
+                <Trans>
+                  For more information on rescheduling,{' '}
+                  <a href="http://www.cic.gc.ca/english/helpcentre/answer.asp?qnum=786&amp;top=5">
+                    read the guidelines
+                  </a>.
+                </Trans>
+              </p>
             </li>
           </ul>
-        </section>
 
-        <section className={landingSection}>
-          <H2>
+          <p>
             <Trans>
-              After verifying your personal information, you will be able to
-              select three (3) alternative days when you are able to take the
-              Citizenship test.
+              After that, you will select <strong>three (3) days</strong> when
+              you’re available for an appointment in the future.
             </Trans>
-          </H2>
+          </p>
         </section>
 
-        <section className={landingSection}>
+        <section>
           <H3>
             <Trans>
               Important: by sending this request to reschedule, you will be

--- a/web/src/Layout.js
+++ b/web/src/Layout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { injectGlobal } from 'emotion'
 import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
-import { theme, mediaQuery, H1, Content } from './styles'
+import { theme, mediaQuery, Content } from './styles'
 import PageHeader from './PageHeader'
 import AlphaBanner from './AlphaBanner'
 import FederalBanner from './FederalBanner'
@@ -58,9 +58,7 @@ const Layout = ({ children, contentClass = '' }) => (
     <FederalBanner />
     <main role="main">
       <PageHeader>
-        <H1>
-          <Trans>Request a new Canadian Citizenship test date</Trans>
-        </H1>
+        <Trans>Request a new Canadian Citizenship appointment</Trans>
       </PageHeader>
       <Content className={contentClass}>{children}</Content>
       <Footer topBarBackground="black" />

--- a/web/src/PageHeader.js
+++ b/web/src/PageHeader.js
@@ -4,14 +4,19 @@ import { css } from 'react-emotion'
 import { theme, mediaQuery } from './styles'
 
 const banner = css`
-  background-color: ${theme.colour.greyLight};
-  color: ${theme.colour.black};
-  padding: ${theme.spacing.xxl} ${theme.spacing.xxxl};
+  background-color: ${theme.colour.blue};
+  color: ${theme.colour.white};
+  padding: ${theme.spacing.lg} ${theme.spacing.xxxl};
 
   ${mediaQuery.small(css`
     padding-left: ${theme.spacing.xl};
     padding-right: ${theme.spacing.xl};
   `)};
+
+  > * {
+    font-size: ${theme.font.xxl};
+    font-weight: 700;
+  }
 `
 
 const PageHeader = ({ children }) => (

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -70,6 +70,7 @@ export const theme = {
     blue: '#1177DD',
     blueDark: '#073767',
     blueAlpha: '#4A90E2',
+    alpha: '#F90277',
     red: '#A5071B',
     grey: '#4A4A4A',
     gray: '#4A4A4A',

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -64,13 +64,7 @@ export const breakpoints = {
 
 export const theme = {
   colour: {
-    yellow: '#FDD262',
-    yellowLight: '#E5BF73',
-    yellowDark: '#E7AE27',
-    blue: '#1177DD',
-    blueDark: '#073767',
-    blueAlpha: '#4A90E2',
-    alpha: '#F90277',
+    blue: '#335075',
     red: '#A5071B',
     redFIP: '#FF0000',
     grey: '#4A4A4A',
@@ -83,6 +77,7 @@ export const theme = {
     black: '#000000',
     focus: '#ffbf47',
     visited: '#551a8b',
+    alpha: '#F90277',
   },
   font: {
     xs: '0.694rem',

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -72,6 +72,7 @@ export const theme = {
     blueAlpha: '#4A90E2',
     alpha: '#F90277',
     red: '#A5071B',
+    redFIP: '#FF0000',
     grey: '#4A4A4A',
     gray: '#4A4A4A',
     greyLight: '#DBDBDB',

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -9,7 +9,9 @@ describe('Server Side Rendering', () => {
   it('renders the landing page at /', async () => {
     let response = await request(server).get('/')
 
-    expect(response.text).toMatch(/Use this service to notify IRCC/)
+    expect(response.text).toMatch(
+      /Use this service to notify Immigration, Refugees and Citizenship Canada/,
+    )
   })
 
   it('renders the register page at /register', async () => {


### PR DESCRIPTION
This PR is a start towards the beta redesign that we're doing:

- Adds pink alpha colour to `AlphaBanner` (same as on [the CDS products page](https://digital.canada.ca/products/))
- Adds Federal Identity red flag
- `PageHeader` background changes to Canada.ca blue (also shorter)
  - `PageHeader` no longer uses an `<h1>`, which is great because now we don't have two `<h1>`s on every page
- Copy on landing page gets a revamp
  - words have been updated and visually it just looks nicer

There is more to do as part of the reskinning but this is a good start.

### screenshots (click for fullscreen version)

| before | after | mockup |
|--------|-------|--------|
| <img alt="screen shot 2018-05-15 at 9 10 06 am" src="https://user-images.githubusercontent.com/2454380/40058801-3edc4a56-5820-11e8-9936-3f958b223ee7.png"> | <img  alt="screen shot 2018-05-15 at 9 10 38 am" src="https://user-images.githubusercontent.com/2454380/40058785-35e36592-5820-11e8-9daf-ea9071a383d7.png"> | <img alt="screen shot 2018-05-15 at 9 09 54 am" src="https://user-images.githubusercontent.com/2454380/40058767-27e63974-5820-11e8-8ac5-72195c5615f6.png"> |



