### PR TITLE
Clean up calendar

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -230,13 +230,10 @@ class Calendar extends Component {
   constructor(props) {
     super(props)
     this.handleDayClick = this.handleDayClick.bind(this)
-    this.updateFieldParams = this.updateFieldParams.bind(this)
     this.removeDayOnClickOrKeyPress = this.removeDayOnClickOrKeyPress.bind(this)
     this.state = {
-      selectedDays: this.props.input.value || [],
       errorMessage: null,
     }
-    this.props.input.value = this.state.selectedDays
   }
 
   removeDayOnClickOrKeyPress = day => e => {
@@ -273,23 +270,9 @@ class Calendar extends Component {
     /* Cast all Dates to 12 noon GMT */
     day = makeGMTDate(day)
 
-    /*
-      The first time we return to this page with pre-populated dates,
-      - this.props.input.value will contain all of the pre-poulated dates
-      - this.state.selectedDates will be empty
+    let { dayLimit } = this.props
 
-      So let's update the state with the prepopulated dates
-    */
-    let {
-      input: { value },
-      dayLimit,
-    } = this.props
-
-    if (!this.state.selectedDays.length && value && value.length) {
-      await this.setState({ selectedDays: value })
-    }
-
-    const { selectedDays } = this.state
+    const selectedDays = this.props.input.value || []
 
     // !selected means that this current day is not marked as 'selected' on the calendar
     if (!selected) {
@@ -316,13 +299,11 @@ class Calendar extends Component {
       selectedDays.splice(selectedIndex, 1)
     }
 
-    await this.setState({ selectedDays, errorMessage: null })
-    this.updateFieldParams()
-  }
-
-  updateFieldParams() {
-    this.props.input.value = this.state.selectedDays
+    this.props.input.value = selectedDays
     this.props.input.onChange(this.props.input.value)
+    await this.setState({
+      errorMessage: null,
+    })
   }
 
   render() {
@@ -342,8 +323,8 @@ class Calendar extends Component {
           disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
           onDayClick={this.handleDayClick}
           selectedDays={value || []}
-          onFocus={v => onFocus(v)}
-          onBlur={v => onBlur(v)}
+          onFocus={() => onFocus(value)}
+          onBlur={() => onBlur(value)}
         />
         {/*
           This code demonstrates how to update the page as dates are selected.

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -316,10 +316,10 @@ class Calendar extends Component {
           className={css`
             ${dayPickerDefault} ${dayPicker};
           `}
-          month={new Date(2018, 5)}
+          initialMonth={new Date(2018, 5)}
           fromMonth={new Date(2018, 5)}
           toMonth={new Date(2018, 6)}
-          numberOfMonths={2}
+          numberOfMonths={1}
           disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
           onDayClick={this.handleDayClick}
           selectedDays={value || []}

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -286,6 +286,7 @@ class Calendar extends Component {
             </Trans>
           ),
         })
+        this.errorContainer.focus()
         return
       }
 
@@ -332,10 +333,18 @@ class Calendar extends Component {
         */}
         <div>
           <h3>Dates selected:</h3>
-          <ErrorMessage
-            message={this.state.errorMessage}
-            id="selectedDays-error"
-          />
+          <div
+            tabIndex="-1"
+            ref={errorContainer => {
+              this.errorContainer = errorContainer
+            }}
+          >
+            <ErrorMessage
+              message={this.state.errorMessage}
+              id="selectedDays-error"
+            />
+          </div>
+
           <div id="selectedDays">
             {value && value.length > 0 ? (
               <ol>

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -6,6 +6,7 @@ import DayPicker, { DateUtils } from 'react-day-picker'
 import { css } from 'emotion'
 import Time, { makeGMTDate } from './Time'
 import ErrorMessage from './ErrorMessage'
+import { theme, mediaQuery, incrementColor } from '../styles'
 
 const dayPickerDefault = css`
   /* DayPicker styles */
@@ -158,11 +159,6 @@ const dayPickerDefault = css`
 
   /* Default modifiers */
 
-  .DayPicker-Day--today {
-    color: #d0021b;
-    font-weight: 700;
-  }
-
   .DayPicker-Day--outside {
     cursor: default;
     color: #8b9898;
@@ -171,60 +167,191 @@ const dayPickerDefault = css`
   .DayPicker-Day--disabled {
     color: #dce0e0;
     cursor: default;
-    /* background-color: #eff1f1; */
-  }
-
-  /* Example modifiers */
-
-  .DayPicker-Day--sunday {
-    background-color: #f7f8f8;
-  }
-
-  .DayPicker-Day--sunday:not(.DayPicker-Day--today) {
-    color: #dce0e0;
-  }
-
-  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-    position: relative;
-    color: #f0f8ff;
-    background-color: #4a90e2;
-    border-radius: 100%;
-  }
-
-  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover {
-    background-color: #51a0fa;
-  }
-
-  .DayPicker:not(.DayPicker--interactionDisabled)
-    .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
-    background-color: #f0f8ff;
-    border-radius: 50%;
-  }
-
-  /* DayPickerInput */
-
-  .DayPickerInput {
-    display: inline-block;
-  }
-
-  .DayPickerInput-OverlayWrapper {
-    position: relative;
-  }
-
-  .DayPickerInput-Overlay {
-    left: 0;
-    z-index: 1;
-    position: absolute;
-    background: white;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
   }
 `
 
 const dayPicker = css`
   .DayPicker-wrapper {
     background-color: white;
+    font-size: ${theme.font.lg};
+    border: 2px solid ${theme.colour.greyLight};
+  }
+
+  .DayPicker-NavButton {
+    top: 1.5rem;
+    right: auto;
+    color: ${theme.colour.black};
+    width: 1.35rem;
+    height: 1.35rem;
+    background-size: 50%;
+
+    &:focus {
+      outline: 3px solid ${theme.colour.focus};
+      outline-offset: 2px;
+    }
+
+    &.DayPicker-NavButton--next {
+      right: 2.5rem;
+    }
+
+    &.DayPicker-NavButton--prev {
+      left: 2.5rem;
+    }
+  }
+
+  .DayPicker-Weekday,
+  .DayPicker-Day {
+    padding: 0.7rem;
+  }
+
+  .DayPicker-Caption {
+    border-bottom: 2px dotted black;
+    text-align: center;
+    padding: ${theme.spacing.sm};
+
+    > div {
+      font-weight: 700;
+    }
+  }
+
+  .DayPicker-Day {
+    /* enabled dates */
+    &[aria-disabled='false'] {
+      font-weight: 700;
+
+      &:focus {
+        outline: 3px solid ${theme.colour.focus};
+        outline-offset: -2px;
+      }
+      &:hover {
+        background-color: ${theme.colour.greyLight};
+      }
+    }
+
+    /* disabled dates */
+    &[aria-disabled='true'] {
+      cursor: not-allowed;
+
+      &:focus {
+        outline: 3px solid ${theme.colour.lightGrey};
+        outline-offset: -2px;
+      }
+    }
+  }
+
+  /* selected dates */
+  .DayPicker-Day--selected:not([aria-disabled='true']):not(.DayPicker-Day--outside) {
+    background-color: ${theme.colour.blue};
+    color: ${theme.colour.white};
+
+    &:hover {
+      background-color: ${incrementColor(theme.colour.blue, 30)};
+    }
   }
 `
+
+const calendarContainer = css`
+  display: inline-flex;
+  flex-direction: row;
+  align-items: flex-start;
+  flex-wrap: wrap;
+
+  > div:first-of-type {
+    width: 25em;
+    margin-right: ${theme.spacing.xxl};
+  }
+  > div:last-of-type {
+    width: 22em;
+  }
+
+  ${mediaQuery.lg(css`
+    display: block;
+  `)};
+
+  ${mediaQuery.md(css`
+    > div:first-of-type,
+    > div:last-of-type {
+      width: 100%;
+    }
+  `)};
+
+  #selectedDays {
+    margin: ${theme.spacing.md} 0;
+  }
+`
+
+const dayBox = css`
+  margin-bottom: ${theme.spacing.md};
+  display: flex;
+  justify-content: space-between;
+
+  .day-box {
+    font-size: ${theme.font.lg};
+    width: 12em;
+    display: inline-block;
+    border: 2px solid ${theme.colour.grey};
+    background-color: ${theme.colour.white};
+    padding: ${theme.spacing.sm} 0;
+    text-align: center;
+
+    &.empty {
+      background-color: ${theme.colour.greyLight};
+      border: 2px solid ${theme.colour.greyLight};
+
+      * {
+        visibility: hidden;
+      }
+    }
+  }
+
+  button {
+    font-size: ${theme.font.md};
+    text-decoration: underline;
+    color: ${theme.colour.link};
+    background-color: transparent;
+    border: 0;
+    cursor: pointer;
+
+    &:focus {
+      outline-offset: 2px;
+      outline: 3px solid ${theme.colour.focus};
+    }
+  }
+`
+
+const renderDayBoxes = ({
+  dayLimit,
+  selectedDays,
+  removeDayOnClickOrKeyPress,
+}) => {
+  let dayBoxes = []
+  for (let i = 0; i < dayLimit; i++) {
+    let selectedDay = selectedDays[i] // eslint-disable-line security/detect-object-injection
+    dayBoxes.push(
+      selectedDay ? (
+        <li key={i} className={dayBox}>
+          <span className="day-box">
+            <Time date={selectedDay} />
+          </span>
+          <button
+            type="button"
+            onClick={removeDayOnClickOrKeyPress(selectedDay)}
+            onKeyPress={removeDayOnClickOrKeyPress(selectedDay)}
+          >
+            <Trans>Remove date</Trans>
+          </button>
+        </li>
+      ) : (
+        <li key={i} className={dayBox}>
+          <span className="empty day-box">
+            <span>No date selected</span>
+          </span>
+        </li>
+      ),
+    )
+  }
+  return dayBoxes
+}
 
 class Calendar extends Component {
   constructor(props) {
@@ -310,9 +437,11 @@ class Calendar extends Component {
   render() {
     let {
       input: { onBlur, onFocus, value },
+      dayLimit,
     } = this.props
+    value = value || []
     return (
-      <div>
+      <div className={calendarContainer}>
         <DayPicker
           className={css`
             ${dayPickerDefault} ${dayPicker};
@@ -323,14 +452,10 @@ class Calendar extends Component {
           numberOfMonths={1}
           disabledDays={[{ daysOfWeek: [0, 1, 3, 4, 6] }]}
           onDayClick={this.handleDayClick}
-          selectedDays={value || []}
+          selectedDays={value}
           onFocus={() => onFocus(value)}
           onBlur={() => onBlur(value)}
         />
-        {/*
-          This code demonstrates how to update the page as dates are selected.
-          It should be replaced as we fine-tune the interaction.
-        */}
         <div>
           <h3>Dates selected:</h3>
           <div
@@ -345,27 +470,13 @@ class Calendar extends Component {
             />
           </div>
 
-          <div id="selectedDays">
-            {value && value.length > 0 ? (
-              <ol>
-                {value.map((day, index) => (
-                  <li key={index}>
-                    {`${index + 1}. `}
-                    <Time date={day} />{' '}
-                    <button
-                      type="button"
-                      onClick={this.removeDayOnClickOrKeyPress(day)}
-                      onKeyPress={this.removeDayOnClickOrKeyPress(day)}
-                    >
-                      <Trans>Remove date</Trans>
-                    </button>
-                  </li>
-                ))}
-              </ol>
-            ) : (
-              'No dates selected'
-            )}
-          </div>
+          <ul id="selectedDays">
+            {renderDayBoxes({
+              dayLimit,
+              selectedDays: value,
+              removeDayOnClickOrKeyPress: this.removeDayOnClickOrKeyPress,
+            })}
+          </ul>
         </div>
       </div>
     )

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -264,15 +264,23 @@ const calendarContainer = css`
     width: 22em;
   }
 
+  width: 130%;
+
   ${mediaQuery.lg(css`
     display: block;
   `)};
 
   ${mediaQuery.md(css`
+    width: 125%;
+
     > div:first-of-type,
     > div:last-of-type {
       width: 100%;
     }
+  `)};
+
+  ${mediaQuery.sm(css`
+    width: 100%;
   `)};
 
   #selectedDays {

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -74,7 +74,7 @@ describe('<CalendarAdapter />', () => {
 
   it('selects a date when it is clicked', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
@@ -84,12 +84,12 @@ describe('<CalendarAdapter />', () => {
   it('unselects a date when it is clicked twice', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
 
-    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
     // click the first available day (June 1st, 2018) twice
     clickFirstDate(wrapper)
     clickFirstDate(wrapper)
-    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
   })
 
   it('will not select more days once the limit is reached', () => {
@@ -132,7 +132,7 @@ describe('<CalendarAdapter />', () => {
       .find('#selectedDays button')
       .first()
       .simulate('click')
-    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
     expect(getErrorMessageString(wrapper)).toEqual('')
   })
 
@@ -149,7 +149,7 @@ describe('<CalendarAdapter />', () => {
 
     // click June 5th, 2018
     clickDate(wrapper, 1)
-    expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
@@ -211,7 +211,7 @@ describe('<CalendarAdapter />', () => {
   events.map(({ eventType, options, toString }) => {
     it(`will remove a date when its "Remove date" button is triggered by a ${toString}`, () => {
       const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-      expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+      expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
       clickFirstDate(wrapper)
       expect(getDateStrings(wrapper)).toEqual('Fri, 01 Jun 2018')
@@ -220,7 +220,7 @@ describe('<CalendarAdapter />', () => {
         .find('#selectedDays button')
         .first()
         .simulate(eventType, options)
-      expect(wrapper.find('#selectedDays').text()).toEqual('No dates selected')
+      expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
     })
   })
 })

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -35,10 +35,16 @@ const defaultProps = ({ value = '', dayLimit = 3 } = {}) => {
 }
 
 describe('<CalendarAdapter />', () => {
-  it('renders June and July 2018', () => {
+  it('renders June 2018', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
     expect(wrapper.text()).toMatch(/June 2018/)
+  })
+
+  it('renders July 2018', () => {
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
+    wrapper.find('.DayPicker-NavButton--next').simulate('click')
     expect(wrapper.text()).toMatch(/July 2018/)
+    expect(wrapper.text()).not.toMatch(/June 2018/)
   })
 
   it('will prefill a date if an initial value is provided', () => {

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
-import { css } from 'react-emotion'
+import styled, { css } from 'react-emotion'
 import {
   theme,
-  visuallyhidden,
-  CalHeader,
   CalReminder,
   BottomContainer,
   TopContainer,
+  H1,
+  H2,
 } from '../styles'
 import Layout from '../components/Layout'
 import Button from '../components/forms/Button'
@@ -27,6 +27,25 @@ const errorClass = css`
   display: block;
   color: red;
   margin-bottom: ${theme.spacing.sm};
+`
+
+const headerStyles = css`
+  font-weight: 400;
+  margin-bottom: ${theme.spacing.xl};
+
+  strong {
+    font-weight: 700;
+  }
+`
+
+const CalendarHeader = styled(H1)`
+  font-size: ${theme.font.xl};
+  ${headerStyles};
+`
+
+const CalendarSubheader = styled(H2)`
+  font-size: ${theme.font.lg};
+  ${headerStyles};
 `
 
 class CalendarPage extends Component {
@@ -91,9 +110,6 @@ class CalendarPage extends Component {
   render() {
     return (
       <Layout>
-        <h1 className={visuallyhidden}>
-          Now use the calendar to tell us when you’re available.
-        </h1>
         <TopContainer>
           <nav>
             <NavLink to="/register">
@@ -102,13 +118,19 @@ class CalendarPage extends Component {
           </nav>
         </TopContainer>
 
-        <CalHeader>
+        <CalendarHeader>
           <Trans>
-            Citizenship Tests are scheduled on Tuesdays and Fridays. Use the
-            calendar to select at least three (3) days you’re available in June
-            and July.
+            Citizenship Tests are scheduled on <strong>Tuesdays</strong> and{' '}
+            <strong>Fridays</strong>.
           </Trans>
-        </CalHeader>
+        </CalendarHeader>
+        <CalendarSubheader>
+          <Trans>
+            <strong>Select three (3) days you are available</strong> in June and
+            July.
+          </Trans>
+        </CalendarSubheader>
+
         <Form
           onSubmit={this.onSubmit}
           initialValues={this.state.data}

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -30,27 +30,6 @@ export const incrementColor = (col, amt) => {
   return (usePound ? '#' : '') + (g | (b << 8) | (r << 16)).toString(16)
 }
 
-export const roundedEdges = css`
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
-  border-radius: 2px;
-`
-
-/*
- * Hide only visually, but have it
- * available for screenreaders
- */
-export const visuallyhidden = css`
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-`
-
 export const breakpoints = {
   xs: 481,
   sm: 576,
@@ -70,12 +49,13 @@ export const theme = {
     gray: '#4A4A4A',
     greyLight: '#DBDBDB',
     grayLight: '#DBDBDB',
-    greyVeryLight: '#f5f5f5',
-    grayVeryLight: '#f5f5f5',
+    greyVeryLight: '#F5F5F5',
+    grayVeryLight: '#F5F5F5',
     white: '#FFFFFF',
     black: '#000000',
-    focus: '#ffbf47',
-    visited: '#551a8b',
+    focus: '#FFBF47',
+    link: '#0000EE',
+    visited: '#551A8B',
     alpha: '#F90277',
   },
   font: {
@@ -117,6 +97,27 @@ export const mediaQuery = Object.keys(breakpoints).reduce(
   },
   {},
 )
+
+export const roundedEdges = css`
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+`
+
+/*
+ * Hide only visually, but have it
+ * available for screenreaders
+ */
+export const visuallyhidden = css`
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+`
 
 /* eslint-enable security/detect-object-injection */
 

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -185,15 +185,6 @@ export const Calendar = styled.div`
   background: ${theme.colour.greyLight};
 `
 
-export const CalHeader = styled.div`
-  width: 32em;
-  font-size: ${theme.font.lg};
-  padding-bottom: ${theme.spacing.xl};
-  ${mediaQuery.md(css`
-    width: 100%;
-  `)};
-`
-
 export const CalReminder = styled.div`
   font-size: ${theme.font.lg};
   padding: ${theme.spacing.xl} 0 ${theme.spacing.lg} 0;

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -8,7 +8,6 @@ import server from '../src/server'
 describe('Server Side Rendering', () => {
   it('renders the landing page at /', async () => {
     let response = await request(server).get('/')
-
     expect(response.text).toMatch(
       /Use this service to notify Immigration, Refugees and Citizenship Canada/,
     )
@@ -16,13 +15,12 @@ describe('Server Side Rendering', () => {
 
   it('renders the register page at /register', async () => {
     let response = await request(server).get('/register')
-
     expect(response.text).toMatch(/Full name/)
   })
 
   it('renders the calendar page at /calendar', async () => {
     let response = await request(server).get('/calendar')
-    expect(response.text).toMatch(/Use the calendar to select./)
+    expect(response.text).toMatch(/Citizenship Tests are scheduled on/)
   })
 
   it('renders the review page at /review', async () => {


### PR DESCRIPTION
This pull request does a bunch of fun stuff:
- Updates the calendar styling
  - Calendar now shows one month at a time
  - Calendar now has hover/focus styles so that it's keyboard navigable
  - Calendar looks a bit nicer
- Updates the list of dates beside the calendar
  - When no dates are selected, users see three grey boxes
  - As users select dates, they are entered into the boxes and a "remove" button appears
- Updates the words on the calendar page to match the mock-up
- Simplifies some of the internal date storage

Merging this pull request resolves #86.

**Note: the code is all there so you can build locally, but I can't upload screenshots right now**

## renders

| before | after |
|--------|-------|
|  two-month calendar no dates selected   |   one-month calendar no dates selected |
|   <img width="1440" alt="screen shot 2018-05-24 at 12 31 23 pm" src="https://user-images.githubusercontent.com/2454380/40501921-50d715ea-5f57-11e8-9daf-90b01f103b24.png">   |  <img width="1440" alt="screen shot 2018-05-24 at 12 31 25 pm" src="https://user-images.githubusercontent.com/2454380/40501952-701559f8-5f57-11e8-8183-c20dde6b4517.png">|
|    two-month calendar 3 dates selected    |   one-month calendar 3 dates selected     |
|   <img width="1440" alt="screen shot 2018-05-24 at 12 31 33 pm" src="https://user-images.githubusercontent.com/2454380/40502036-b30f81de-5f57-11e8-9f26-12389c59dd20.png">     |   <img width="1440" alt="screen shot 2018-05-24 at 12 31 46 pm" src="https://user-images.githubusercontent.com/2454380/40502037-b331311c-5f57-11e8-8cc1-4bc184418dad.png">  |

## picking dates 
![calendar-1](https://user-images.githubusercontent.com/2454380/40502073-d33ecdd4-5f57-11e8-9ea2-63a4f60459fd.gif)


## picking and removing dates
![calendar-2](https://user-images.githubusercontent.com/2454380/40502075-d4f1a8a4-5f57-11e8-86a8-c1edce596391.gif)

## using a keyboard
![calendar-3](https://user-images.githubusercontent.com/2454380/40502081-df8cf58e-5f57-11e8-9dd6-0a548bf5390b.gif)


