### PR TITLE
Content changes to the Error page

### DIFF
--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -36,19 +36,33 @@ const contact = css`
   margin-bottom: ${theme.spacing.lg};
 `
 
-const Contact = ({ children }) => (
+const Contact = ({ children, phoneFirst = false }) => (
   <div className={contact}>
     {children}
-    <p>
-      <a href="mailto:vancouverIRCC@cic.gc.ca">vancouverIRCC@cic.gc.ca</a>
-    </p>
-    <p>
-      <TelLink tel="1-888-242-2100" />
-    </p>
+    {!phoneFirst ? (
+      <React.Fragment>
+        <p>
+          <a href="mailto:vancouverIRCC@cic.gc.ca">vancouverIRCC@cic.gc.ca</a>
+        </p>
+        <p>
+          <TelLink tel="1-888-242-2100" />
+        </p>
+      </React.Fragment>
+    ) : (
+      <React.Fragment>
+        <p>
+          <TelLink tel="1-888-242-2100" />
+        </p>
+        <p>
+          <a href="mailto:vancouverIRCC@cic.gc.ca">vancouverIRCC@cic.gc.ca</a>
+        </p>
+      </React.Fragment>
+    )}
   </div>
 )
 Contact.propTypes = {
   children: PropTypes.element.isRequired,
+  phoneFirst: PropTypes.bool,
 }
 
 export { Contact as default, TelLink }

--- a/web/src/components/__tests__/Contact.test.js
+++ b/web/src/components/__tests__/Contact.test.js
@@ -16,7 +16,7 @@ describe('<TelLink />', () => {
 })
 
 describe('<Contact />', () => {
-  it('renders itself and child', () => {
+  it('renders with children', () => {
     const wrapper = shallow(
       <Contact>
         <h1>Get in touch ✉️</h1>
@@ -28,6 +28,14 @@ describe('<Contact />', () => {
 
     const h1 = wrapper.find('h1')
     expect(h1.text()).toEqual('Get in touch ✉️')
+  })
+
+  it('renders with the email first and the telephone number second', () => {
+    const wrapper = shallow(
+      <Contact>
+        <h1>Get in touch ✉️</h1>
+      </Contact>,
+    )
 
     expect(
       wrapper
@@ -42,5 +50,27 @@ describe('<Contact />', () => {
         .at(1)
         .text(),
     ).toEqual('<TelLink />')
+  })
+
+  it('renders with the email first and the telephone number second', () => {
+    const wrapper = shallow(
+      <Contact phoneFirst={true}>
+        <h1>Get in touch ✉️</h1>
+      </Contact>,
+    )
+
+    expect(
+      wrapper
+        .find('p')
+        .at(0)
+        .text(),
+    ).toEqual('<TelLink />')
+
+    expect(
+      wrapper
+        .find('p')
+        .at(1)
+        .text(),
+    ).toEqual('vancouverIRCC@cic.gc.ca')
   })
 })

--- a/web/src/pages/ErrorPage.js
+++ b/web/src/pages/ErrorPage.js
@@ -32,7 +32,7 @@ export class ErrorPageContent extends React.Component {
           </Trans>
         </p>
 
-        <Contact>
+        <Contact phoneFirst={true}>
           <div>
             <p>
               <Trans>

--- a/web/src/pages/ErrorPage.js
+++ b/web/src/pages/ErrorPage.js
@@ -9,6 +9,8 @@ import styled, { css } from 'react-emotion'
 
 const ErrorH1 = styled(H1)`
   margin-bottom: ${theme.spacing.sm};
+  margin-top: ${theme.spacing.sm};
+  font-weight: normal;
 `
 
 const contentClass = css`
@@ -21,43 +23,46 @@ export class ErrorPageContent extends React.Component {
     return (
       <React.Fragment>
         <ErrorH1>
-          <Trans>We&apos;re sorry, something went wrong.</Trans>
+          <Trans>Sorry, something went wrong.</Trans>
         </ErrorH1>
+        <p>
+          <Trans>
+            Your request <strong>was not completed</strong>. Your appointment or
+            application wasn&rsquo;t changed in any way.
+          </Trans>
+        </p>
+
         <Contact>
           <div>
             <p>
               <Trans>
-                Our team has been notified, but click{' '}
-                <a
-                  tabIndex="0"
-                  href="#bug-report"
-                  onClick={e => {
-                    e.preventDefault()
-                    window &&
-                      window.Raven.lastEventId() &&
-                      window.Raven.showReportDialog()
-                  }}
-                  aria-label={<Trans>Report a bug</Trans>}
-                >
-                  here
-                </a>{' '}
-                to fill out an error report.
-              </Trans>
-            </p>
-            <p>
-              <Trans>
-                Please contact{' '}
+                Contact{' '}
                 <abbr title="Immigration, Refugees and Citizenship Canada">
                   IRCC
                 </abbr>{' '}
-                directly to reschedule your appointment
+                directly to reschedule your appointment:
               </Trans>
             </p>
           </div>
         </Contact>
-        <NavLink className="chevron-link" to="/">
-          <Chevron dir="left" /> <Trans>Home</Trans>
-        </NavLink>
+        <p>
+          <Trans>
+            Our team has been notified of this error, but you can also{' '}
+            <a
+              tabIndex="0"
+              href="#bug-report"
+              onClick={e => {
+                e.preventDefault()
+                window &&
+                  window.Raven.lastEventId() &&
+                  window.Raven.showReportDialog()
+              }}
+              aria-label={<Trans>Tell us what went wrong</Trans>}
+            >
+              tell us what went wrong
+            </a>.
+          </Trans>
+        </p>
       </React.Fragment>
     )
   }
@@ -67,6 +72,9 @@ class ErrorPage extends React.Component {
   render() {
     return (
       <Layout contentClass={contentClass} headerClass={visuallyhidden}>
+        <NavLink className="chevron-link" to="/">
+          <Chevron dir="left" /> <Trans>Home</Trans>
+        </NavLink>
         <ErrorPageContent />
       </Layout>
     )

--- a/web/src/pages/__tests__/ErrorPage.test.js
+++ b/web/src/pages/__tests__/ErrorPage.test.js
@@ -8,7 +8,7 @@ describe('<ErrorPageContent />', () => {
     const wrapper = shallow(<ErrorPageContent />)
     // have to use mount so that we don't get <withI18N />
     const header = mount(wrapper.props().children[0])
-    expect(header.text()).toEqual("We're sorry, something went wrong.")
+    expect(header.text()).toEqual('Sorry, something went wrong.')
   })
 })
 


### PR DESCRIPTION
This PR address content changes to the error page. Do not merge until team has reviewed and changes are final (by end of day Tuesday).

Content and ordering is relevant, visual design and spacing **will be changed** with coming global typography updates.

**Before:**

![image](https://user-images.githubusercontent.com/546495/41864575-79f1f9ce-7878-11e8-850a-e5e7ae91223e.png)

**After:**
![image](https://user-images.githubusercontent.com/546495/41864750-fa98c59e-7878-11e8-989a-abacc6104166.png)
