### PR TITLE
Add Google Analytics to track pageviews

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -3,3 +3,6 @@ dist
 node_modules
 # Vim swap files
 *.swp
+
+# environment variables used in prod
+.env.production

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "react-dom": "16.3.1",
     "react-emotion": "^9.1.1",
     "react-final-form": "^3.1.5",
+    "react-ga": "^2.5.3",
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.2.2",
     "unfetch": "^3.0.0"

--- a/web/src/utils/analytics.js
+++ b/web/src/utils/analytics.js
@@ -1,0 +1,24 @@
+import ReactGA from 'react-ga'
+
+export const initGA = ga_id => {
+  ReactGA.initialize(ga_id)
+}
+
+export const logPageView = () => {
+  // eslint-disable-next-line no-console
+  console.log(`Logging pageview for ${window.location.pathname}`)
+  ReactGA.set({ page: window.location.pathname })
+  ReactGA.pageview(window.location.pathname)
+}
+
+export const logEvent = (category = '', action = '') => {
+  if (category && action) {
+    ReactGA.event({ category, action })
+  }
+}
+
+export const logException = (description = '', fatal = false) => {
+  if (description) {
+    ReactGA.exception({ description, fatal })
+  }
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6956,6 +6956,13 @@ react-final-form@^3.1.5:
   dependencies:
     react-lifecycles-compat "^3.0.4"
 
+react-ga@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.3.tgz#0f447c73664c069a5fc341f6f431262e3d4c23c4"
+  optionalDependencies:
+    prop-types "^15.6.0"
+    react "^15.6.2 || ^16.0"
+
 react-helmet@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
@@ -7039,7 +7046,7 @@ react@16.3.1:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.3.2:
+"react@^15.6.2 || ^16.0", react@^16.3.2:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:


### PR DESCRIPTION
Adds Google Analytics to every page using the [`react-ga`](https://github.com/react-ga/react-ga) library.

Added some logic to make sure that Google Analytics is only started when
- the `NODE_ENV` environment variable is set to 'production'
- the `RAZZLE_GA_ID` environment variable exists (this should be our Google tracking ID)

Otherwise, the app will run as normal and nothing will be logged.

Currently there is a print statement each time a page is logged by Google Analytics. We should shut this off before we are in live beta or whatever, but for now this seems okay.

Merging this resolves (long-standing) issue #8.

//

This is the same library that the VAC team are using, so we can help each other if need be.

Relevant VAC pull request:
cds-snc/vac-benefits-directory#42

Also this example was helpful: https://github.com/zeit/next.js/tree/canary/examples/with-react-ga