### PR TITLE
Order list of selected days chronologically

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -373,14 +373,22 @@ const selectedDaysError = css`
   }
 `
 
+const sortSelectedDays = selectedDays => {
+  // create a new array because .sort() modifies our original array
+  let temp = selectedDays.slice()
+  temp.sort((date1, date2) => date1.getTime() - date2.getTime())
+  return temp
+}
+
 const renderDayBoxes = ({
   dayLimit,
   selectedDays,
   removeDayOnClickOrKeyPress,
 }) => {
   let dayBoxes = []
+  let selectedDaysSorted = sortSelectedDays(selectedDays)
   for (let i = 0; i < dayLimit; i++) {
-    let selectedDay = selectedDays[i] // eslint-disable-line security/detect-object-injection
+    let selectedDay = selectedDaysSorted[i] // eslint-disable-line security/detect-object-injection
     dayBoxes.push(
       selectedDay ? (
         <li key={i} className={dayBox}>

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -81,6 +81,26 @@ describe('<CalendarAdapter />', () => {
     expect(getDateStrings(wrapper)).toEqual('Fri, 01 Jun 2018')
   })
 
+  it('orders selected dates chronologically', () => {
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
+    expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
+
+    // click June 8th, 2018
+    clickDate(wrapper, 2)
+    expect(getDateStrings(wrapper)).toEqual('Fri, 08 Jun 2018')
+
+    // click June 5th, 2018
+    clickDate(wrapper, 1)
+    expect(getDateStrings(wrapper)).toEqual('Tue, 05 Jun 2018 Fri, 08 Jun 2018')
+
+    // click June 1st, 2018
+    clickDate(wrapper, 0)
+
+    expect(getDateStrings(wrapper)).toEqual(
+      'Fri, 01 Jun 2018 Tue, 05 Jun 2018 Fri, 08 Jun 2018',
+    )
+  })
+
   it('unselects a date when it is clicked twice', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
 
@@ -172,7 +192,7 @@ describe('<CalendarAdapter />', () => {
     // click the first available day (June 1st, 2018)
     clickFirstDate(wrapper)
     expect(getDateStrings(wrapper)).toEqual(
-      'Tue, 05 Jun 2018 Fri, 08 Jun 2018 Fri, 01 Jun 2018',
+      'Fri, 01 Jun 2018 Tue, 05 Jun 2018 Fri, 08 Jun 2018',
     )
   })
 


### PR DESCRIPTION
Up to now, dates would show up in the order the user selected them.

ie, if they selected "June 8, June 5, June 1", they would be displayed in that order.

This could lead to the assumption that their preferred ordering was important when making their selection.

Since we're not letting them order dates at all, we're enforcing a chronological order which is how IRCC will get them.

now, if they select
-  "June 8, June 5, June 1"

they will see
- "June 1, June 5, June 8" 

as the dates they have selected.

Test it out here (might take a while to load but just grit your teeth): https://ircc-rescheduler-pyizkhsyuf.now.sh/calendar

## gif

![dates](https://user-images.githubusercontent.com/2454380/41179788-f137c0dc-6b39-11e8-99a7-5df15ab0cf43.gif)

Merging this PR resolves issue #129 