### PR TITLE
Make a GraphQL post from the server II

### DIFF
--- a/api/src/schema.js
+++ b/api/src/schema.js
@@ -26,15 +26,6 @@ const createSchema = t => {
   var mutation = new GraphQLObjectType({
     name: 'Mutation',
     fields: () => ({
-      test: {
-        type: GraphQLString,
-        args: {
-          name: { type: new GraphQLNonNull(GraphQLString) },
-        },
-        resolve(_, { name }) {
-          return 'test mutation: ' + name
-        },
-      },
       decline: {
         description: t('mutation.fields.decline.description'),
         args: {

--- a/api/test/i18n.test.js
+++ b/api/test/i18n.test.js
@@ -29,7 +29,7 @@ describe('I18n', () => {
     })
   })
 
-  it.skip('shows purchase description in the language specified by the Accept-Language header', async () => {
+  it('shows purchase description in the language specified by the Accept-Language header', async () => {
     let lang = 'fr-CA'
     let response = await request(app)
       .post('/graphql')
@@ -51,7 +51,7 @@ describe('I18n', () => {
     expect(first.description).toEqual(fr('mutation.fields.decline.description'))
   })
 
-  it.skip('it translates the arg descriptions', async () => {
+  it('it translates the arg descriptions', async () => {
     let lang = 'fr-CA'
     let response = await request(app)
       .post('/graphql')
@@ -77,7 +77,7 @@ describe('I18n', () => {
     expect(uci.description).toEqual(fr('mutation.fields.decline.args.uci'))
   })
 
-  it.skip('defaults to the en locale if no Accept-Language header is sent', async () => {
+  it('defaults to the en locale if no Accept-Language header is sent', async () => {
     let response = await request(app)
       .post('/graphql')
       .set('Content-Type', 'application/graphql; charset=utf-8').send(`

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,6 @@
     "js-cookie": "^2.2.0",
     "lingui-react": "^1.4.1",
     "moment": "2.22.0",
-    "node-fetch": "^2.1.2",
     "prop-types": "^15.6.1",
     "raven-js": "^3.25.2",
     "razzle": "^2.1.0",

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -29,25 +29,32 @@ server
   .use(cors())
   .post('/submit', async (req, res) => {
     try {
-      const dates = req.body.availability.split(',')
-      req.body.availability = dates
+      let data = Object.assign({}, req.body) // make a new object
+      data.availability = data.availability.split(',')
 
       /*
       let data = {
         fullName: 'john li',
         email: 'john@johnliindustries.com',
-        explanation: 'this is a textbox field with a bunch of freely-formatted text',
+        paperFileNumber: '123456789'
         reason: 'medical',
+        explanation: 'this is a textbox field with a bunch of freely-formatted text',
         availability: ['2018-09-05', '2018-09-06', '2018-09-12']
       }
       */
 
+      // eslint-disable-next-line no-unused-vars
       const response = await client.mutate({
         mutation: SUBMIT,
-        variables: req.body,
+        variables: data,
       })
 
+      /*
+      TODO: handle response gracefully
       res.json(response)
+      */
+
+      return res.redirect('/confirmation')
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(e.message)

--- a/web/src/utils/createApolloClient.js
+++ b/web/src/utils/createApolloClient.js
@@ -2,11 +2,9 @@ import { ApolloLink } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
 import { ApolloClient } from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
-// import fetch from 'node-fetch';
 import { withClientState } from 'apollo-link-state'
 import gql from 'graphql-tag'
-
-require('isomorphic-fetch')
+import fetch from 'isomorphic-fetch'
 
 const cache = new InMemoryCache()
 
@@ -45,13 +43,15 @@ const stateLink = withClientState({
   typeDefs,
 })
 
-//const endpoint = 'http://localhost:3004/graphql'
-//
+const uri =
+  process.env.NODE_ENV === 'production'
+    ? 'https://rescheduler.cds-snc.ca/graphql'
+    : 'http://localhost:3004/graphql'
 
 const createApolloClient = ({ ssrMode }) =>
   new ApolloClient({
     ssrMode,
-    link: ApolloLink.from([stateLink, new HttpLink({ fetch })]), // eslint-disable-line no-undef
+    link: ApolloLink.from([stateLink, new HttpLink({ fetch, uri })]),
     cache: ssrMode
       ? new InMemoryCache()
       : new InMemoryCache().restore(window.__APOLLO_STATE__),


### PR DESCRIPTION
A couple changes in here:

- created a new object from `res.body` so that we're not mutating it
- added paperFileNumber to test data
- removed 'test' mutation since we no longer need it
- redirect to `/confirmation` if no error is thrown
- added an absolute URL in production since that seems to be an issue