### PR TITLE
Merge 1st: Reveal radios + checkboxes

### DIFF
--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -62,18 +62,16 @@ const Calendar = ({ startDate, endDate, dates }) => {
       const checked = dates.includes(val)
 
       const el = (
-        <React.Fragment key={val}>
-          <li>
-            <Checkbox
-              name="calendar"
-              id={`calendar-${idMonth}-${index}`}
-              value={val}
-              label={label}
-              onChange={() => {}}
-              checked={checked}
-            />
-          </li>
-        </React.Fragment>
+        <li key={val}>
+          <Checkbox
+            name="calendar"
+            id={`calendar-${idMonth}-${index}`}
+            value={val}
+            label={label}
+            onChange={() => {}}
+            checked={checked}
+          />
+        </li>
       )
 
       // eslint-disable-next-line security/detect-object-injection
@@ -103,7 +101,7 @@ const Calendar = ({ startDate, endDate, dates }) => {
 Calendar.propTypes = {
   startDate: isValidDateString,
   endDate: isValidDateString,
-  dates: PropTypes.oneOfType(PropTypes.array, PropTypes.object),
+  dates: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
 }
 
 // Go 4 weeks from today (ie, add 28 days)
@@ -125,7 +123,7 @@ class CalendarNoJs extends Component {
 }
 
 CalendarNoJs.propTypes = {
-  dates: PropTypes.oneOfType(PropTypes.array, PropTypes.object),
+  dates: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
 }
 
 export default CalendarNoJs

--- a/web/src/components/forms/MultipleChoice.js
+++ b/web/src/components/forms/MultipleChoice.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import FieldAdapterPropTypes from '../_Field'
 import { css } from 'react-emotion'
-import { theme, roundedEdges, mediaQuery } from '../../styles'
+import { theme, mediaQuery } from '../../styles'
 
 const govuk_multiple_choice = css`
   display: block;
@@ -129,45 +129,13 @@ const govuk_label_pseudo_elements = css`
 `
 
 const cds_multiple_choice = css`
-  padding: 0 0 0 ${theme.spacing.xl};
-  margin-bottom: ${theme.spacing.sm};
-  input {
-    width: 24px;
-    height: 24px;
-  }
-  label {
-    display: inline-block;
-    padding: 0;
-    height: initial;
-    font-size: ${theme.font.lg};
-    > span {
-      padding: 0 ${theme.spacing.sm} 0 ${theme.spacing.xs};
-    }
-  }
-  ${mediaQuery.sm(css`
-    margin-bottom: ${theme.spacing.md};
-    input {
-      width: 22px;
-      height: 22px;
-    }
-    label {
-      font-size: ${theme.font.lg};
-      > span {
-        padding-left: 0;
-      }
-    }
-  `)};
-`
-
-const radio = css`
-  ${govuk_multiple_choice};
-
   label {
     padding-top: 3px;
     font-size: ${theme.font.lg};
   }
 
-  input[type='radio'] + label::before {
+  input[type='radio'] + label::before,
+  input[type='checkbox'] + label::before {
     border: 2px solid ${theme.colour.black};
     background-color: ${theme.colour.white};
   }
@@ -177,6 +145,11 @@ const radio = css`
       padding-top: 4px;
     }
   `)};
+`
+
+const radio = css`
+  ${govuk_multiple_choice};
+  ${cds_multiple_choice};
 `
 
 const MultipleChoice = ({
@@ -236,22 +209,11 @@ const checkbox = css`
   ${govuk_multiple_choice};
   ${cds_multiple_choice};
 
-  input[type='checkbox'] + label::before {
-    border: 2px solid ${theme.colour.grey};
-    width: 22px;
-    height: 22px;
-    top: 2px;
-    left: 0;
-    background-color: ${theme.colour.white};
-    ${roundedEdges};
-  }
-
   input[type='checkbox'] + label::after {
-    border-width: 0 0 3px 3px;
-    width: 14px;
-    height: 7px;
-    top: 8px;
-    left: 4px;
+    width: 21px;
+    height: 11px;
+    top: 9px;
+    left: 7px;
   }
 `
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -26,6 +26,7 @@ import { ErrorList, errorList } from '../components/ErrorMessage'
 import { windowExists } from '../utils/windowExists'
 import CalendarNoJS from '../components/CalendarNoJS'
 import CancelButton from '../components/CancelButton'
+import { Checkbox } from '../components/forms/MultipleChoice'
 
 const DAY_LIMIT = 3
 
@@ -274,6 +275,15 @@ class NoJS extends Component {
       <Layout>
         <CalHeader props={this.props} />
         {NoJS.validate(calendar).calendar}
+        {/*
+          the first checkbox / radio on the page doesn't have its CSS applied correctly
+          so this is a dummy checkbox that nobody should ever see
+          it's also outside of the form so it can't be submitted
+          if it is removed, the first checkbox in the list of dates will disappear
+        */}
+        <div style={{ display: 'none' }}>
+          <Checkbox id="ignore-me" value="ignore-me" />
+        </div>
         <form>
           <div className={listContainer}>
             <CalendarNoJS dates={calendar} />

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -18,7 +18,7 @@ import {
   TextAreaAdapter,
 } from '../components/forms/TextInput'
 import FieldSet from '../components/forms/FieldSet'
-import { RadioAdapter } from '../components/forms/MultipleChoice'
+import { Radio, RadioAdapter } from '../components/forms/MultipleChoice'
 import Button from '../components/forms/Button'
 import { ValidationMessage, ErrorList } from '../components/ErrorMessage'
 import { Form, Field } from 'react-final-form'
@@ -193,6 +193,15 @@ class RegistrationPage extends React.Component {
           First, supply some personal information and tell us why you need a new
           appointment.
         </h1>
+        {/*
+          the first checkbox / radio on the page doesn't have its CSS applied correctly
+          so this is a dummy radio button that nobody should ever see
+          it's also outside of the form so it can't be submitted
+          if it is removed, the first radio button in the list of reasons will disappear
+        */}
+        <div style={{ display: 'none' }}>
+          <Radio id="ignore-me" value="ignore-me" />
+        </div>
         <Form
           onSubmit={this.onSubmit}
           initialValues={register || {}}


### PR DESCRIPTION
This PR does a couple things:

- removes some unused CSS from the checkboxes + radios styling
- cleans up a linting error we were getting by not passing an array to `oneOfType`
- adds some dummy input elements to our registration page and No-JS calendar page
  - not my proudest moment (more info below)

***

## screenshots

| before | after |
|--------|-------|
|  radio hidden on the registration page   |  radio unhidden!    |
|     <img width="957" alt="screen shot 2018-06-29 at 9 18 35 pm" src="https://user-images.githubusercontent.com/2454380/42120066-e46f0c98-7be2-11e8-92a8-15bc44ba8ca4.png">   |    <img width="957" alt="screen shot 2018-06-29 at 9 18 37 pm" src="https://user-images.githubusercontent.com/2454380/42120067-e554d0ac-7be2-11e8-8cab-d4f416a04527.png">   |
|  small checkboxes + first one is hidden  |  larger checkboxes + first one unhidden!    |
|   <img width="1009" alt="screen shot 2018-06-29 at 9 19 54 pm" src="https://user-images.githubusercontent.com/2454380/42120051-b84417ee-7be2-11e8-88db-85081ed3debf.png">   |  <img width="1009" alt="screen shot 2018-06-29 at 9 20 00 pm" src="https://user-images.githubusercontent.com/2454380/42120058-cf38be0a-7be2-11e8-9d3b-0a2a99e59313.png">     |








***

### Add dummy radio button / checkbox to our pages 
This is nuts.

Pseudo element styles are not being applied correctly to the first
radio button and checkbox on the page, when in No-JS mode.

I don't know why this is happening really, but I don't want to
debug it at this point.

Adding a dummy radio to the registration page and a dummy checkbox
to the No-JS calendar page and then wrapping them in a hidden div.
- 'display: none' hides elements from visual interfaces and AT
- they are outside of our forms so they can't be submitted


