### PR TITLE
Merge 2nd: Polish up No-JS calendar + save dates the same way between calendars

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -4,7 +4,7 @@ import { Trans, withI18n } from 'lingui-react'
 import FieldAdapterPropTypes from './_Field'
 import DayPicker, { DateUtils } from 'react-day-picker'
 import { css } from 'emotion'
-import Time, { makeGMTDate } from './Time'
+import Time, { makeGMTDate, dateToHTMLString } from './Time'
 import ErrorMessage from './ErrorMessage'
 import { theme, mediaQuery, incrementColor, focusRing } from '../styles'
 import Cancel from '../assets/cancel.svg'
@@ -402,13 +402,14 @@ const renderDayBoxes = ({
             type="button"
             onClick={removeDayOnClickOrKeyPress(selectedDay)}
             onKeyPress={removeDayOnClickOrKeyPress(selectedDay)}
+            aria-label={`Remove day: ${dateToHTMLString(selectedDay)}`}
           >
             <div className={removeDateDesktop}>
               <Trans>Remove day</Trans>
             </div>
 
             <div className={removeDateMobile}>
-              <img src={Cancel} alt="Remove Day" />
+              <img src={Cancel} alt="Remove day" />
             </div>
           </button>
         </li>

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -288,7 +288,7 @@ const calendarContainer = css`
     width: 100%;
   `)};
 
