### PR TITLE
Alpha Banner Alignment

### DIFF
--- a/web/src/components/AlphaBanner.js
+++ b/web/src/components/AlphaBanner.js
@@ -5,10 +5,26 @@ import { PhaseBanner } from '@cdssnc/gcui'
 let AlphaBanner = styled(PhaseBanner)`
   padding-top: ${theme.spacing.sm};
   padding-bottom: ${theme.spacing.sm};
+  display: flex;
+
+  span:last-of-type {
+    margin-left: 0;
+    ${mediaQuery.sm(css`
+      padding: 0;
+      line-height: 1.3;
+    `)};
+  }
+
+  span:first-of-type {
+    padding: 0 ${theme.spacing.md} 0 ${theme.spacing.md};
+    ${mediaQuery.sm(css`
+      padding: 0.1rem ${theme.spacing.md} 0.1rem ${theme.spacing.md};
+    `)};
+  }
 
   ${mediaQuery.sm(css`
-    padding-left: ${theme.spacing.xl};
-    padding-bottom: ${theme.spacing.sm};
+    padding: ${theme.spacing.md} 0 ${theme.spacing.md} ${theme.spacing.xl};
+    display: flex;
   `)};
 `
 


### PR DESCRIPTION
**This PR consists of:**
- Adjusting alpha banner mobile functionality to display the banner message beside the badge instead of below it.

| Before | After |
|--------|-------|
|    ![alphabannerbefore](https://user-images.githubusercontent.com/30609058/41320798-35fba67e-6e6f-11e8-88ec-bc7d88cbd73b.gif)    |   ![alphabannerafter](https://user-images.githubusercontent.com/30609058/41320797-35e9411e-6e6f-11e8-945c-1cf61bd7f06e.gif)    |


