### PR TITLE
Tiny config change for the API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,7 +12,7 @@ if (!process.env.IRCC_RECEIVING_ADDRESS)
   throw new Error('IRCC_RECEIVING_ADDRESS was not found in the environment')
 if (!process.env.SENDING_ADDRESS)
   throw new Error('SENDING_ADDRESS was not found in the environment')
-if (!process.env.SITE_URL)
+if (typeof process.env.SITE_URL === 'undefined')
   throw new Error('SITE_URL was not found in the environment')
 
 AWS.config.update({ region: process.env.AWS_REGION })
@@ -21,7 +21,7 @@ const server = Server({
   mailer: new AWS.SES({ apiVersion: '2010-12-01' }),
   receivingAddress: process.env.IRCC_RECEIVING_ADDRESS,
   sendingAddress: process.env.SENDING_ADDRESS,
-  siteUrl: process.env.SITE_URL,
+  siteUrl: process.env.SITE_URL || ' ',
 })
 
 server.listen(3001)


### PR DESCRIPTION
Our inline-css package wants a URL from us so that it can give us good links to stuff once we render everything to text.

But if we don't need to worry about this (ie, currently we don't have any links in our emails so no problemo), then their advice is to pass in an empty string.

BUT! Passing in an empty string would fail our falsey check in `api/index.js` so now it doesn't.

🎈 🎉 🎈 

Docs:
https://github.com/jonkemp/inline-css#optionsurl