### PR TITLE
White feedback link in header

### DIFF
--- a/web/src/components/PhaseBanner.js
+++ b/web/src/components/PhaseBanner.js
@@ -36,6 +36,7 @@ const container = css`
     margin-bottom: ${theme.spacing.md};
   `)};
 
+  a,
   a:visited {
     color: ${theme.colour.white};
   }


### PR DESCRIPTION
For visited links it will already be white, but it was showing up as blue for people who hadn't clicked it before.