### PR TITLE
Remove styling from `<main>` element

### DIFF
--- a/web/src/components/Layout.js
+++ b/web/src/components/Layout.js
@@ -87,9 +87,11 @@ class Layout extends React.Component {
               <Trans>Request a new Canadian Citizenship appointment</Trans>
             </PageHeader>
           </div>
-          <Content className={this.props.contentClass || ''} role="main">
-            {this.props.children}
-          </Content>
+          <main role="main">
+            <Content className={this.props.contentClass || ''}>
+              {this.props.children}
+            </Content>
+          </main>
           <Footer topBarBackground="black" />
         </ErrorBoundary>
       </div>

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -158,7 +158,7 @@ const contentSpacing = css`
   `)};
 `
 
-export const Content = styled.main`
+export const Content = styled.div`
   padding: ${theme.spacing.xl} ${theme.spacing.xxxl} ${theme.spacing.xxl}
     ${theme.spacing.xxxl};
   width: 100%;


### PR DESCRIPTION
The Internet Explorers of the world have problems with the HTML5 `<main>` tag, so I just kept the main as an unstyled markup element and changed Content to a `div`.

Means our site displays properly again in IE11.

This PR resolves #158.

More on `<main>`s for those interested: https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html