### PR TITLE
[WIP] Possible `withI18n` refactor

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",
     "@jaredpalmer/after": "^1.3.1",
+    "@lingui/core": "^2.2.0",
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.1",

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -2,8 +2,8 @@ import React from 'react'
 import withContext from '../withContext'
 import { contextPropTypes } from '../context'
 import PropTypes from 'prop-types'
-import { Trans, withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
+import { Trans } from 'lingui-react'
+import { translateTextBetter } from '../utils/linguiUtils'
 import { WordMark } from '@cdssnc/gcui'
 import styled, { css } from 'react-emotion'
 import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
@@ -87,7 +87,7 @@ const TopBar = styled.hr(
   props => ({ background: props.background }),
 )
 
-const Footer = withI18n()(({ topBarBackground, i18n, context = {} }) => (
+const Footer = ({ topBarBackground, context = {} }) => (
   <div>
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
     <footer className={footer}>
@@ -96,14 +96,19 @@ const Footer = withI18n()(({ topBarBackground, i18n, context = {} }) => (
           <Trans>Contact</Trans>
         </a>
         <a
-          href={translateText(
-            i18n,
-            'https://www.canada.ca/en/transparency/privacy.html',
+          href={translateTextBetter(
+            <Trans>https://www.canada.ca/en/transparency/privacy.html</Trans>,
+            context.store.language,
           )}
         >
           <Trans>Privacy</Trans>
         </a>
-        <a href={translateText(i18n, 'https://digital.canada.ca/legal/terms/')}>
+        <a
+          href={translateTextBetter(
+            <Trans>https://digital.canada.ca/legal/terms/</Trans>,
+            context.store.language,
+          )}
+        >
           <Trans>Terms</Trans>
           {context.store &&
           context.store.language &&
@@ -126,7 +131,7 @@ const Footer = withI18n()(({ topBarBackground, i18n, context = {} }) => (
       </div>
     </footer>
   </div>
-))
+)
 Footer.propTypes = {
   ...contextPropTypes,
   topBarBackground: PropTypes.string,

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -3,8 +3,8 @@ import withContext from '../withContext'
 import { contextPropTypes } from '../context'
 import { Helmet } from 'react-helmet'
 import { css } from 'react-emotion'
-import { Trans, withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
+import { Trans } from 'lingui-react'
+import { translateTextBetter } from '../utils/linguiUtils'
 import {
   theme,
   visuallyhidden,
@@ -60,14 +60,17 @@ class LanguageSwitcher extends React.Component {
   }
 
   render() {
-    let { context: { setStore } = {}, i18n } = this.props
+    let { context: { setStore } = {} } = this.props
 
     return (
       <form>
         <Helmet>
           <html lang={this.state.language} />
           <title>
-            {translateText(i18n, 'Request a new citizenship appointment')}
+            {translateTextBetter(
+              <Trans>Request a new citizenship appointment</Trans>,
+              this.state.language,
+            )}
           </title>
         </Helmet>
         <h2 className={visuallyhidden}>
@@ -107,7 +110,7 @@ LanguageSwitcher.propTypes = {
   ...contextPropTypes,
 }
 
-const LanguageSwitcherContext = withContext(withI18n()(LanguageSwitcher))
+const LanguageSwitcherContext = withContext(LanguageSwitcher)
 
 export {
   LanguageSwitcherContext as default,

--- a/web/src/components/__tests__/Footer.test.js
+++ b/web/src/components/__tests__/Footer.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { FooterBase as Footer } from '../Footer'
 import { getStore } from './LanguageSwitcher.test.js'
 
 describe('<Footer />', () => {
   it('renders footer', () => {
-    const footer = mount(<Footer context={getStore('en')} />)
+    const footer = shallow(<Footer context={getStore('en')} />)
     expect(footer.find('footer').length).toBe(1)
     expect(footer.find('hr').length).toBe(0)
   })
@@ -20,22 +20,20 @@ describe('<Footer />', () => {
   })
 
   it('renders "and Conditions" in English', () => {
-    const footer = mount(<Footer context={getStore('en')} />)
-    expect(
-      footer
-        .find('a')
-        .at(2)
-        .text(),
-    ).toMatch(/and Conditions/)
+    const footer = shallow(<Footer context={getStore('en')} />)
+    let termsLink = footer.find('a').at(2)
+    expect(termsLink.text()).toMatch(/and Conditions/)
+    expect(termsLink.props().href).toEqual(
+      'https://digital.canada.ca/legal/terms/',
+    )
   })
 
   it('renders without "and Conditions" in French', () => {
-    const footer = mount(<Footer context={getStore('fr')} />)
-    expect(
-      footer
-        .find('a')
-        .at(2)
-        .text(),
-    ).not.toMatch(/and Conditions/)
+    const footer = shallow(<Footer context={getStore('fr')} />)
+    let termsLink = footer.find('a').at(2)
+    expect(termsLink.text()).not.toMatch(/and Conditions/)
+    expect(termsLink.props().href).toEqual(
+      'https://numerique.canada.ca/transparence/avis/',
+    )
   })
 })

--- a/web/src/utils/linguiUtils.js
+++ b/web/src/utils/linguiUtils.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Trans } from 'lingui-react'
-
-// import 'babel-polyfill'
+import { setupI18n } from '@lingui/core'
 import { unpackCatalog } from 'lingui-i18n'
 import en from '../../locale/en/messages.js'
 import fr from '../../locale/fr/messages.js'
@@ -20,6 +19,31 @@ export const linguiDev =
 export const translateText = (i18n, text) => {
   const translation = i18n === undefined ? text : i18n._(text)
   return translation
+}
+
+/*
+  Our components are being wrapped in withI18n for a very small use case.
+  I think it is needlessly overcomplicating our app, and so I've come up with this function as a solution
+  It accepts a <Trans> tag and a language string (ie, 'en', or 'fr')
+  It creates a new lingui translation object with our catalogue and our passed-in language.
+  The reason it wants a Trans component is so that when we run `lingui extract`, it will find the translation
+  What we were doing previously was creating a useless list of <Trans> objects below
+
+  This function will extract the string from the component and then return the localised version of it.
+  This means we don't have to use `withI18n` anymore to wrap our components
+  As long as we have the current language (which we can get from the context), we can easily translate strings
+  */
+export const translateTextBetter = (TransComponent, language) => {
+  if (TransComponent.type.name !== 'withI18n') {
+    throw new Error(
+      'translateTextBetter: first parameter must be a `<Trans>` component',
+    )
+  }
+  const i18n = setupI18n({
+    language,
+    catalogs,
+  })
+  return i18n._(TransComponent.props.id)
 }
 
 // eslint-disable-next-line no-unused-vars
@@ -51,8 +75,6 @@ const translations = () => (
     <Trans>Thu</Trans>
     <Trans>Fri</Trans>
     <Trans>Sat</Trans>
-    <Trans>https://www.canada.ca/en/transparency/privacy.html</Trans>
-    <Trans>https://digital.canada.ca/legal/terms/</Trans>
     <Trans>
       https://docs.google.com/forms/d/e/1FAIpQLSdEF3D7QCZ1ecPVKdqz_-dQAvlVdwdCQtHHLzg_v2q5q7XBlg/viewform
     </Trans>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -171,6 +171,14 @@
     react-router-dom "^4.2.2"
     serialize-javascript "^1.5.0"
 
+"@lingui/core@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-2.2.0.tgz#0bd8485355bc31f4fe782ef4d68d00646306ffda"
+  dependencies:
+    babel-runtime "^6.26.0"
+    make-plural "^4.1.1"
+    messageformat-parser "^2.0.0"
+
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -2313,13 +2321,6 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cors@^2.8.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
-  dependencies:
-    object-assign "^4"
-    vary "^1"
 
 cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
   version "2.2.2"
@@ -6080,10 +6081,6 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -6244,7 +6241,7 @@ oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -8734,7 +8731,7 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
-vary@^1, vary@~1.1.2:
+vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 


### PR DESCRIPTION
**Note this is an example of what a refactor would look like. I've only changed the `Footer` and the `LanguageSwitcher`. If this seems like a good idea, I will refactor all the other components that need `withI18n`**

***

[Lingui](https://github.com/lingui/js-lingui)’s `<Trans>` components are handling translations pretty well for us in general, I would say.

However, translating pure strings (for hrefs or alt text, for example) is a much less intuitive process.

To do this, we have been doing the following ([reference code here -- from lingui github repo](https://camo.githubusercontent.com/5804b6395ceb4d7e0db70d61327054f81391fe94/68747470733a2f2f6c696e6775692e6769746875622e696f2f6a732d6c696e6775692f5f7374617469632f6c696e6775692d70697463682e706e67)):
- wrapping components with `withI18n`
- This gives a component access to an `i18n` object
- Using the i18n object, we can translate the text (ie, i18n.t('text'))
    - But in order for this to work with `yarn extract` (and alias for `lingui extract`), we have to put the string in a <Trans> tag somewhere
            - This is why we have [a useless list of <Trans> tags in `linguiUtils.js`](https://github.com/cds-snc/ircc-rescheduler/blob/master/web/src/utils/linguiUtils.js#L26)

I was thinking about this over the last day and a bit and I came up with the following:

If the component has access to the `language` variable (ie, from withContext(Component)), then we can pass that to a new i18n object and it will do our string translation for us. 

The method I’m proposing looks like 
```translateString(<Trans>string to be translated</Trans>, ‘fr’)```

- We create the i18N object the same way that [the I18nProvider does](https://github.com/lingui/js-lingui/blob/stable-2.x/packages/react/src/I18nProvider.js#L77-L80), 
- We pass in a `<Trans>` component and a language string
- Then it returns a string

| pros | cons |
|--------|-------|
|  - Get rid of double-wrapping like `withContext(withI18n()(Footer))`. Everything we need comes from the context.  |  - withContext is a hand-rolled thing, whereas `withI18n` is (to some extent) documented     |
|    - We can use <Trans> components means we don’t have to save them in another place    |   - Getting language variable from `withContext` can be a bit abstract    |
|   - We can remove `withI18n` everywhere     |       |