-  #selectedDays {
+  #selectedDays-list {
     margin: 0;
 
     li:last-of-type {
@@ -562,7 +562,7 @@ class Calendar extends Component {
             />
           </div>
 
-          <ul id="selectedDays">
+          <ul id="selectedDays-list">
             {renderDayBoxes({
               dayLimit,
               selectedDays: value,

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -8,6 +8,7 @@ import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 import { Checkbox } from '../components/forms/MultipleChoice'
 import PropTypes from 'prop-types'
+import Time, { dateToISODateString } from './Time'
 
 const calList = css`
   display: flex;
@@ -45,8 +46,6 @@ const isValidDateString = (props, propName, componentName) => {
   }
 }
 
-const dateToString = date => (date ? format(date, 'YYYY-MM-DD') : '')
-
 const Calendar = ({ startDate, endDate, dates }) => {
   const days = eachDay(startDate, endDate)
   const mapped = {}
@@ -56,9 +55,8 @@ const Calendar = ({ startDate, endDate, dates }) => {
 
     if (validDay) {
       const monthName = format(date, 'MMMM')
-      const label = format(date, 'dddd MMMM D')
       const idMonth = format(date, 'MM')
-      const val = dateToString(date)
+      const val = dateToISODateString(date)
       const checked = dates.includes(val)
 
       const el = (
@@ -67,7 +65,7 @@ const Calendar = ({ startDate, endDate, dates }) => {
             name="selectedDays"
             id={`selectedDays-${idMonth}-${index}`}
             value={val}
-            label={label}
+            label={<Time date={date} />}
             onChange={() => {}}
             checked={checked}
           />
@@ -109,8 +107,8 @@ Calendar.propTypes = {
 class CalendarNoJs extends Component {
   render() {
     const { dates } = this.props
-    const startDate = dateToString(addWeeks(new Date(), 4))
-    const endDate = dateToString(addWeeks(new Date(startDate), 8))
+    const startDate = dateToISODateString(addWeeks(new Date(), 4))
+    const endDate = dateToISODateString(addWeeks(new Date(startDate), 8))
 
     return (
       <Calendar

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -62,18 +62,16 @@ const Calendar = ({ startDate, endDate, dates }) => {
       const checked = dates.includes(val)
 
       const el = (
-        <React.Fragment key={val}>
-          <li>
-            <Checkbox
-              name="calendar"
-              id={`calendar-${idMonth}-${index}`}
-              value={val}
-              label={label}
-              onChange={() => {}}
-              checked={checked}
-            />
-          </li>
-        </React.Fragment>
+        <li key={val}>
+          <Checkbox
+            name="calendar"
+            id={`calendar-${idMonth}-${index}`}
+            value={val}
+            label={label}
+            onChange={() => {}}
+            checked={checked}
+          />
+        </li>
       )
 
       // eslint-disable-next-line security/detect-object-injection
@@ -103,7 +101,7 @@ const Calendar = ({ startDate, endDate, dates }) => {
 Calendar.propTypes = {
   startDate: isValidDateString,
   endDate: isValidDateString,
-  dates: PropTypes.oneOfType(PropTypes.array, PropTypes.object),
+  dates: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
 }
 
 // Go 4 weeks from today (ie, add 28 days)
@@ -125,7 +123,7 @@ class CalendarNoJs extends Component {
 }
 
 CalendarNoJs.propTypes = {
-  dates: PropTypes.oneOfType(PropTypes.array, PropTypes.object),
+  dates: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
 }
 
 export default CalendarNoJs

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -13,14 +13,25 @@ import Time, { dateToISODateString } from './Time'
 const calList = css`
   display: flex;
 
-  ${mediaQuery.md(css`
+  h2 {
+    margin-top: 0;
+    margin-bottom: ${theme.spacing.md};
+  }
+
+  ${mediaQuery.lg(css`
     flex-direction: column;
   `)};
 `
 
 const column = css`
   border-left: 2px solid black;
-  padding: 0 ${theme.spacing.xxxl} 0 ${theme.spacing.lg};
+  padding-left: ${theme.spacing.lg};
+  margin: 0 ${theme.spacing.xxl} ${theme.spacing.lg} 0;
+
+  /* this is so that the border bottom aligns with the bottom of the checkbox */
+  li:last-of-type label {
+    padding-bottom: 2px;
+  }
 `
 
 const isValidDate = (
@@ -85,10 +96,12 @@ const Calendar = ({ startDate, endDate, dates }) => {
     <div className={calList}>
       {Object.keys(mapped).map((keyName, keyIndex) => {
         return (
-          <ul className={column} key={keyName}>
+          <div key={keyIndex}>
             <h2>{keyName}</h2>
-            {mapped[keyName]}
-          </ul>
+            <ul className={column} key={keyName}>
+              {mapped[keyName]}
+            </ul>
+          </div>
         )
       })}
     </div>

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -64,8 +64,8 @@ const Calendar = ({ startDate, endDate, dates }) => {
       const el = (
         <li key={val}>
           <Checkbox
-            name="calendar"
-            id={`calendar-${idMonth}-${index}`}
+            name="selectedDays"
+            id={`selectedDays-${idMonth}-${index}`}
             value={val}
             label={label}
             onChange={() => {}}
@@ -114,7 +114,7 @@ class CalendarNoJs extends Component {
 
     return (
       <Calendar
-        dates={dates && dates.calendar ? dates.calendar : []}
+        dates={dates && dates.selectedDays ? dates.selectedDays : []}
         startDate={startDate}
         endDate={endDate}
       />

--- a/web/src/components/Time.js
+++ b/web/src/components/Time.js
@@ -12,7 +12,7 @@ const makeGMTDate = date => {
   )
 }
 
-const dateToHTMLString = (date, locale) => {
+const dateToHTMLString = (date, locale = 'en') => {
   var options = {
     weekday: 'long',
     year: 'numeric',

--- a/web/src/components/Time.js
+++ b/web/src/components/Time.js
@@ -44,4 +44,4 @@ Time.propTypes = {
   locale: PropTypes.string,
 }
 
-export { Time as default, makeGMTDate, dateToISODateString }
+export { Time as default, makeGMTDate, dateToISODateString, dateToHTMLString }

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -15,7 +15,7 @@ const clickFirstDate = wrapper => {
 
 const getDateStrings = wrapper => {
   return wrapper
-    .find('#selectedDays time')
+    .find('#selectedDays-list time')
     .map(time => time.text())
     .join(' ')
 }
@@ -153,7 +153,7 @@ describe('<CalendarAdapter />', () => {
 
     // click first "Remove date" button
     wrapper
-      .find('#selectedDays button')
+      .find('#selectedDays-list button')
       .first()
       .simulate('click')
     expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
@@ -245,7 +245,7 @@ describe('<CalendarAdapter />', () => {
       expect(getDateStrings(wrapper)).toEqual('Wednesday, August 1, 2018')
 
       wrapper
-        .find('#selectedDays button')
+        .find('#selectedDays-list button')
         .first()
         .simulate(eventType, options)
       expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)

--- a/web/src/components/forms/MultipleChoice.js
+++ b/web/src/components/forms/MultipleChoice.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import FieldAdapterPropTypes from '../_Field'
 import { css } from 'react-emotion'
-import { theme, roundedEdges, mediaQuery } from '../../styles'
+import { theme, mediaQuery } from '../../styles'
 
 const govuk_multiple_choice = css`
   display: block;
@@ -129,45 +129,13 @@ const govuk_label_pseudo_elements = css`
 `
 
 const cds_multiple_choice = css`
-  padding: 0 0 0 ${theme.spacing.xl};
-  margin-bottom: ${theme.spacing.sm};
-  input {
-    width: 24px;
-    height: 24px;
-  }
-  label {
-    display: inline-block;
-    padding: 0;
-    height: initial;
-    font-size: ${theme.font.lg};
-    > span {
-      padding: 0 ${theme.spacing.sm} 0 ${theme.spacing.xs};
-    }
-  }
-  ${mediaQuery.sm(css`
-    margin-bottom: ${theme.spacing.md};
-    input {
-      width: 22px;
-      height: 22px;
-    }
-    label {
-      font-size: ${theme.font.lg};
-      > span {
-        padding-left: 0;
-      }
-    }
-  `)};
-`
-
-const radio = css`
-  ${govuk_multiple_choice};
-
   label {
     padding-top: 3px;
     font-size: ${theme.font.lg};
   }
 
-  input[type='radio'] + label::before {
+  input[type='radio'] + label::before,
+  input[type='checkbox'] + label::before {
     border: 2px solid ${theme.colour.black};
     background-color: ${theme.colour.white};
   }
@@ -177,6 +145,11 @@ const radio = css`
       padding-top: 4px;
     }
   `)};
+`
+
+const radio = css`
+  ${govuk_multiple_choice};
+  ${cds_multiple_choice};
 `
 
 const MultipleChoice = ({
@@ -236,22 +209,11 @@ const checkbox = css`
   ${govuk_multiple_choice};
   ${cds_multiple_choice};
 
-  input[type='checkbox'] + label::before {
-    border: 2px solid ${theme.colour.grey};
-    width: 22px;
-    height: 22px;
-    top: 2px;
-    left: 0;
-    background-color: ${theme.colour.white};
-    ${roundedEdges};
-  }
-
   input[type='checkbox'] + label::after {
-    border-width: 0 0 3px 3px;
-    width: 14px;
-    height: 7px;
-    top: 8px;
-    left: 4px;
+    width: 21px;
+    height: 11px;
+    top: 9px;
+    left: 7px;
   }
 `
 

--- a/web/src/components/forms/MultipleChoice.js
+++ b/web/src/components/forms/MultipleChoice.js
@@ -186,7 +186,7 @@ const MultipleChoice = ({
 MultipleChoice.propTypes = {
   type: PropTypes.string.isRequired,
   className: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.element.isRequired, PropTypes.string]),
+  label: PropTypes.element,
   value: PropTypes.string.isRequired,
   name: PropTypes.string,
   id: PropTypes.string,

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -63,7 +63,7 @@ const CalReminder = styled(Reminder)`
 
 const labelNames = id => {
   switch (id) {
-    case 'calendar':
+    case 'selectedDays':
       return <Trans>Calendar</Trans>
     default:
       return ''
@@ -121,31 +121,31 @@ CalBottom.propTypes = {
 
 class CalendarPage extends Component {
   static get fields() {
-    return ['calendar']
+    return ['selectedDays']
   }
 
   static validate(values) {
     const errors = {}
-    if (!values.calendar || !values.calendar.length) {
-      errors.calendar = <Trans>You must select 3 days.</Trans>
-    } else if (values.calendar.length < DAY_LIMIT) {
-      switch (values.calendar.length) {
+    if (!values.selectedDays || !values.selectedDays.length) {
+      errors.selectedDays = <Trans>You must select 3 days.</Trans>
+    } else if (values.selectedDays.length < DAY_LIMIT) {
+      switch (values.selectedDays.length) {
         case 1:
-          errors.calendar = (
+          errors.selectedDays = (
             <Trans>
               You must select 3 days. Please select 2 more days to continue.
             </Trans>
           )
           break
         case 2:
-          errors.calendar = (
+          errors.selectedDays = (
             <Trans>
               You must select 3 days. Please select 1 more day to continue.
             </Trans>
           )
           break
         default:
-          errors.calendar = <Trans>You must select 3 days.</Trans>
+          errors.selectedDays = <Trans>You must select 3 days.</Trans>
       }
     }
     return errors
@@ -163,7 +163,7 @@ class CalendarPage extends Component {
     if (Object.keys(submitErrors).length) {
       this.errorContainer.focus()
       return {
-        [FORM_ERROR]: submitErrors.calendar,
+        [FORM_ERROR]: submitErrors.selectedDays,
       }
     }
 
@@ -177,14 +177,16 @@ class CalendarPage extends Component {
     let { context: { store: { calendar = {} } = {} } = {} } = this.props
     // we aren't going to check for a no-js submission because currently nothing happens when someone presses "review request"
 
-    // cast values to Date objects if calendar.calendar exists and has a length
-    if (calendar && calendar.calendar && calendar.calendar.length) {
-      calendar = { calendar: calendar.calendar.map(day => makeGMTDate(day)) }
+    // cast values to Date objects if calendar.selectedDays exists and has a length
+    if (calendar && calendar.selectedDays && calendar.selectedDays.length) {
+      calendar = {
+        selectedDays: calendar.selectedDays.map(day => makeGMTDate(day)),
+      }
     }
 
     return (
       <Layout>
-        <CalHeader props={this.props} />
+        <CalHeader />
         <Form
           onSubmit={this.onSubmit}
           initialValues={calendar}
@@ -217,8 +219,8 @@ class CalendarPage extends Component {
                   </ErrorList>
                 </div>
                 <Field
-                  name="calendar"
-                  id="calendar"
+                  name="selectedDays"
+                  id="selectedDays"
                   tabIndex={-1}
                   component={CalendarAdapter}
                   dayLimit={DAY_LIMIT}
@@ -248,7 +250,7 @@ CalendarPage.propTypes = {
 
 class NoJS extends Component {
   static get fields() {
-    return ['calendar']
+    return ['selectedDays']
   }
 
   static get redirect() {
@@ -256,11 +258,11 @@ class NoJS extends Component {
   }
 
   static validate(values) {
-    if (values && values.calendar && values.calendar.length === 3) {
+    if (values && values.selectedDays && values.selectedDays.length === 3) {
       return {}
     }
     return {
-      calendar: <Trans>You must select 3 days.</Trans>,
+      selectedDays: <Trans>You must select 3 days.</Trans>,
     }
   }
 
@@ -280,9 +282,9 @@ class NoJS extends Component {
 
     return (
       <Layout>
-        <CalHeader props={this.props} />
+        <CalHeader />
         {Object.keys(errorsNoJS).length ? (
-          <ErrorList message={errorsNoJS.calendar}>
+          <ErrorList message={errorsNoJS.selectedDays}>
             <a href="#selectedDays">Calendar</a>
           </ErrorList>
         ) : (

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -52,13 +52,12 @@ const CalendarSubheader = styled(H2)`
   ${headerStyles};
 `
 
-const listContainer = css`
-  display: flex;
-  margin-bottom: ${theme.spacing.xxl};
-`
-
 const CalReminder = styled(Reminder)`
   padding: ${theme.spacing.md} 0;
+`
+
+const fullWidth = css`
+  width: 100% !important;
 `
 
 const labelNames = id => {
@@ -202,7 +201,7 @@ class CalendarPage extends Component {
             errors,
             submitError,
           }) => (
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={handleSubmit} className={fullWidth}>
               <div>
                 <div
                   id="submit-error"
@@ -302,10 +301,8 @@ class NoJS extends Component {
         <div style={{ display: 'none' }}>
           <Checkbox id="ignore-me" value="ignore-me" />
         </div>
-        <form id="selectedDays-form">
-          <div className={listContainer}>
-            <CalendarNoJS dates={calendar} />
-          </div>
+        <form id="selectedDays-form" className={fullWidth}>
+          <CalendarNoJS dates={calendar} />
           <CalBottom
             submit={() => {
               return (

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -20,7 +20,7 @@ import CalendarAdapter from '../components/Calendar'
 import Chevron from '../components/Chevron'
 import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
-import { makeGMTDate } from '../components/Time'
+import { makeGMTDate, dateToISODateString } from '../components/Time'
 import Reminder from '../components/Reminder'
 import { ErrorList } from '../components/ErrorMessage'
 import { windowExists } from '../utils/windowExists'
@@ -167,7 +167,10 @@ class CalendarPage extends Component {
       }
     }
 
-    // if setStore doesn't exist, nothing gets saved between pages
+    // values.selectedDays is an array of dates, so cast them to ISO date strings
+    values = {
+      selectedDays: values.selectedDays.map(date => dateToISODateString(date)),
+    }
     await this.props.context.setStore(this.props.match.path.slice(1), values)
 
     await this.props.history.push('/review')

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -288,7 +288,7 @@ class NoJS extends Component {
         <CalHeader />
         {Object.keys(errorsNoJS).length ? (
           <ErrorList message={errorsNoJS.selectedDays}>
-            <a href="#selectedDays">Calendar</a>
+            <a href="#selectedDays-form">Calendar</a>
           </ErrorList>
         ) : (
           ''
@@ -302,7 +302,7 @@ class NoJS extends Component {
         <div style={{ display: 'none' }}>
           <Checkbox id="ignore-me" value="ignore-me" />
         </div>
-        <form>
+        <form id="selectedDays-form">
           <div className={listContainer}>
             <CalendarNoJS dates={calendar} />
           </div>

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -26,6 +26,7 @@ import { ErrorList, errorList } from '../components/ErrorMessage'
 import { windowExists } from '../utils/windowExists'
 import CalendarNoJS from '../components/CalendarNoJS'
 import CancelButton from '../components/CancelButton'
+import { Checkbox } from '../components/forms/MultipleChoice'
 
 const DAY_LIMIT = 3
 
@@ -274,6 +275,15 @@ class NoJS extends Component {
       <Layout>
         <CalHeader props={this.props} />
         {NoJS.validate(calendar).calendar}
+        {/*
+          the first checkbox / radio on the page doesn't have its CSS applied correctly
+          so this is a dummy checkbox that nobody should ever see
+          it's also outside of the form so it can't be submitted
+          if it is removed, the first checkbox in the list of dates will disappear
+        */}
+        <div style={{ display: 'none' }}>
+          <Checkbox id="ignore-me" value="ignore-me" />
+        </div>
         <form>
           <div className={listContainer}>
             <CalendarNoJS dates={calendar} />

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -22,7 +22,7 @@ import { Form, Field } from 'react-final-form'
 import { FORM_ERROR } from 'final-form'
 import { makeGMTDate } from '../components/Time'
 import Reminder from '../components/Reminder'
-import { ErrorList, errorList } from '../components/ErrorMessage'
+import { ErrorList } from '../components/ErrorMessage'
 import { windowExists } from '../utils/windowExists'
 import CalendarNoJS from '../components/CalendarNoJS'
 import CancelButton from '../components/CancelButton'
@@ -240,12 +240,12 @@ class CalendarPage extends Component {
     )
   }
 }
-
 CalendarPage.propTypes = {
   ...contextPropTypes,
   history: PropTypes.any,
   submit: PropTypes.func,
 }
+
 class NoJS extends Component {
   static get fields() {
     return ['calendar']
@@ -260,21 +260,34 @@ class NoJS extends Component {
       return {}
     }
     return {
-      calendar: (
-        <div className={errorList}>
-          <Trans>You must select 3 days.</Trans>
-        </div>
-      ),
+      calendar: <Trans>You must select 3 days.</Trans>,
     }
   }
 
   render() {
     let { context: { store: { calendar } = {} } = {} } = this.props
+    let errorsNoJS = {}
+
+    // only run this if there's a location.search
+    // AND at least one of our fields exists in the string somewhere
+    // so we know for sure they pressed "submit" on this page
+    if (
+      this.props.location.search &&
+      NoJS.fields.some(field => this.props.location.search.includes(field))
+    ) {
+      errorsNoJS = NoJS.validate(calendar)
+    }
 
     return (
       <Layout>
         <CalHeader props={this.props} />
-        {NoJS.validate(calendar).calendar}
+        {Object.keys(errorsNoJS).length ? (
+          <ErrorList message={errorsNoJS.calendar}>
+            <a href="#selectedDays">Calendar</a>
+          </ErrorList>
+        ) : (
+          ''
+        )}
         {/*
           the first checkbox / radio on the page doesn't have its CSS applied correctly
           so this is a dummy checkbox that nobody should ever see
@@ -302,9 +315,9 @@ class NoJS extends Component {
     )
   }
 }
-
 NoJS.propTypes = {
-  context: PropTypes.object,
+  ...contextPropTypes,
+  location: PropTypes.object.isRequired,
 }
 
 const WhichCal = () => {

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -18,7 +18,7 @@ import {
   TextAreaAdapter,
 } from '../components/forms/TextInput'
 import FieldSet from '../components/forms/FieldSet'
-import { RadioAdapter } from '../components/forms/MultipleChoice'
+import { Radio, RadioAdapter } from '../components/forms/MultipleChoice'
 import Button from '../components/forms/Button'
 import { ValidationMessage, ErrorList } from '../components/ErrorMessage'
 import { Form, Field } from 'react-final-form'
@@ -193,6 +193,15 @@ class RegistrationPage extends React.Component {
           First, supply some personal information and tell us why you need a new
           appointment.
         </h1>
+        {/*
+          the first checkbox / radio on the page doesn't have its CSS applied correctly
+          so this is a dummy radio button that nobody should ever see
+          it's also outside of the form so it can't be submitted
+          if it is removed, the first radio button in the list of reasons will disappear
+        */}
+        <div style={{ display: 'none' }}>
+          <Radio id="ignore-me" value="ignore-me" />
+        </div>
         <Form
           onSubmit={this.onSubmit}
           initialValues={register || {}}

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -147,12 +147,10 @@ class ReviewPage extends React.Component {
             reason,
             explanation,
           } = {},
-          calendar: { calendar: selectedDays = [] } = {},
+          calendar: { selectedDays = [] } = {},
         } = {},
       } = {},
     } = this.props
-
-    /* TODO: handle a NO-JS submission */
 
     return (
       <Layout contentClass={contentClass}>


### PR DESCRIPTION
**Note: this PR follows up on #219, which should be merged first.**

_This PR is only from commit 3ce8e9293724be5ac0d06e4257edbefb5968adb6 onwards._

***

This PR: 
- fixes the error message on the No-JS calendar page so that it only shows up when it's meant to
- changes `calendar.calendar` → `calendar.selectedDays` everywhere
- saves values from both calendars in the same format
- does some styling updates to the No-JS calendar
- reuses `ErrorList` -- I know there's only one possible error to link to but it seemed better to link than to not
- adds the more descriptive aria-label to the `Remove day` button
  - this is one of the issues noted in https://github.com/cds-snc/ircc-rescheduler/issues/161

Things we could do in the future:
- use `date-fns` stuff in `Time` 
- revisit the displayed months and the displayed days on the NoJS calendar
- reuse the same date logic powering the NoJS calendar since currently the calendar is static
- tests for the NoJS calendar since it doesn't have any
- keep values on NoJS calendar if it comes back with an error

## Screenshots

| before | after |
|--------|-------|
|  first load: error shows up when it shouldn't   |  first load: no error and months are outside of list  |
|   ![rescheduler cds-snc ca_calendar](https://user-images.githubusercontent.com/2454380/42189682-73a8af72-7e27-11e8-885b-48adf53b7336.png)     |    ![localhost_3004_calendar](https://user-images.githubusercontent.com/2454380/42189695-7f56b18e-7e27-11e8-8f05-34602c2aba1f.png)   |
|  only submitted two dates: identical to first load  |  only submitted two dates: using standard error list  |
|    ![rescheduler cds-snc ca_calendar](https://user-images.githubusercontent.com/2454380/42189682-73a8af72-7e27-11e8-885b-48adf53b7336.png)    |   ![localhost_3004_calendar_selecteddays 2018-08-01 selecteddays 2018-08-02](https://user-images.githubusercontent.com/2454380/42189659-5f87f9bc-7e27-11e8-9bc1-e00092c51f61.png)    |

