### PR TITLE
improvements to run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "repository": "https://github.com/cds-snc/ircc-rescheduler.git",
   "license": "MIT",
   "scripts": {
-    "start": "cd web && yarn build && cd .. && NODE_ENV=production forever start web/build/server.js && cd api && forever start index.js",
+    "build-web": "cd web && yarn && yarn build",
+    "build-api": "cd api && yarn",
+    "start-web": "NODE_ENV=production forever start web/build/server.js",
+    "start-api": "cd api && forever start index.js",
+    "start": "yarn stop && yarn build-web && yarn build-api && yarn start-web && yarn start-api",
     "stop": "forever stopall"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "repository": "https://github.com/cds-snc/ircc-rescheduler.git",
   "license": "MIT",
   "scripts": {
-    "build-web": "cd web && yarn && yarn build",
-    "build-api": "cd api && yarn",
-    "start-web": "NODE_ENV=production forever start web/build/server.js",
-    "start-api": "cd api && forever start index.js",
-    "start": "yarn stop && yarn build-web && yarn build-api && yarn start-web && yarn start-api",
+    "build_web": "cd web && yarn && yarn build",
+    "build_api": "cd api && yarn",
+    "start_web": "NODE_ENV=production forever start web/build/server.js",
+    "start_api": "cd api && forever start index.js",
+    "start": "yarn stop && yarn build_web && yarn build_api && yarn start_web && yarn start_api",
     "stop": "forever stopall"
   },
   "dependencies": {


### PR DESCRIPTION
should make this slightly easier to work with 

- just run `yarn start` instead of stopping and starting
- added build steps for both api/web
