### PR TITLE
Language link is littler

### DIFF
--- a/web/src/components/FederalBanner.js
+++ b/web/src/components/FederalBanner.js
@@ -7,7 +7,7 @@ import { theme, mediaQuery } from '../styles'
 import { LanguageSwitcher } from './LanguageSwitcher'
 
 const container = css`
-  padding: ${theme.spacing.lg} ${theme.spacing.xxxl} ${theme.spacing.lg}
+  padding: ${theme.spacing.lg} ${theme.spacing.xxxl} ${theme.spacing.md}
     ${theme.spacing.xxxl};
   width: auto;
   justify-content: space-between;
@@ -25,27 +25,21 @@ const container = css`
   }
 
   ${mediaQuery.sm(css`
-    padding-left: ${theme.spacing.xl};
-    padding-right: ${theme.spacing.xl};
+    padding: ${theme.spacing.md} ${theme.spacing.xl} ${theme.spacing.md}
+      ${theme.spacing.xl};
   `)};
 
   ${mediaQuery.xs(css`
-    flex-direction: column;
-  `)};
+    .svg-container {
+      width: 210px;
+      height: 20px;
 
-  /*
-  This is a fudge.
-  We shouldn't know that the LanguageSwitcher component is a <section>, really.
-  The reason for this is that these spacing rules make sense in the
-  context of the Banner segment, not on the switcher by itself.
-  */
-  section {
-    ${mediaQuery.xs(css`
-      margin-top: ${theme.spacing.sm};
-      /* this means the "Français" link looks aligned with the flag */
-      margin-left: -2px;
-    `)};
-  }
+      svg {
+        width: 210px;
+        height: 20px;
+      }
+    }
+  `)};
 `
 
 const FederalBanner = () => (

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -3,7 +3,7 @@ import { Query, Mutation } from 'react-apollo'
 import { GET_LANGUAGE_QUERY, CHANGE_LANGUAGE_MUTATION } from '../queries'
 import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
-import { theme, visuallyhidden } from '../styles'
+import { theme, visuallyhidden, mediaQuery } from '../styles'
 
 const link = css`
   font-size: ${theme.font.base};
@@ -14,6 +14,22 @@ const link = css`
   &:hover {
     cursor: pointer;
   }
+`
+
+const hiddenOnMobile = css`
+  display: initial;
+
+  ${mediaQuery.sm(css`
+    display: none;
+  `)};
+`
+
+const hiddenOnDesktop = css`
+  display: none;
+
+  ${mediaQuery.sm(css`
+    display: initial;
+  `)};
 `
 
 export const LanguageSwitcher = () => (
@@ -36,7 +52,14 @@ export const LanguageSwitcher = () => (
                 }
               }}
             >
-              {language === 'en' ? 'Français' : 'English'}
+              {language === 'en' ? (
+                <span>
+                  <span className={hiddenOnMobile}>Français</span>
+                  <span className={hiddenOnDesktop}>FR</span>
+                </span>
+              ) : (
+                'English'
+              )}
             </a>
           )}
         </Mutation>

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -3,7 +3,12 @@ import { Query, Mutation } from 'react-apollo'
 import { GET_LANGUAGE_QUERY, CHANGE_LANGUAGE_MUTATION } from '../queries'
 import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
-import { theme, visuallyhidden, mediaQuery } from '../styles'
+import {
+  theme,
+  visuallyhidden,
+  visuallyhiddenMobile,
+  mediaQuery,
+} from '../styles'
 
 const link = css`
   font-size: ${theme.font.base};
@@ -14,14 +19,6 @@ const link = css`
   &:hover {
     cursor: pointer;
   }
-`
-
-const hiddenOnMobile = css`
-  display: initial;
-
-  ${mediaQuery.sm(css`
-    display: none;
-  `)};
 `
 
 const hiddenOnDesktop = css`
@@ -54,8 +51,10 @@ export const LanguageSwitcher = () => (
             >
               {language === 'en' ? (
                 <span>
-                  <span className={hiddenOnMobile}>Français</span>
-                  <span className={hiddenOnDesktop}>FR</span>
+                  <span className={visuallyhiddenMobile}>Français</span>
+                  <span className={hiddenOnDesktop} aria-hidden="true">
+                    FR
+                  </span>
                 </span>
               ) : (
                 'English'


### PR DESCRIPTION
This pull request makes the language link smaller on mobile and keeps it on the same line as the Canadian Identity stuff. It also reduces the vertical padding a bit and makes the FIP banner smaller on really <sup>tiny</sup> screens.

When going through the page with a screenreader, the link will always be read as "français" and never "FR".

| before | after |
|--------|-------|
|  francais link drops down to next line     | francais link shortened to "RF" and stays on the same line    |
| ![screen shot 2018-06-14 at 4 21 12 pm](https://user-images.githubusercontent.com/2454380/41436235-06997b50-6fef-11e8-8dca-dfb65ab0639f.png) | ![screen shot 2018-06-14 at 4 21 06 pm](https://user-images.githubusercontent.com/2454380/41436252-0e32df8c-6fef-11e8-9b0d-79320d876708.png) |
|    ![header-2](https://user-images.githubusercontent.com/2454380/41436183-d7ae627e-6fee-11e8-9242-1a71f9d6bbfa.gif)  |   ![header-1](https://user-images.githubusercontent.com/2454380/41436160-d13be1fa-6fee-11e8-9a21-99593f18cf7f.gif) |



