### PR TITLE
Usability Content changes discluding cal changes

### DIFF
--- a/web/src/pages/ConfirmationPage.js
+++ b/web/src/pages/ConfirmationPage.js
@@ -13,12 +13,14 @@ class ConfirmationPage extends React.Component {
             <Trans>Thank you! Your request has been received.</Trans>
           </H1>
 
+          <p> We&#39;ve sent you a confirmation email. </p>
+
           <H2>
             <Trans>What happens next?</Trans>
           </H2>
           <p>
             <Trans>
-              Within six (6) weeks, your local{' '}
+              By July 6, 2018, your local{' '}
               <abbr title="Immigration, Refugees and Citizenship Canada">
                 IRCC
               </abbr>{' '}

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -77,15 +77,6 @@ class LandingPage extends React.Component {
 
             <li>
               <p>
-                <Trans>Your full name</Trans>
-              </p>
-              <p>
-                <Trans>This should match the name on your application.</Trans>
-              </p>
-            </li>
-
-            <li>
-              <p>
                 <Trans>To describe your reason for rescheduling</Trans>
               </p>
               <p>
@@ -111,8 +102,8 @@ class LandingPage extends React.Component {
           <Trans>
             By sending this request to reschedule, you will be{' '}
             <strong>cancelling your current appointment</strong>. After you
-            complete this process, it could take up to six (6) weeks for IRCC to
-            schedule your new appointment.
+            complete this process, it could take up to nine (9) weeks for IRCC
+            to schedule your new appointment.
           </Trans>
         </Reminder>
 

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -72,7 +72,7 @@ const labelNames = id => {
     case 'paperFileNumber':
       return <Trans>Paper File Number</Trans>
     case 'reason':
-      return <Trans>Reason for rescheduling</Trans>
+      return <Trans>Why are you rescheduling?</Trans>
     case 'explanation':
       return <Trans>Explanation</Trans>
     default:
@@ -272,12 +272,6 @@ class RegistrationPage extends React.Component {
                           : ''
                       }
                     />
-                    <span id="reason-details">
-                      <Trans>If you’re not sure if you can reschedule,</Trans>{' '}
-                      <a href="http://www.cic.gc.ca/english/helpcentre/answer.asp?qnum=786&amp;top=5">
-                        <Trans>read the guidelines for rescheduling</Trans>
-                      </a>.
-                    </span>
                   </legend>
 
                   <Field


### PR DESCRIPTION
**This PR consists of:**

**Landing Page**
- Remove “full name” item
- Six (6) weeks -> Nine (9) weeks

**Info Page**
- Change “Reason for rescheduling” to “Why are you rescheduling?” And remove text below

**Confirmation**
- Under “Thank you! Your request was received.” add “We’ve sent you a confirmation email.”
- Change “6 weeks” to “July 6, 2018" (edited)