### PR TITLE
Throw to error page from node

### DIFF
--- a/web/src/server.js
+++ b/web/src/server.js
@@ -41,7 +41,8 @@ server
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error.message, error.stack)
-      res.json({ error: error.message })
+      res.redirect('/error');
+      //res.json({ error: error.message })
     }
   })
 


### PR DESCRIPTION
When trying to test an error that would catch with React Error Boundary I found that the page error was getting caught via Node / server.

 ```
res.json({ error: error.message })
```

Outputting the error json to the page in production mode.

This update sets the server to redirect to the standard error page.