### PR TITLE
Catch errors more comprehensively

### DIFF
--- a/web/src/components/Submission.js
+++ b/web/src/components/Submission.js
@@ -2,12 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
 
-const _logError = error => {
-  /* TODO log error.message */
-  return undefined
-}
 export const Submission = props => (
-  <Mutation mutation={props.action} onError={_logError}>
+  <Mutation mutation={props.action} onError={props.onError}>
     {(submit, { data, error, called, loading }) => {
       if (called && !loading) {
         if (error || data.errors) {
@@ -26,4 +22,5 @@ Submission.propTypes = {
   action: PropTypes.object.isRequired,
   success: PropTypes.func.isRequired,
   failure: PropTypes.func.isRequired,
+  onError: PropTypes.func,
 }

--- a/web/src/components/Submission.js
+++ b/web/src/components/Submission.js
@@ -2,11 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
 
+const _logError = error => {
+  /* TODO log error.message */
+  return undefined
+}
 export const Submission = props => (
-  <Mutation mutation={props.action}>
+  <Mutation mutation={props.action} onError={_logError}>
     {(submit, { data, error, called, loading }) => {
       if (called && !loading) {
-        if (data.errors) return props.failure(data.errors)
+        if (error || data.errors) {
+          return error ? props.failure(error) : props.failure(data.errors)
+        }
         if (data) return props.success(data)
       } else {
         return props.children(submit)

--- a/web/src/components/__tests__/Submission.test.js
+++ b/web/src/components/__tests__/Submission.test.js
@@ -70,10 +70,7 @@ describe('<Submission />', () => {
       paperFileNumber: '12341235',
     }
 
-    const successSpy = jest.fn(data => {
-      return <div>success</div>
-    })
-
+    const successSpy = jest.fn(data => <div>success</div>)
     const failureSpy = jest.fn(err => null)
     const spy = jest.fn(submit => <div onClick={() => submit(data)}>foo</div>)
 
@@ -107,9 +104,7 @@ describe('<Submission />', () => {
     })
 
     const successSpy = jest.fn(data => <div>success</div>)
-
     const failureSpy = jest.fn(err => <div>error</div>)
-
     const spy = jest.fn(submit => <div onClick={() => submit()}>foo</div>)
 
     const wrapper = mount(
@@ -126,5 +121,32 @@ describe('<Submission />', () => {
     expect(Array.isArray(failureSpy.mock.calls[0][0])).toEqual(true)
     // first element of the first argument of the first call
     expect(failureSpy.mock.calls[0][0][0].message).toEqual('sadness')
+  })
+
+  it(`calls the failure prop with an errors array when there is a Network error`, async () => {
+    const client = makeFakeClient({
+      fail: true,
+      failWith: Error('omg where is the api??? 🤷‍♀️'),
+    })
+
+    const successSpy = jest.fn(data => <div>success</div>)
+    const failureSpy = jest.fn(err => <div>error</div>)
+    const spy = jest.fn(submit => <div onClick={() => submit()}>foo</div>)
+
+    const wrapper = mount(
+      <ApolloProvider client={client}>
+        <Submission action={SUBMIT} success={successSpy} failure={failureSpy}>
+          {spy}
+        </Submission>
+      </ApolloProvider>,
+    )
+
+    wrapper.find('div').simulate('click')
+    await flushPromises()
+    expect(failureSpy).toHaveBeenCalled()
+    // first element of the first argument of the first call
+    expect(failureSpy.mock.calls[0][0].message).toEqual(
+      'Network error: omg where is the api??? 🤷‍♀️',
+    )
   })
 })

--- a/web/src/components/__tests__/Submission.test.js
+++ b/web/src/components/__tests__/Submission.test.js
@@ -135,7 +135,12 @@ describe('<Submission />', () => {
 
     const wrapper = mount(
       <ApolloProvider client={client}>
-        <Submission action={SUBMIT} success={successSpy} failure={failureSpy}>
+        <Submission
+          action={SUBMIT}
+          success={successSpy}
+          failure={failureSpy}
+          onError={error => {}}
+        >
           {spy}
         </Submission>
       </ApolloProvider>,


### PR DESCRIPTION
Previously, our `Submission` component was catching GraphQL errors, like an email being sent with the wrong fields, but wasn't catching regular Errors, like a NetworkError.

Now it catches both.