### PR TITLE
add email field to reg form

### DIFF
--- a/api/src/types/RescheduleForm.js
+++ b/api/src/types/RescheduleForm.js
@@ -5,7 +5,6 @@ const {
   GraphQLList,
 } = require('graphql')
 const { GraphQLDate } = require('graphql-iso-date')
-const { GraphQLEmail } = require('graphql-custom-types')
 
 module.exports.default = t => {
   const RescheduleFormInput = new GraphQLInputObjectType({
@@ -18,7 +17,7 @@ module.exports.default = t => {
       },
       email: {
         description: t('types.rescheduleForm.fields.email'),
-        type: new GraphQLNonNull(GraphQLEmail),
+        type: new GraphQLNonNull(GraphQLString),
       },
       explanation: {
         description: t('types.rescheduleForm.fields.explanation'),

--- a/web/src/components/LinkStateDisplay.js
+++ b/web/src/components/LinkStateDisplay.js
@@ -10,6 +10,7 @@ const QUERY = gql`
       paperFileNumber
       reason
       explanation
+      email
     }
     selectedDays @client
   }

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -110,6 +110,7 @@ SummaryRow.propTypes = {
 
 const Summary = ({
   fullName,
+  email,
   paperFileNumber,
   reason,
   explanation,
@@ -119,6 +120,11 @@ const Summary = ({
     <SummaryRow
       summaryHeader={<Trans>Full name</Trans>}
       summaryBody={fullName}
+      summaryLink={'/register'}
+    />
+    <SummaryRow
+      summaryHeader={<Trans>Email</Trans>}
+      summaryBody={email}
       summaryLink={'/register'}
     />
     <SummaryRow
@@ -146,6 +152,7 @@ const Summary = ({
 
 Summary.propTypes = {
   fullName: PropTypes.string,
+  email: PropTypes.string,
   reason: PropTypes.object,
   explanation: PropTypes.string,
   paperFileNumber: PropTypes.string,

--- a/web/src/components/__tests__/Summary.test.js
+++ b/web/src/components/__tests__/Summary.test.js
@@ -12,6 +12,7 @@ const selectedDays = [
 
 const defaultProps = {
   fullName: 'Test1',
+  email: 'test@test.com',
   paperFileNumber: '12346789',
   explanation: 'feeling lazy',
   reason: <Trans>Travel</Trans>,
@@ -59,14 +60,15 @@ describe('<Summary />', () => {
     const wrapper = shallow(<Summary {...defaultProps} />)
     const numOfSummaryRows = wrapper.children()
 
-    expect(numOfSummaryRows.length).toBe(5)
+    expect(numOfSummaryRows.length).toBe(6)
     expect(numOfSummaryRows.at(0).prop('summaryBody')).toEqual('Test1')
-    expect(numOfSummaryRows.at(1).prop('summaryBody')).toEqual('12346789')
-    expect(numOfSummaryRows.at(2).prop('summaryBody').props.id).toEqual(
+    expect(numOfSummaryRows.at(1).prop('summaryBody')).toEqual('test@test.com')
+    expect(numOfSummaryRows.at(2).prop('summaryBody')).toEqual('12346789')
+    expect(numOfSummaryRows.at(3).prop('summaryBody').props.id).toEqual(
       'Travel',
     )
-    expect(numOfSummaryRows.at(3).prop('summaryBody')).toEqual('feeling lazy')
-    expect(numOfSummaryRows.at(4).prop('summaryBody')).toMatchObject(
+    expect(numOfSummaryRows.at(4).prop('summaryBody')).toEqual('feeling lazy')
+    expect(numOfSummaryRows.at(5).prop('summaryBody')).toMatchObject(
       <SelectedDayList selectedDays={selectedDays} />,
     )
   })

--- a/web/src/pages/ConfirmationPage.js
+++ b/web/src/pages/ConfirmationPage.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import { H1, H2, visuallyhidden } from '../styles'
+import { H1, H2, visuallyhidden, theme } from '../styles'
 import { css } from 'react-emotion'
 import { Trans } from 'lingui-react'
 import Layout from '../components/Layout'
 import Contact from '../components/Contact'
-import { theme } from '../styles'
 
 const contentClass = css`
   p {

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types'
 import { Trans } from 'lingui-react'
 import { NavLink } from 'react-router-dom'
 import { css } from 'react-emotion'
-import { theme, visuallyhidden, mediaQuery, BottomContainer, focusRing } from '../styles'
+import {
+  theme,
+  visuallyhidden,
+  mediaQuery,
+  BottomContainer,
+  focusRing,
+} from '../styles'
 import Layout from '../components/Layout'
 import {
   TextFieldAdapter,
@@ -76,9 +82,18 @@ const labelNames = id => {
       return <Trans>Why are you rescheduling?</Trans>
     case 'explanation':
       return <Trans>Describe why you can’t attend your test</Trans>
+    case 'email':
+      return <Trans>Email</Trans>
     default:
       return ''
   }
+}
+
+function validateEmail(email) {
+  /*eslint-disable */
+  var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  return re.test(String(email).toLowerCase())
+  /*eslint-enable */
 }
 
 const validate = values => {
@@ -114,6 +129,16 @@ const validate = values => {
       </Trans>
     )
   }
+
+  if (!validateEmail(values.email)) {
+    errors.email = (
+      <Trans>
+        You need to provide an email address so we can send you a confirmation
+        message.
+      </Trans>
+    )
+  }
+
   return errors
 }
 
@@ -152,11 +177,7 @@ class RegistrationPage extends React.Component {
     if (Object.keys(submitErrors).length) {
       this.errorContainer.focus()
       return {
-        [FORM_ERROR]: (
-          <Trans>
-            Some information is missing.
-          </Trans>
-        ),
+        [FORM_ERROR]: <Trans>Some information is missing.</Trans>,
       }
     }
 
@@ -230,6 +251,29 @@ class RegistrationPage extends React.Component {
                       <Trans>
                         This is the full name you used on your citizenship
                         application.
+                      </Trans>
+                    </span>
+                  </label>
+                </Field>
+              </div>
+              <div>
+                <Field component={TextFieldAdapter} name="email" id="email">
+                  <label htmlFor="email" id="email-label">
+                    <span id="email-header">
+                      <Trans>Email address</Trans>
+                    </span>
+                    <ValidationMessage
+                      id="email-error"
+                      message={
+                        submitError && validate(values).email
+                          ? validate(values).email
+                          : ''
+                      }
+                    />
+                    <span id="email-details">
+                      <Trans>
+                        We will send a confirmation message to this email
+                        address.
                       </Trans>
                     </span>
                   </label>

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -54,6 +54,7 @@ class ReviewPage extends React.Component {
             let {
               userRegistrationData: {
                 fullName,
+                email,
                 paperFileNumber,
                 explanation,
                 reason,
@@ -65,6 +66,7 @@ class ReviewPage extends React.Component {
               <section>
                 <Summary
                   fullName={fullName}
+                  email={email}
                   paperFileNumber={paperFileNumber}
                   explanation={explanation}
                   reason={this.translateReason(reason)}
@@ -90,6 +92,7 @@ class ReviewPage extends React.Component {
                           submit({
                             variables: {
                               fullName,
+                              email,
                               reason,
                               explanation,
                               paperFileNumber,

--- a/web/src/queries.js
+++ b/web/src/queries.js
@@ -14,6 +14,7 @@ export const GET_USER_DATA = gql`
   query getUserData {
     userRegistrationData @client {
       fullName
+      email
       paperFileNumber
       reason
       explanation
@@ -25,6 +26,7 @@ export const GET_USER_DATA = gql`
 export const SUBMIT = gql`
   mutation submit(
     $fullName: String!
+    $email: String!
     $explanation: String!
     $reason: String!
     $paperFileNumber: String!
@@ -33,6 +35,7 @@ export const SUBMIT = gql`
     decline(
       input: {
         fullName: $fullName
+        email: $email
         explanation: $explanation
         reason: $reason
         paperFileNumber: $paperFileNumber

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -12,6 +12,7 @@ const cache = new InMemoryCache()
 const typeDefs = `
   type UserData {
     fullName: String
+    email: String
     paperFileNumber: String
     reason: String
     explanation: String
@@ -52,17 +53,19 @@ const stateLink = withClientState({
           {
             userRegistrationData @client {
               fullName
+              email
               paperFileNumber
               reason
               explanation
             }
           }
         `
-        const { fullName, reason, paperFileNumber, explanation } = args.data
+        const { fullName,email, reason, paperFileNumber, explanation } = args.data
         const data = {
           userRegistrationData: {
             __typename: 'UserData',
             fullName,
+            email,
             paperFileNumber,
             reason,
             explanation,
@@ -90,6 +93,7 @@ const stateLink = withClientState({
     userRegistrationData: {
       __typename: 'UserData',
       fullName: '',
+      email: '',
       paperFileNumber: '',
       reason: '',
       explanation: '',


### PR DESCRIPTION
Added an email field to the Registration form. 

Now all emails sent by our app will include the user's inputted email as well as the rest of it (ie, dates, name, reason, etc.).

This story does _not_ yet send an email to the user's provided email. That will be done in an upcoming pull request.