### PR TITLE
Amend Review + Confirmation Pages + Error

### DIFF
--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -30,10 +30,15 @@ const Row = styled.div`
     padding-bottom: 0;
     margin-bottom: ${theme.spacing.xs};
   }
+
+  li:last-of-type {
+    margin-bottom: 0;
+  }
 `
 
 const SummaryHeader = styled.div`
   width: 100%;
+  margin-bottom: 0;
 `
 
 const SummaryBody = styled.div`
@@ -60,6 +65,10 @@ const SummaryLink = styled.div`
   `)};
 `
 
+const SummaryH2 = styled(H2)`
+  margin-bottom: ${theme.spacing.sm};
+`
+
 const SelectedDayList = ({ selectedDays }) => {
   return selectedDays && selectedDays.length > 0 ? (
     <ul>
@@ -82,7 +91,7 @@ SelectedDayList.propTypes = {
 const SummaryRow = ({ summaryHeader, summaryBody, summaryLink }) => (
   <Row>
     <SummaryHeader>
-      <H2>{summaryHeader}</H2>
+      <SummaryH2>{summaryHeader}</SummaryH2>
       <SummaryBody>{summaryBody}</SummaryBody>
     </SummaryHeader>
 

--- a/web/src/pages/ConfirmationPage.js
+++ b/web/src/pages/ConfirmationPage.js
@@ -1,13 +1,21 @@
 import React from 'react'
-import { H1, H2, visuallyhiddenMobile } from '../styles'
+import { H1, H2, visuallyhidden } from '../styles'
+import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
 import Layout from '../components/Layout'
 import Contact from '../components/Contact'
+import { theme } from '../styles'
+
+const contentClass = css`
+  p {
+    margin-top: ${theme.spacing.xs};
+  }
+`
 
 class ConfirmationPage extends React.Component {
   render() {
     return (
-      <Layout headerClass={visuallyhiddenMobile}>
+      <Layout contentClass={contentClass} headerClass={visuallyhidden}>
         <section>
           <H1>
             <Trans>Thank you! Your request has been received.</Trans>

--- a/web/src/pages/ErrorPage.js
+++ b/web/src/pages/ErrorPage.js
@@ -1,17 +1,28 @@
 import React from 'react'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
-import { H1, visuallyhiddenMobile } from '../styles'
+import { H1, visuallyhidden, theme } from '../styles'
 import Layout from '../components/Layout'
 import Contact from '../components/Contact'
+import styled, { css } from 'react-emotion'
+
+const ErrorH1 = styled(H1)`
+  margin-bottom: ${theme.spacing.sm};
+`
+
+const contentClass = css`
+  p:last-of-type {
+    margin-bottom: ${theme.spacing.md};
+  }
+`
 
 class ErrorPage extends React.Component {
   render() {
     return (
-      <Layout headerClass={visuallyhiddenMobile}>
-        <H1>
+      <Layout contentClass={contentClass} headerClass={visuallyhidden}>
+        <ErrorH1>
           <Trans>We&apos;re sorry, something went wrong.</Trans>
-        </H1>
+        </ErrorH1>
         <Contact>
           <div>
             <p>

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { css } from 'react-emotion'
 import { NavLink } from 'react-router-dom'
-import { H1, H2, theme, mediaQuery } from '../styles'
+import { H1, H2, theme, mediaQuery, arrow } from '../styles'
 import Layout from '../components/Layout'
 import Reminder from '../components/Reminder'
 import { buttonStyles } from '../components/forms/Button'
@@ -13,11 +13,6 @@ const contentClass = css`
   p {
     margin-bottom: ${theme.spacing.lg};
   }
-`
-
-const arrow = css`
-  width: 0.9rem;
-  height: 0.9rem;
 `
 
 const list = css`

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -3,13 +3,14 @@ import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
 import { Query } from 'react-apollo'
 import { NavLink, Redirect } from 'react-router-dom'
-import { H1, theme, BottomContainer, TopContainer } from '../styles'
+import { H2, theme, BottomContainer, TopContainer, arrow } from '../styles'
 import Layout from '../components/Layout'
 import { GET_USER_DATA, SUBMIT } from '../queries'
 import Button from '../components/forms/Button'
 import Summary from '../components/Summary'
 import { Submission } from '../components/Submission'
 import Reminder from '../components/Reminder'
+import rightArrow from '../assets/rightArrow.svg'
 
 const contentClass = css`
   p {
@@ -43,9 +44,9 @@ class ReviewPage extends React.Component {
             ← <Trans>Go Back</Trans>
           </NavLink>
         </TopContainer>
-        <H1>
+        <H2>
           <Trans>Review your request before sending it</Trans>
-        </H1>
+        </H2>
         <Query query={GET_USER_DATA}>
           {({ loading, error, data }) => {
             if (loading) return 'Loading...'
@@ -96,7 +97,8 @@ class ReviewPage extends React.Component {
                           })
                         }}
                       >
-                        <Trans>Send Request</Trans> →
+                        <Trans>Send Request</Trans>{' '}
+                        <img src={rightArrow} className={arrow} alt="" />
                       </Button>
                     )}
                   </Submission>

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -235,3 +235,8 @@ export const change = css`
     right: 0rem;
   `)};
 `
+
+export const arrow = css`
+  width: 0.9rem;
+  height: 0.9rem;
+`


### PR DESCRIPTION
**This PR consists of:**

- Page header reduced in size:

| Before | After |
|--------|-------|
|   <img width="905" alt="screen shot 2018-06-20 at 17 38 44" src="https://user-images.githubusercontent.com/30609058/41686386-de874d3c-74b1-11e8-9c00-77cba03e07c8.png">     |    <img width="894" alt="screen shot 2018-06-20 at 17 42 34" src="https://user-images.githubusercontent.com/30609058/41686384-dc9f8354-74b1-11e8-9e33-31e346ef3ef5.png">   |

- Summary header margin increase:

| Before | After |
|--------|-------|
|   <img width="917" alt="screen shot 2018-06-20 at 17 39 01" src="https://user-images.githubusercontent.com/30609058/41686412-fc270bca-74b1-11e8-80f1-53af161d9647.png">  | <img width="890" alt="screen shot 2018-06-20 at 17 42 49" src="https://user-images.githubusercontent.com/30609058/41686416-fdc06710-74b1-11e8-98aa-c72f07bcfada.png">|

- Last change link now aligns with bottom date item:

| Before | After |
|--------|-------|
|    <img width="870" alt="screen shot 2018-06-20 at 17 39 51" src="https://user-images.githubusercontent.com/30609058/41686471-3ae7f356-74b2-11e8-8686-ecdcf7c310e1.png">|    <img width="873" alt="screen shot 2018-06-20 at 17 42 56" src="https://user-images.githubusercontent.com/30609058/41686472-3c9070c0-74b2-11e8-8077-940953b3d58a.png">|

- Arrow changed to the right-arrow svg, moved arrow styling into styles.js as it will now be used on multiple pages:

| Before | After |
|--------|-------|
|   <img width="226" alt="screen shot 2018-06-20 at 17 40 15" src="https://user-images.githubusercontent.com/30609058/41686503-548adcba-74b2-11e8-83b0-91e31df81610.png">     |   <img width="218" alt="screen shot 2018-06-20 at 17 43 05" src="https://user-images.githubusercontent.com/30609058/41686500-52b2cca4-74b2-11e8-9bd9-904019dbfa53.png">    |

- Removed Page Header from confirmation and Error Page + Spacing between headers and p elements increased on Confirmation and Error Page:

| Before | After |
|--------|-------|
|   ![screen shot 2018-06-20 at 17 40 46](https://user-images.githubusercontent.com/30609058/41686558-8329e1c4-74b2-11e8-8958-a4cf8519170f.png)     |   ![screen shot 2018-06-20 at 17 44 23](https://user-images.githubusercontent.com/30609058/41686560-85fab766-74b2-11e8-8b56-9f39fe228f19.png)|

| Before | After |
|--------|-------|
|    ![screen shot 2018-06-20 at 17 40 34](https://user-images.githubusercontent.com/30609058/41686574-8d98e998-74b2-11e8-8f72-2134e931f71b.png) |   ![screen shot 2018-06-20 at 17 44 10](https://user-images.githubusercontent.com/30609058/41686568-8b2be69c-74b2-11e8-8ad7-571a6c287ddf.png) |



