### PR TITLE
Copyediting Pass: Form Page Error Block & Toughened Rescheduling Language

### DIFF
--- a/web/src/components/ErrorMessage.js
+++ b/web/src/components/ErrorMessage.js
@@ -56,7 +56,7 @@ class ErrorList extends React.Component {
         ) : (
           <div>
             <h2>{this.props.message}</h2>
-            <p>Please take another look at the:</p>
+            <p>Please check the following sections for errors:</p>
             <ul>
               {Array.isArray(this.props.children) ? (
                 this.props.children.map((child, i) => <li key={i}>{child}</li>)

--- a/web/src/components/__tests__/ErrorMessage.test.js
+++ b/web/src/components/__tests__/ErrorMessage.test.js
@@ -90,7 +90,9 @@ describe(`<ErrorList />`, () => {
     expect(wrapper.find('h2').length).toBe(1)
     expect(wrapper.find('h2').text()).toEqual('This is a message')
     expect(wrapper.find('p').length).toBe(1)
-    expect(wrapper.find('p').text()).toEqual('Please take another look at the:')
+    expect(wrapper.find('p').text()).toEqual(
+      'Please check the following sections for errors:',
+    )
     expect(wrapper.find('ul > li > span').text()).toEqual('This is a span')
     expect(wrapper.props().className).not.toMatch(/^empty/)
   })

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -102,9 +102,9 @@ class LandingPage extends React.Component {
 
         <LongReminder>
           <Trans>
-            Requesting a new appointment will cancel your existing appointment.
-            <strong> Do not attend your old appointment</strong> after you request a new one.
-            It can take up to 9 weeks to schedule your new appointment.
+            Requesting a new appointment will cancel your current one.
+            <strong> Do not attend your old appointment</strong> after you complete this request.
+            It can take up to 9 weeks for us to reschedule you.
           </Trans>
         </LongReminder>
 

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -102,9 +102,9 @@ class LandingPage extends React.Component {
 
         <LongReminder>
           <Trans>
-            When you request a new appointment, you will be{' '}
-            <strong>cancelling your current appointment</strong>. It can take up
-            to six weeks to schedule your new appointment.
+            Requesting a new appointment will cancel your existing appointment.
+            <strong> Do not attend your old appointment</strong> after you request a new one.
+            It can take up to 9 weeks to schedule your new appointment.
           </Trans>
         </LongReminder>
 

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -69,13 +69,13 @@ const forNowSubmitErrorStyles = css`
 const labelNames = id => {
   switch (id) {
     case 'fullName':
-      return <Trans>Full Name</Trans>
+      return <Trans>Full name</Trans>
     case 'paperFileNumber':
-      return <Trans>Paper File Number</Trans>
+      return <Trans>Paper file number</Trans>
     case 'reason':
       return <Trans>Why are you rescheduling?</Trans>
     case 'explanation':
-      return <Trans>Explanation</Trans>
+      return <Trans>Describe why you can’t attend your test</Trans>
     default:
       return ''
   }
@@ -154,7 +154,7 @@ class RegistrationPage extends React.Component {
       return {
         [FORM_ERROR]: (
           <Trans>
-            Sorry, there was a problem with the information you submitted.
+            Some information is missing.
           </Trans>
         ),
       }

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -71,7 +71,7 @@ class ReviewPage extends React.Component {
                 />
                 <Reminder>
                   <Trans>
-                    Sending this request will cancel your existing appointment.
+                    Sending this request will cancel your current appointment.
                     <strong> Do not attend your old appointment</strong> after
                     you send this request.
                   </Trans>

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -71,8 +71,9 @@ class ReviewPage extends React.Component {
                 />
                 <Reminder>
                   <Trans>
-                    By sending this request, you are{' '}
-                    <strong>cancelling your current appointment.</strong>
+                    Sending this request will cancel your existing appointment.
+                    <strong> Do not attend your old appointment</strong> after
+                    you send this request.
                   </Trans>
                 </Reminder>
 

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -9,7 +9,7 @@ describe('Server Side Rendering', () => {
   it('renders the landing page at /', async () => {
     let response = await request(server).get('/')
     expect(response.text).toMatch(
-      /It can take up to six weeks to schedule your new appointment./,
+      /It can take up to 9 weeks for us to reschedule you./,
     )
   })
 


### PR DESCRIPTION
This PR updates copy in the error message block on the form page. 

![image](https://user-images.githubusercontent.com/546495/41723925-5c24ac48-753a-11e8-81c0-ac0da1b92ecc.png)


This PR updates the language around rescheduling and the impact on current appointments:

![image](https://user-images.githubusercontent.com/546495/41727146-adbda8a0-7541-11e8-84ce-7ea365a9c6f7.png)
![image](https://user-images.githubusercontent.com/546495/41727159-b3858910-7541-11e8-9f7b-20d158abd5e5.png)
