### PR TITLE
Go-live date change 📅

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -524,17 +524,17 @@ class Calendar extends Component {
           months={date.months}
           weekdaysLong={date.weekdaysLong}
           weekdaysShort={date.weekdaysShort}
-          initialMonth={new Date(2018, 6)}
-          fromMonth={new Date(2018, 6)}
+          initialMonth={new Date(2018, 7)}
+          fromMonth={new Date(2018, 7)}
           toMonth={new Date(2018, 8)}
           numberOfMonths={1}
           disabledDays={[
             {
-              before: new Date(2018, 6, 14),
-              after: new Date(2018, 8, 14),
+              before: new Date(2018, 7, 1),
+              after: new Date(2018, 8, 20),
             },
             {
-              daysOfWeek: [0, 1, 3, 4, 6],
+              daysOfWeek: [0, 1, 2, 5, 6],
             },
           ]}
           onDayClick={this.handleDayClick}

--- a/web/src/components/Time.js
+++ b/web/src/components/Time.js
@@ -14,9 +14,9 @@ const makeGMTDate = date => {
 
 const dateToHTMLString = (date, locale) => {
   var options = {
-    weekday: 'short',
+    weekday: 'long',
     year: 'numeric',
-    month: 'short',
+    month: 'long',
     day: 'numeric',
   }
   return makeGMTDate(date).toLocaleDateString(locale, options)

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -35,21 +35,13 @@ const defaultProps = ({ value = '', dayLimit = 3 } = {}) => {
 }
 
 describe('<CalendarAdapter />', () => {
-  it('renders July 2018', () => {
-    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-    expect(wrapper.text()).toMatch(/July 2018/)
-  })
-
   it('renders August 2018', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-    wrapper.find('.DayPicker-NavButton--next').simulate('click')
     expect(wrapper.text()).toMatch(/August 2018/)
-    expect(wrapper.text()).not.toMatch(/July 2018/)
   })
 
   it('renders September 2018', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-    wrapper.find('.DayPicker-NavButton--next').simulate('click')
     wrapper.find('.DayPicker-NavButton--next').simulate('click')
     expect(wrapper.text()).toMatch(/September 2018/)
     expect(wrapper.text()).not.toMatch(/August 2018/)
@@ -58,11 +50,11 @@ describe('<CalendarAdapter />', () => {
   it('will prefill a date if an initial value is provided', () => {
     const wrapper = mount(
       <CalendarAdapter
-        {...defaultProps({ value: [new Date('2018-07-17T12:00:00.000')] })}
+        {...defaultProps({ value: [new Date('2018-08-01T12:00:00.000')] })}
       />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
   })
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
@@ -70,14 +62,14 @@ describe('<CalendarAdapter />', () => {
       <CalendarAdapter
         {...defaultProps({
           value: [
-            new Date('2018-07-17T12:00:00.000'),
-            new Date('2018-07-20T12:00:00.000'),
+            new Date('2018-08-01T12:00:00.000'),
+            new Date('2018-08-02T12:00:00.000'),
           ],
         })}
       />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018 Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018 Thu, Aug 2, 2018')
   })
 
   it('selects a date when it is clicked', () => {
@@ -86,7 +78,7 @@ describe('<CalendarAdapter />', () => {
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
   })
 
   it('orders selected dates chronologically', () => {
@@ -95,17 +87,17 @@ describe('<CalendarAdapter />', () => {
 
     // click July 24th, 2018
     clickDate(wrapper, 2)
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 24, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 8, 2018')
 
     // click July 20th, 2018
     clickDate(wrapper, 1)
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018 Tue, Jul 24, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018 Wed, Aug 8, 2018')
 
     // click July 17th, 2018
     clickDate(wrapper, 0)
 
     expect(getDateStrings(wrapper)).toEqual(
-      'Tue, Jul 17, 2018 Fri, Jul 20, 2018 Tue, Jul 24, 2018',
+      'Wed, Aug 1, 2018 Thu, Aug 2, 2018 Wed, Aug 8, 2018',
     )
   })
 
@@ -124,16 +116,16 @@ describe('<CalendarAdapter />', () => {
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [new Date('2018-07-20T12:00:00.000')],
+          value: [new Date('2018-08-02T12:00:00.000')],
           dayLimit: 1,
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
     expect(getErrorMessageString(wrapper)).toEqual(
       'You have already selected the maximum number of dates!',
     )
@@ -143,14 +135,14 @@ describe('<CalendarAdapter />', () => {
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [new Date('2018-07-20T12:00:00.000')],
+          value: [new Date('2018-08-02T12:00:00.000')],
           dayLimit: 1,
         })}
       />,
     )
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
     expect(getErrorMessageString(wrapper)).toEqual(
       'You have already selected the maximum number of dates!',
     )
@@ -168,12 +160,12 @@ describe('<CalendarAdapter />', () => {
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [new Date('2018-07-20T12:00:00.000')],
+          value: [new Date('2018-08-02T12:00:00.000')],
           dayLimit: 1,
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
 
     // click July 20th, 2018
     clickDate(wrapper, 1)
@@ -181,7 +173,7 @@ describe('<CalendarAdapter />', () => {
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
   })
 
   it('will keep pre-filled dates when clicking new ones', () => {
@@ -189,18 +181,18 @@ describe('<CalendarAdapter />', () => {
       <CalendarAdapter
         {...defaultProps({
           value: [
-            new Date('2018-07-20T12:00:00.000'),
-            new Date('2018-07-24T12:00:00.000'),
+            new Date('2018-08-02T12:00:00.000'),
+            new Date('2018-08-08T12:00:00.000'),
           ],
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018 Tue, Jul 24, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018 Wed, Aug 8, 2018')
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
     expect(getDateStrings(wrapper)).toEqual(
-      'Tue, Jul 17, 2018 Fri, Jul 20, 2018 Tue, Jul 24, 2018',
+      'Wed, Aug 1, 2018 Thu, Aug 2, 2018 Wed, Aug 8, 2018',
     )
   })
 
@@ -209,17 +201,17 @@ describe('<CalendarAdapter />', () => {
       <CalendarAdapter
         {...defaultProps({
           value: [
-            new Date('2018-07-17T12:00:00.000'),
-            new Date('2018-07-20T12:00:00.000'),
+            new Date('2018-08-01T12:00:00.000'),
+            new Date('2018-08-02T12:00:00.000'),
           ],
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018 Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018 Thu, Aug 2, 2018')
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Fri, Jul 20, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
   })
 
   const events = [
@@ -242,7 +234,7 @@ describe('<CalendarAdapter />', () => {
       expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
       clickFirstDate(wrapper)
-      expect(getDateStrings(wrapper)).toEqual('Tue, Jul 17, 2018')
+      expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
 
       wrapper
         .find('#selectedDays button')

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -54,7 +54,7 @@ describe('<CalendarAdapter />', () => {
       />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 1, 2018')
   })
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
@@ -69,7 +69,9 @@ describe('<CalendarAdapter />', () => {
       />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018 Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual(
+      'Wednesday, August 1, 2018 Thursday, August 2, 2018',
+    )
   })
 
   it('selects a date when it is clicked', () => {
@@ -78,7 +80,7 @@ describe('<CalendarAdapter />', () => {
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 1, 2018')
   })
 
   it('orders selected dates chronologically', () => {
@@ -87,17 +89,19 @@ describe('<CalendarAdapter />', () => {
 
     // click July 24th, 2018
     clickDate(wrapper, 2)
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 8, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 8, 2018')
 
     // click July 20th, 2018
     clickDate(wrapper, 1)
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018 Wed, Aug 8, 2018')
+    expect(getDateStrings(wrapper)).toEqual(
+      'Thursday, August 2, 2018 Wednesday, August 8, 2018',
+    )
 
     // click July 17th, 2018
     clickDate(wrapper, 0)
 
     expect(getDateStrings(wrapper)).toEqual(
-      'Wed, Aug 1, 2018 Thu, Aug 2, 2018 Wed, Aug 8, 2018',
+      'Wednesday, August 1, 2018 Thursday, August 2, 2018 Wednesday, August 8, 2018',
     )
   })
 
@@ -121,11 +125,11 @@ describe('<CalendarAdapter />', () => {
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
     expect(getErrorMessageString(wrapper)).toEqual(
       'You have already selected the maximum number of dates!',
     )
@@ -142,7 +146,7 @@ describe('<CalendarAdapter />', () => {
     )
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
     expect(getErrorMessageString(wrapper)).toEqual(
       'You have already selected the maximum number of dates!',
     )
@@ -165,7 +169,7 @@ describe('<CalendarAdapter />', () => {
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
 
     // click July 20th, 2018
     clickDate(wrapper, 1)
@@ -173,7 +177,7 @@ describe('<CalendarAdapter />', () => {
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 1, 2018')
   })
 
   it('will keep pre-filled dates when clicking new ones', () => {
@@ -187,12 +191,14 @@ describe('<CalendarAdapter />', () => {
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018 Wed, Aug 8, 2018')
+    expect(getDateStrings(wrapper)).toEqual(
+      'Thursday, August 2, 2018 Wednesday, August 8, 2018',
+    )
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
     expect(getDateStrings(wrapper)).toEqual(
-      'Wed, Aug 1, 2018 Thu, Aug 2, 2018 Wed, Aug 8, 2018',
+      'Wednesday, August 1, 2018 Thursday, August 2, 2018 Wednesday, August 8, 2018',
     )
   })
 
@@ -207,11 +213,13 @@ describe('<CalendarAdapter />', () => {
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018 Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual(
+      'Wednesday, August 1, 2018 Thursday, August 2, 2018',
+    )
 
     // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Thu, Aug 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
   })
 
   const events = [
@@ -234,7 +242,7 @@ describe('<CalendarAdapter />', () => {
       expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
       clickFirstDate(wrapper)
-      expect(getDateStrings(wrapper)).toEqual('Wed, Aug 1, 2018')
+      expect(getDateStrings(wrapper)).toEqual('Wednesday, August 1, 2018')
 
       wrapper
         .find('#selectedDays button')

--- a/web/src/components/__tests__/Time.test.js
+++ b/web/src/components/__tests__/Time.test.js
@@ -7,20 +7,20 @@ describe('<Time />', () => {
   let date = new Date(dateString)
 
   it('renders a <time> element', () => {
-    const time = shallow(<Time date={date} locale={'en'}/>)
+    const time = shallow(<Time date={date} locale={'en'} />)
     expect(time.find('time').length).toEqual(1)
   })
 
   it('renders correctly from a Date object in french format', () => {
-    const time = shallow(<Time date={date} locale={'fr'}/>)
+    const time = shallow(<Time date={date} locale={'fr'} />)
     expect(time.props().dateTime).toEqual('1870-04-22')
-    expect(time.text()).toEqual('ven. 22 avr. 1870')
+    expect(time.text()).toEqual('vendredi 22 avril 1870')
   })
 
   it('renders correctly from a date string', () => {
-    const time = shallow(<Time date={dateString} locale={'en'}/>)
+    const time = shallow(<Time date={dateString} locale={'en'} />)
     expect(time.props().dateTime).toEqual('1870-04-22')
-    expect(time.text()).toEqual('Fri, Apr 22, 1870')
+    expect(time.text()).toEqual('Friday, April 22, 1870')
   })
 })
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -61,10 +61,27 @@ class CalendarPage extends Component {
 
   static validate(values) {
     const errors = {}
-    if (!values.calendar || values.calendar.length < DAY_LIMIT) {
-      errors.calendar = (
-        <Trans>You have already selected the maximum number of dates!</Trans>
-      )
+    if (!values.calendar || !values.calendar.length) {
+      errors.calendar = <Trans>You must select 3 days.</Trans>
+    } else if (values.calendar.length < DAY_LIMIT) {
+      switch (values.calendar.length) {
+        case 1:
+          errors.calendar = (
+            <Trans>
+              You must select 3 days. Please select 2 more days to continue.
+            </Trans>
+          )
+          break
+        case 2:
+          errors.calendar = (
+            <Trans>
+              You must select 3 days. Please select 1 more day to continue.
+            </Trans>
+          )
+          break
+        default:
+          errors.calendar = <Trans>You must select 3 days.</Trans>
+      }
     }
     return errors
   }
@@ -81,11 +98,7 @@ class CalendarPage extends Component {
     if (Object.keys(submitErrors).length) {
       this.errorContainer.focus()
       return {
-        [FORM_ERROR]: (
-          <Trans>
-            Sorry, there was a problem with the information you submitted.
-          </Trans>
-        ),
+        [FORM_ERROR]: submitErrors.calendar,
       }
     }
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -110,7 +110,7 @@ class CalendarPage extends Component {
           <nav>
             <NavLink className="chevron-link" to="/register">
               <Chevron dir="left" />
-              <Trans>Go Back</Trans>
+              <Trans>Go back</Trans>
             </NavLink>
           </nav>
         </TopContainer>

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -117,13 +117,13 @@ class CalendarPage extends Component {
 
         <CalendarHeader>
           <Trans>
-            Citizenship appointments are scheduled on <strong>Tuesdays</strong>{' '}
-            and <strong>Fridays</strong>.
+            Citizenship appointments are scheduled on{' '}
+            <strong>Wednesdays</strong> and <strong>Fridays</strong>.
           </Trans>
         </CalendarHeader>
         <CalendarSubheader>
           <Trans>
-            <strong>Select 3 days</strong> you’re available between July and
+            <strong>Select 3 days</strong> you’re available between August and
             September:
           </Trans>
         </CalendarSubheader>

--- a/web/src/pages/CancelPage.js
+++ b/web/src/pages/CancelPage.js
@@ -31,7 +31,7 @@ class CancelPage extends React.Component {
       <Layout contentClass={contentClass} headerClass={visuallyhidden}>
         <NavLink className="chevron-link nav-link-top" to="/">
           <Chevron dir="left" />
-          <Trans>Start Over</Trans>
+          <Trans>Start over</Trans>
         </NavLink>
         <H1>
           <Trans>Your request has been cancelled.</Trans>

--- a/web/src/pages/ConfirmationPage.js
+++ b/web/src/pages/ConfirmationPage.js
@@ -33,7 +33,7 @@ class ConfirmationPage extends React.Component {
           </H2>
           <p>
             <Trans>
-              By July 6, 2018, your local{' '}
+              By September 6, 2018, your local{' '}
               <abbr title="Immigration, Refugees and Citizenship Canada">
                 IRCC
               </abbr>{' '}

--- a/web/src/pages/NoJSCalendarPage.js
+++ b/web/src/pages/NoJSCalendarPage.js
@@ -63,7 +63,7 @@ class NoJSCalendarPage extends React.Component {
         <TopContainer>
           <nav>
             <NavLink to="/register">
-              &#10094; <Trans>Go Back</Trans>
+              &#10094; <Trans>Go back</Trans>
             </NavLink>
           </nav>
         </TopContainer>

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -63,7 +63,7 @@ class ReviewPage extends React.Component {
         <TopContainer>
           <NavLink className="chevron-link" to="/calendar">
             <Chevron dir="left" />
-            <Trans>Go Back</Trans>
+            <Trans>Go back</Trans>
           </NavLink>
         </TopContainer>
         <H1>


### PR DESCRIPTION
This PR:

- changes the date range to August 1st - September 20th (ie 4 weeks from July 4th, and then 8 weeks of Wednesdays and Thursdays)
- Updates our date format to display longer months and days
  - `Thu, Sep 6, 2018` -> `Thursday, September 6, 2018`
  - `jeu. 6 sept. 2018` -> `jeudi 6 septembre 2018`
- updates page copy where we refer to dates
- updates our "Go Back" links to say "Go back"
- updates our hardcoded tests

| before | after |
|--------|-------|
|    ![calendar-1](https://user-images.githubusercontent.com/2454380/41935246-f8fa3afe-7956-11e8-90c0-a5803350ea6a.gif)    |  ![calendar-2](https://user-images.githubusercontent.com/2454380/41935242-f67f5e30-7956-11e8-9b3c-a1a4d4316782.gif)     |




