### PR TITLE
Add image to list of shared files

### DIFF
--- a/shipitfile.js
+++ b/shipitfile.js
@@ -11,7 +11,11 @@ module.exports = shipit => {
       repositoryUrl: 'https://github.com/cds-snc/ircc-rescheduler.git',
       shared: {
         overwrite: true,
-        files: ['api/.env', 'web/.env.production'],
+        files: [
+          'api/.env',
+          'api/src/email_templates/CanWordmark.png',
+          'web/.env.production',
+        ],
       },
     },
     dev: {


### PR DESCRIPTION
Our email isn't sending properly because we have a linked file in our repo which it can't find once it's deployed.