### PR TITLE
Footer restyling

### DIFF
--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -19,7 +19,6 @@ const footer = css`
   padding: ${theme.spacing.xl} ${theme.spacing.xxxl};
   display: flex;
   justify-content: space-between;
-  flex-direction: row-reverse;
   position: relative;
   font-size: ${theme.font.md};
 
@@ -40,12 +39,11 @@ const footer = css`
 
   ${mediaQuery.md(css`
     align-items: center;
-    flex-direction: row;
     padding: ${theme.spacing.xl} ${theme.spacing.xxxl};
   `)};
 
   ${mediaQuery.sm(css`
-    padding: ${theme.spacing.xl} ${theme.spacing.xl};
+    padding: ${theme.spacing.lg} ${theme.spacing.xl};
   `)};
 `
 
@@ -74,19 +72,17 @@ const bottomLinks = css`
   ${mediaQuery.md(css`
     display: flex;
     margin-top: ${theme.spacing.sm};
-    font-size: ${theme.font.sm};
-    flex-direction: row;
-    align-items: center;
   `)};
 
   ${mediaQuery.sm(css`
     margin-top: ${theme.spacing.md};
+    font-size: ${theme.font.sm};
   `)};
 `
 const terms = css`
   span::after {
     content: "Terms and Conditions";
-    ${mediaQuery.xs(css`
+    ${mediaQuery.md(css`
       content: "Terms";
     `)};
   }

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { WordMark } from '@cdssnc/gcui'
 import styled, { css } from 'react-emotion'
-import { theme, mediaQuery } from '../styles'
+import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
 
 const Circle = styled.span`
   font-size: 0.5em;
@@ -72,20 +72,12 @@ const bottomLinks = css`
   ${mediaQuery.md(css`
     display: flex;
     margin-top: ${theme.spacing.sm};
+    font-size: ${theme.font.sm};
   `)};
 
   ${mediaQuery.sm(css`
     margin-top: ${theme.spacing.md};
-    font-size: ${theme.font.sm};
   `)};
-`
-const terms = css`
-  span::after {
-    content: "Terms and Conditions";
-    ${mediaQuery.md(css`
-      content: "Terms";
-    `)};
-  }
 `
 
 const TopBar = styled.hr(
@@ -115,8 +107,8 @@ const Footer = ({ topBarBackground }) => (
         <Circle>&#9679;</Circle>
         <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
         <Circle>&#9679;</Circle>
-        <a className={terms} href="https://digital.canada.ca/legal/terms/">
-          <span className={terms}></span>
+        <a href="https://digital.canada.ca/legal/terms/">
+          Terms<span className={visuallyhiddenMobile}> and Conditions</span>
         </a>
       </div>
     </footer>

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -27,15 +27,25 @@ const footer = css`
     width: 150px;
     height: 40px;
 
+    ${mediaQuery.md(css`
+      width: 85px;
+      height: 25px;
+    `)};
+
     ${mediaQuery.sm(css`
-      width: 140px;
-      height: 36px;
+      width: 65px;
+      height: 18px;
     `)};
   }
 
   ${mediaQuery.md(css`
-    flex-direction: column;
     align-items: center;
+    flex-direction: row;
+    padding: ${theme.spacing.xl} ${theme.spacing.xxxl};
+  `)};
+
+  ${mediaQuery.sm(css`
+    padding: ${theme.spacing.xl} ${theme.spacing.xl};
   `)};
 `
 
@@ -47,8 +57,12 @@ const bottomLinks = css`
   > * {
     margin-right: ${theme.spacing.md};
 
-    ${mediaQuery.sm(css`
+    ${mediaQuery.md(css`
       margin-right: 0;
+      margin-left: ${theme.spacing.md};
+    `)};
+
+    ${mediaQuery.sm(css`
       margin-bottom: ${theme.spacing.xs};
     `)};
   }
@@ -59,15 +73,23 @@ const bottomLinks = css`
 
   ${mediaQuery.md(css`
     display: flex;
-    margin-top: ${theme.spacing.xl};
+    margin-top: ${theme.spacing.sm};
+    font-size: ${theme.font.sm};
     flex-direction: row;
     align-items: center;
   `)};
 
   ${mediaQuery.sm(css`
-    margin-top: ${theme.spacing.lg};
-    flex-direction: column;
+    margin-top: ${theme.spacing.md};
   `)};
+`
+const terms = css`
+  span::after {
+    content: "Terms and Conditions";
+    ${mediaQuery.xs(css`
+      content: "Terms";
+    `)};
+  }
 `
 
 const TopBar = styled.hr(
@@ -93,12 +115,12 @@ const Footer = ({ topBarBackground }) => (
       </div>
 
       <div className={bottomLinks}>
-        <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
-        <Circle>&#9679;</Circle>
         <a href="mailto:cds-snc@tbs-sct.gc.ca">Contact</a>
         <Circle>&#9679;</Circle>
-        <a href="https://digital.canada.ca/legal/terms/">
-          Terms and Conditions
+        <a href="https://www.canada.ca/en/transparency/privacy.html">Privacy</a>
+        <Circle>&#9679;</Circle>
+        <a className={terms} href="https://digital.canada.ca/legal/terms/">
+          <span className={terms}></span>
         </a>
       </div>
     </footer>

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -105,7 +105,7 @@ export const roundedEdges = css`
 `
 
 export const focusRing = css`
-  &:focus{
+  &:focus {
     outline: 3px solid ${theme.colour.focus};
   }
 `
@@ -123,6 +123,12 @@ export const visuallyhidden = css`
   padding: 0;
   position: absolute;
   width: 1px;
+`
+
+export const visuallyhiddenMobile = css`
+  ${mediaQuery.sm(css`
+    ${visuallyhidden};
+  `)};
 `
 
 /* eslint-enable security/detect-object-injection */

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -117,12 +117,13 @@ export const focusRing = css`
 export const visuallyhidden = css`
   border: 0;
   clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
+  height: auto;
+  margin: 0;
   overflow: hidden;
   padding: 0;
   position: absolute;
   width: 1px;
+  white-space: nowrap;
 `
 
 export const visuallyhiddenMobile = css`


### PR DESCRIPTION
**This PR consists of:**

| Before | After |
|--------|-------|
|    ![41063620-26eda6cc-69a7-11e8-9e2b-f991575f1376](https://user-images.githubusercontent.com/30609058/41242796-770eb554-6d6e-11e8-9b77-0f4f5735829a.jpg)    |   <img width="387" alt="screen shot 2018-06-11 at 11 59 19" src="https://user-images.githubusercontent.com/30609058/41242955-faba8176-6d6e-11e8-9ce3-a2648567d41f.png">  |





**For Mobile:**
- Reduced the size of the Canada Wordmark by 50%
- Removed row-reverse as the flex-direction so that the footer is ordered Wordmark -> Links
- Font-size reduction on smaller screens for the links
- 'Terms and Conditions' becomes 'Terms' on smaller screens

**For Desktop:**
- Removed row-reverse as the flex-direction so that the footer is ordered Wordmark -> Links


