### PR TITLE
Make buttons look more like GOV.UK buttons

### DIFF
--- a/web/src/CalendarPage.js
+++ b/web/src/CalendarPage.js
@@ -145,7 +145,7 @@ class CalendarPage extends Component {
               </CalReminder>
               <BottomContainer>
                 <Button disabled={submitting}>
-                  <Trans>Review →</Trans>
+                  <Trans>Review</Trans>
                 </Button>
 
                 <div>

--- a/web/src/LandingPage.js
+++ b/web/src/LandingPage.js
@@ -3,7 +3,7 @@ import styled, { css } from 'react-emotion'
 import { NavLink } from 'react-router-dom'
 import { H1, H2, H3, theme, mediaQuery } from './styles'
 import Layout from './Layout'
-import Button from './forms/Button'
+import { buttonStyles } from './forms/Button'
 import { Trans } from 'lingui-react'
 import { Helmet } from 'react-helmet'
 
@@ -125,10 +125,8 @@ class LandingPage extends React.Component {
           </H3>
         </section>
 
-        <NavLink to="/register">
-          <Button>
-            <Trans>Start Now →</Trans>
-          </Button>
+        <NavLink to="/register" className={buttonStyles}>
+          <Trans>Start Now →</Trans>
         </NavLink>
       </Layout>
     )

--- a/web/src/RegistrationPage.js
+++ b/web/src/RegistrationPage.js
@@ -309,7 +309,7 @@ class RegistrationPage extends React.Component {
                     Object.keys(touched).length
                 }
               >
-                <Trans>Next →</Trans>
+                <Trans>Continue</Trans>
               </Button>
             </form>
           )}

--- a/web/src/forms/Button.js
+++ b/web/src/forms/Button.js
@@ -4,18 +4,34 @@ import { theme, roundedEdges, mediaQuery, incrementColor } from '../styles'
 const Button = styled.button`
   font-size: ${theme.font.lg};
   font-weight: 500;
+  line-height: 2;
+
   color: ${theme.colour.white};
-  background-color: ${theme.colour.gray};
-  border: 5px solid transparent;
-  outline: 0;
-  padding: ${theme.spacing.xs} ${theme.spacing.lg};
+  background-color: ${theme.colour.green};
+  border: none;
   cursor: pointer;
+
+  // Size and shape
+  position: relative;
+  display: inline-block;
+  padding: ${theme.spacing.sm} ${theme.spacing.lg};
   ${roundedEdges};
+
+  outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
+  outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
+  -webkit-appearance: none;
+
+  // Bottom edge effect
+  box-shadow: 0 2px 0 ${incrementColor(theme.colour.grey, 80)};
 
   ${mediaQuery.small(css`
     width: 100%;
     padding: ${theme.spacing.sm} ${theme.spacing.lg};
   `)};
+
+  &:visited {
+    background-color: ${theme.colour.green};
+  }
 
   &:focus {
     outline: 4px solid ${theme.colour.focus};
@@ -23,9 +39,15 @@ const Button = styled.button`
   }
 
   &:hover,
-  &:active,
   &:focus {
-    background-color: ${incrementColor(theme.colour.gray, 20)};
+    background-color: ${incrementColor(theme.colour.green, 20)};
+    box-shadow: 0 2px 0 ${incrementColor(theme.colour.grey, 100)};
+  }
+
+  &:active {
+    top: 2px;
+    background-color: ${incrementColor(theme.colour.green, 20)};
+    box-shadow: 0 0 0 ${incrementColor(theme.colour.green, 20)};
   }
 
   &:active,
@@ -37,8 +59,27 @@ const Button = styled.button`
   &:disabled {
     &:hover {
       cursor: not-allowed;
-      background-color: ${incrementColor(theme.colour.gray, 30)};
+      background-color: ${incrementColor(theme.colour.green, 30)};
     }
+  }
+
+  // making the click target bigger than the button
+  // (and fill the space made when the button moves)
+  &:before {
+    content: '';
+    height: 110%;
+    width: 100%;
+    display: block;
+    background: transparent;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  &:hover:before,
+  &:active:before {
+    top: -10%;
+    height: 120%;
   }
 `
 

