### PR TITLE
Consolidate cookie validation logic + add `language` to store

### DIFF
--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -1,0 +1,212 @@
+import withProvider from '../withProvider'
+
+class FakeComponentEmpty {
+  constructor() {}
+}
+
+describe('WithProvider', () => {
+  describe('.globalFields and .validate()', () => {
+    const WithProvider = withProvider(FakeComponentEmpty)
+
+    it('has only "language" as a global field', () => {
+      expect(WithProvider.globalFields).toEqual(['language'])
+    })
+
+    it('returns no errors for "en" or "fr" in its validation method', () => {
+      let errors
+      errors = WithProvider.validate({ language: 'en' })
+      expect(errors).toBe(false)
+
+      errors = WithProvider.validate({ language: 'fr' })
+      expect(errors).toBe(false)
+    })
+
+    it('returns errors for some other value in its validation method', () => {
+      let errors
+      errors = WithProvider.validate({ language: 'portuguese' })
+      expect(errors).toEqual({ language: true })
+    })
+  })
+
+  describe('.returnKeyAndValue()', () => {
+    const WithProvider = withProvider(FakeComponentEmpty)
+    let match = { path: '/about' }
+
+    it('undefined key and val when no query passed in', () => {
+      let { key, val } = WithProvider.returnKeyAndValue({}, match)
+      expect(key).toBe(undefined)
+      expect(val).toBe(undefined)
+    })
+
+    it('"language" key and "en" val when global field passed in', () => {
+      let { key, val } = WithProvider.returnKeyAndValue(
+        { language: 'en' },
+        match,
+      )
+      expect(key).toBe('language')
+      expect(val).toBe('en')
+    })
+
+    it('"language" key and "portuguese" val when global field passed in', () => {
+      // ie, it's not running the validateCookie function
+      let { key, val } = WithProvider.returnKeyAndValue(
+        { language: 'portuguese' },
+        match,
+      )
+      expect(key).toBe('language')
+      expect(val).toBe('portuguese')
+    })
+
+    it('"language" key and "en" val when global field passed in as well as other keys', () => {
+      // other fields will be ignored
+      let { key, val } = WithProvider.returnKeyAndValue(
+        { language: 'en', field: 'value' },
+        match,
+      )
+      expect(key).toBe('language')
+      expect(val).toBe('en')
+    })
+
+    it('path key and query value when no global key exists ', () => {
+      // other fields will be ignored
+      let { key, val } = WithProvider.returnKeyAndValue(
+        { field: 'value' },
+        match,
+      )
+      expect(key).toBe('about')
+      expect(val).toEqual({ field: 'value' })
+    })
+  })
+
+  describe('.validateCookie() with global field', () => {
+    const WithProvider = withProvider(FakeComponentEmpty)
+
+    // static validateCookie(key, val = null, fields = [], validate = null)
+    it('returns correct language for "en"', () => {
+      let result = WithProvider.validateCookie('language', 'en')
+      expect(result).toEqual('en')
+    })
+
+    it('returns correct language for "fr"', () => {
+      let result = WithProvider.validateCookie('language', 'fr')
+      expect(result).toEqual('fr')
+    })
+
+    it('returns false for different language', () => {
+      let result = WithProvider.validateCookie('language', 'portuguese')
+      expect(result).toBe(false)
+    })
+
+    let invalidVals = [0, false, { language: 'en' }, ['en'], null, '']
+    invalidVals.map(v => {
+      it(`throws error for global field with a non-empty string value: ${v}`, () => {
+        expect(() => {
+          WithProvider.validateCookie('language', v)
+        }).toThrowError(/^validate: `val` must be a non-empty string$/)
+      })
+    })
+  })
+
+  describe('.validateCookie() with regular field', () => {
+    describe('WrappedComponent without `fields` and `validate`', () => {
+      class FakeComponentWithFields {
+        static get fields() {
+          return ['field']
+        }
+      }
+
+      class FakeComponentWithValidate {
+        static validate(values) {
+          let errors = {}
+          if (!values.field !== 'value') {
+            errors.field = true
+          }
+          return Object.keys(errors).length ? errors : false
+        }
+        constructor() {}
+      }
+
+      const EmptyWithProvider = withProvider(FakeComponentEmpty)
+      const WithProviderFields = withProvider(FakeComponentWithFields)
+      const WithProviderValidate = withProvider(FakeComponentWithValidate)
+
+      it('returns false if WrappedComponent does not have `fields` or `validate`', () => {
+        let result = EmptyWithProvider.validateCookie('field', 'value')
+        expect(result).toBe(false)
+      })
+
+      it('returns false if WrappedComponent does not have `validate`', () => {
+        let result = WithProviderFields.validateCookie('field', 'value')
+        expect(result).toBe(false)
+      })
+
+      it('returns false if WrappedComponent does not have `fields`', () => {
+        let result = WithProviderValidate.validateCookie('field', 'value')
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('WrappedComponent has `fields` and `validate`', () => {
+      class FakeComponentWithFieldsAndValidate {
+        static get fields() {
+          return ['field']
+        }
+        static validate(values) {
+          let errors = {}
+          if (values.field !== 'value') {
+            errors.field = true
+          }
+          return Object.keys(errors).length ? errors : false
+        }
+        constructor() {}
+      }
+
+      const WithProvider = withProvider(FakeComponentWithFieldsAndValidate)
+
+      it('returns original object when validation passes', () => {
+        let result = WithProvider.validateCookie('page', { field: 'value' })
+        expect(result).toEqual({ field: 'value' })
+      })
+
+      let invalidVals = [0, false, {}, ['value'], null, '', 'value']
+      invalidVals.map(v => {
+        it(`throws error for regular field with a non-empty object value: ${v}`, () => {
+          expect(() => {
+            WithProvider.validateCookie('page', v)
+          }).toThrowError(/^validate: `val` must be a non-empty object$/)
+        })
+      })
+
+      it('removes invalid keys from original object', () => {
+        let result = WithProvider.validateCookie('page', {
+          field: 'value',
+          field2: 'value2',
+        })
+        expect(result).toEqual({ field: 'value' })
+      })
+
+      it('sets value to an empty string when key is valid but value is invalid', () => {
+        let result = WithProvider.validateCookie('page', {
+          field: 'wrong value',
+        })
+        expect(result).toEqual({ field: '' })
+      })
+
+      it('does not mutate original object', () => {
+        // original object has too many keys
+        let val1 = { field: 'value', field2: 'value2' }
+        let result1 = WithProvider.validateCookie('page', val1)
+        expect(result1).toEqual({ field: 'value' })
+        //check that the keys are still there
+        expect(val1).toEqual({ field: 'value', field2: 'value2' })
+
+        // original object has invalid value
+        let val2 = { field: 'wrong value' }
+        let result2 = WithProvider.validateCookie('page', val2)
+        expect(result2).toEqual({ field: '' })
+        // check that the original value is still there
+        expect(val2).toEqual({ field: 'wrong value' })
+      })
+    })
+  })
+})

--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -1,38 +1,20 @@
 import cookieEncrypter from 'cookie-encrypter'
 
+const inTenMinutes = () => new Date(new Date().getTime() + 10 * 60 * 1000)
 const inOneWeek = () => new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000)
 
-export const SECRET = 'Immediate convocation of a Party'
-
-const _whitelist = ({ query, fields }) => {
-  /* filter a dict by whitelisted keys
-  https://stackoverflow.com/questions/38750705/filter-object-properties-by-key-in-es6
-  */
-  return Object.keys(query)
-    .filter(key => fields.includes(key))
-    .reduce((obj, key) => {
-      return {
-        ...obj,
-        [key]: query[key], // eslint-disable-line security/detect-object-injection
-      }
-    }, {})
-}
+export const SECRET =
+  process.env.RAZZLE_COOKIE_SECRET ||
+  'Hey I just met you And this is crazy'.slice(0, 32)
 
 export const setStoreCookie = (setCookieFunc, cookie, options = {}) => {
-  if (
-    cookie === null || // if obj is null
-    typeof cookie !== 'object' || // if obj is _not_ an object
-    Object.keys(cookie).length === 0 // if obj is empty
-  ) {
-    throw new Error('setStoreCookie: `cookie` must be a non-empty object')
-  }
-
   cookie = cookieEncrypter.encryptCookie(JSON.stringify(cookie), {
     key: SECRET,
   })
 
   let expires = {
-    expires: inOneWeek(),
+    expires:
+      process.env.NODE_ENV === 'production' ? inOneWeek() : inTenMinutes(),
   }
 
   setCookieFunc('store', cookie, { ...expires, ...options })
@@ -56,34 +38,15 @@ export const getStoreCookie = cookies => {
   return cookie
 }
 
-export const setSSRCookie = (req, res, match, fields = [], validate = null) => {
-  let { query } = req
+export const setSSRCookie = (res, key, val, prevCookie) => {
+  prevCookie = prevCookie || {}
+  let newCookie = { [key]: val }
 
-  if (
-    Object.keys(query).length && // a query was submitted
-    fields.length && // there are fields explicitly defined for the page
-    typeof validate === 'function' // there is a validate function passed-in
-  ) {
-    // whitelist query keys so that arbitrary keys aren't saved to the store
-    query = fields ? _whitelist({ query, fields }) : query
+  // create new cookie by merging with previous values
+  let cookie = { ...prevCookie, ...newCookie }
 
-    // reset values that don't pass validation
-    let errors = validate(query)
-    Object.keys(errors || {}).forEach(field => {
-      query[field] = '' // eslint-disable-line security/detect-object-injection
-    })
+  /* console.log('set cookie! ', cookie) */
+  setStoreCookie(res.cookie.bind(res), cookie)
 
-    let prevCookie = getStoreCookie(req.cookies) || {}
-    // match.path === "/about" or similar
-    let path = match.path.slice(1)
-    let newCookie = { [path]: query }
-
-    // create new cookie by merging with previous values
-    let cookie = { ...prevCookie, ...newCookie }
-
-    /* console.log('set cookie! ', cookie) */
-    setStoreCookie(res.cookie.bind(res), cookie)
-    return cookie
-  }
-  return false
+  return cookie
 }

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -149,6 +149,7 @@ class RegistrationPage extends React.Component {
     super(props)
     this.onSubmit = this.onSubmit.bind(this)
     this.validate = RegistrationPage.validate
+    this.fields = RegistrationPage.fields
   }
 
   async onSubmit(values, event) {
@@ -172,8 +173,12 @@ class RegistrationPage extends React.Component {
     let errorsNoJS = {}
 
     // only run this if there's a location.search
-    // this will be the case on no-JS clients when someone presses "continue"
-    if (this.props.location && this.props.location.search) {
+    // AND at least one of our fields exists in the string somewhere
+    // so we know for sure they pressed "submit" on this page
+    if (
+      this.props.location.search &&
+      this.fields.some(field => this.props.location.search.includes(field))
+    ) {
       errorsNoJS = this.validate(register)
     }
 


### PR DESCRIPTION
There's a lot going on here, but, as before, it's been prototyped out at https://github.com/pcraig3/after-no-js. This PR doesn't update our language switcher to actually sent requests to change the language, but you can see this working at [https://nojs.now.sh/](https://nojs.now.sh/).

## Summary of changes:

1. Consolidate cookie validation logic

Both server-side and client-side cookies are put through the same validation logic now, in `WithProvider.validateCookie()`.
Before, the No-JS validation was happening in [`setSSRCookie`](https://github.com/cds-snc/ircc-rescheduler/blob/master/web/src/cookies.js#L59), while the JS validation was happening in the pages themselves. They were similar but now they are the same.
Also added a bunch of tests for it since it's very easy to throw things at it and see what comes back.

2. Add `language` as a globally-settable field

Previously, we were able to get saved values back on any page, but we could only set them on specific pages.
Since we can send a server-side language change request (?language=fr) from any page in the flow, we need to be able to set a field globally.
Since the pages themselves have a `static get fields()` function that lists permissible fields for that page, I added a `static get fields()` function to `WithProvider` so that all query strings coming through can be checked for whether they contain the `language` query parameter.
The validation logic for this is really gross looking so I added a bunch of tests for that as well.

3. cookies.js is much simpler now

Took all checks out of these methods now that everything is in `WithProvider.validateCookie()`

4. Added (optional) secret env var: RAZZLE_COOKIE_SECRET

If we set a 32-character random string in our .env.production file, we will have a real secret and not one that's public in our github.

5. Shorten cookie expiry time in dev mode

Cookies are only set to a week long in production.
In dev mode they're only 10 minutes.