### PR TITLE
Set secure cookies 🔐 🍪

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ node_modules
 build
 public/static
 .env.*.local
+.env.local
 api/.env

--- a/web/.env
+++ b/web/.env
@@ -1,1 +1,2 @@
 PORT=3004
+VERBOSE=true

--- a/web/.env.local
+++ b/web/.env.local
@@ -1,1 +1,0 @@
-VERBOSE=true

--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -12,12 +12,14 @@ export const setStoreCookie = (setCookieFunc, cookie, options = {}) => {
     key: SECRET,
   })
 
-  let expires = {
+  let defaults = {
+    secure:
+      !process.env.RAZZLE_COOKIE_HTTP && process.env.NODE_ENV === 'production',
     expires:
       process.env.NODE_ENV === 'production' ? inOneWeek() : inTenMinutes(),
   }
 
-  setCookieFunc('store', cookie, { ...expires, ...options })
+  setCookieFunc('store', cookie, { ...defaults, ...options })
 }
 
 export const getStoreCookie = cookies => {


### PR DESCRIPTION
@damcom-gc mentioned today that some of our web header stuff wasn't locked down.

One of the not-locked-down things we're doing is setting browser cookies which are returned over both HTTP and HTTPS. If we set `secure: true` (ie, in [res.cookie](https://expressjs.com/en/4x/api.html#res.cookie)), they will only be returned over HTTPS (which means they're encrypted over the wire). 

I've done some `.env` changes here to accommodate for this, because locally we are running on `http://localhost:3004` and we need to be able to get cookies back.

As a developer on this project, you should create a `.env.local` file which will make sure cookies are always served over HTTP for local development.

```
# .env.local
RAZZLE_COOKIE_HTTP=true
```