--- a/web/src/forms/Button.js
+++ b/web/src/forms/Button.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { css } from 'react-emotion'
 import { theme, roundedEdges, mediaQuery, incrementColor } from '../styles'
 
@@ -143,5 +144,8 @@ const Button = ({ children, ...props }) => (
     {children}
   </button>
 )
+Button.propTypes = {
+  children: PropTypes.any.isRequired,
+}
 
 export { Button as default, button as buttonStyles }

--- a/web/src/forms/Button.js
+++ b/web/src/forms/Button.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'react-emotion'
-import { theme, roundedEdges, mediaQuery, incrementColor } from '../styles'
+import { theme, mediaQuery, incrementColor } from '../styles'
 
 const govuk_button = css`
   /* https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/e00b009b2a9722363d3c247838632d8e3673daa9/stylesheets/design-patterns/_buttons.scss */
@@ -100,7 +100,6 @@ const button = css`
 
   // Size and shape
   padding: ${theme.spacing.sm} ${theme.spacing.lg};
-  ${roundedEdges};
 
   // Bottom edge effect
   box-shadow: 0 2px 0 ${incrementColor(theme.colour.grey, 80)};

--- a/web/src/forms/Button.js
+++ b/web/src/forms/Button.js
@@ -1,25 +1,104 @@
 import styled, { css } from 'react-emotion'
 import { theme, roundedEdges, mediaQuery, incrementColor } from '../styles'
 
+const govuk_button = css`
+  /* https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/e00b009b2a9722363d3c247838632d8e3673daa9/stylesheets/design-patterns/_buttons.scss */
+  /* since I don't have their sass variables, I'm using a close-enough default colour */
+  background-color: forestgreen;
+
+  position: relative;
+  display: inline-block;
+  padding: 10px 15px 5px;
+  border: none;
+  border-radius: 0;
+  outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
+  outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
+  -webkit-appearance: none;
+
+  // Bottom edge effect
+  /* again, I don't have sass variables, so I'm using default colour */
+  box-shadow: 0 2px 0 lightseagreen;
+  /* removed IE8-specific rule */
+
+  // Text
+  font-size: 1em; // inherit from parent
+  line-height: 1.25;
+  text-decoration: none;
+  -webkit-font-smoothing: antialiased;
+
+  // Interaction
+  cursor: pointer;
+
+  &:visited {
+    background-color: forestgreen;
+  }
+
+  &:hover,
+  &:focus {
+    background-color: darkgreen;
+  }
+
+  &:active {
+    top: 2px;
+    box-shadow: 0 0 0 forestgreen;
+  }
+
+  // Disabled button styles
+  &.disabled,
+  &[disabled='disabled'],
+  &[disabled] {
+    opacity: 0.5;
+    &:hover {
+      cursor: default;
+      background-color: forestgreen;
+    }
+
+    &:active {
+      top: 0;
+      box-shadow: 0 2px 0 darkgreen;
+      /* removed IE8-specific rule */
+    }
+  }
+
+  /* removed rules to set text colour depending on background colour */
+
+  // making the click target bigger than the button
+  // (and fill the space made when the button moves)
+  &:before {
+    content: '';
+    height: 110%;
+    width: 100%;
+    display: block;
+    background: transparent;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  &:active:before {
+    top: -10%;
+    height: 120%;
+
+    /* removed IE6-specific rule */
+  }
+
+  /* removed IE8-specific rule */
+`
+
 const Button = styled.button`
+  ${govuk_button};
+
+  font-family: -apple-system, system-ui, Helvetica, Arial, sans-serif;
   font-size: ${theme.font.lg};
-  font-weight: 500;
+  font-weight: 600;
   line-height: 2;
 
   color: ${theme.colour.white};
   background-color: ${theme.colour.green};
-  border: none;
-  cursor: pointer;
 
   // Size and shape
-  position: relative;
-  display: inline-block;
   padding: ${theme.spacing.sm} ${theme.spacing.lg};
   ${roundedEdges};
-
-  outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
-  outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
-  -webkit-appearance: none;
 
   // Bottom edge effect
   box-shadow: 0 2px 0 ${incrementColor(theme.colour.grey, 80)};
@@ -50,36 +129,11 @@ const Button = styled.button`
     box-shadow: 0 0 0 ${incrementColor(theme.colour.green, 20)};
   }
 
-  &:active,
-  &:disabled {
-    filter: alpha(opacity=60);
-    opacity: 0.6;
-  }
-
   &:disabled {
     &:hover {
       cursor: not-allowed;
       background-color: ${incrementColor(theme.colour.green, 30)};
     }
-  }
-
-  // making the click target bigger than the button
-  // (and fill the space made when the button moves)
-  &:before {
-    content: '';
-    height: 110%;
-    width: 100%;
-    display: block;
-    background: transparent;
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
-
-  &:hover:before,
-  &:active:before {
-    top: -10%;
-    height: 120%;
   }
 `
 

--- a/web/src/forms/Button.js
+++ b/web/src/forms/Button.js
@@ -1,4 +1,5 @@
-import styled, { css } from 'react-emotion'
+import React from 'react'
+import { css } from 'react-emotion'
 import { theme, roundedEdges, mediaQuery, incrementColor } from '../styles'
 
 const govuk_button = css`
@@ -85,7 +86,7 @@ const govuk_button = css`
   /* removed IE8-specific rule */
 `
 
-const Button = styled.button`
+const button = css`
   ${govuk_button};
 
   font-family: -apple-system, system-ui, Helvetica, Arial, sans-serif;
@@ -137,4 +138,10 @@ const Button = styled.button`
   }
 `
 
-export default Button
+const Button = ({ children, ...props }) => (
+  <button className={button} {...props}>
+    {children}
+  </button>
+)
+
+export { Button as default, button as buttonStyles }

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -66,6 +66,7 @@ export const theme = {
   colour: {
     blue: '#335075',
     red: '#A5071B',
+    green: '#00823B',
     redFIP: '#FF0000',
     grey: '#4A4A4A',
     gray: '#4A4A4A',


### PR DESCRIPTION
This pull request:

- Styles our buttons so that they look more like [GOV.UK buttons](https://govuk-elements.herokuapp.com/buttons/)
- Also exports the button styles so that we can use them on other elements that aren't buttons (ie, links for example [like on the landing page])
  - Finally, the link on our landing page is just a link now and not a link wrapping a button (this is great)
  - Adds `system-ui` as an explicit font declaration so that link buttons look identical to regular buttons
- Removes unicode arrows except on the first and last pages of our little service 

### screenshots

| before | after | mockup |
|--------|-------|--------|
| <img alt="screen shot 2018-05-15 at 10 58 15 am" src="https://user-images.githubusercontent.com/2454380/40065175-1d8a7288-582f-11e8-8054-f961ed364cb9.png"> |  <img alt="screen shot 2018-05-15 at 10 58 54 am" src="https://user-images.githubusercontent.com/2454380/40065158-1228a1a8-582f-11e8-8660-a029400211dc.png"> |   <img alt="screen shot 2018-05-15 at 10 58 02 am" src="https://user-images.githubusercontent.com/2454380/40065191-2db6bb08-582f-11e8-8768-c5e0b033b8c7.png">   |

### gifs

#### regular button
![button](https://user-images.githubusercontent.com/2454380/40069589-c8fca3f2-5839-11e8-8db3-59a5e8edeb13.gif)


#### disabled button
![button-2](https://user-images.githubusercontent.com/2454380/40069593-cc9ed2c8-5839-11e8-95f9-a9362f6ae833.gif)


<sup>note that we're going to enable this button soon (mentioned in #92), but this is just to make sure the disabled styles still work</sup> 