### PR TITLE
Refactor Calendar Tests to use non-hardcoded data

### DIFF
--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -1,7 +1,17 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import CalendarAdapter from '../Calendar'
-import { getStartMonth } from '../../utils/calendarDates'
+import {
+  getMonthNameAndYear,
+  getStartMonth,
+  getStartDate,
+  getValidDays,
+  getEndDate,
+} from '../../utils/calendarDates'
+
+import parse from 'date-fns/parse'
+import addMonths from 'date-fns/add_months'
+import format from 'date-fns/format'
 
 const clickDate = (wrapper, index) => {
   return wrapper
@@ -29,8 +39,7 @@ const getErrorMessageString = wrapper => {
 }
 
 const defaultProps = ({ value = '', dayLimit = 3 } = {}) => {
-  var date = new Date('July 5, 2018')
-  const startMonth = getStartMonth(date)
+  const startMonth = getStartMonth(new Date())
   return {
     input: { value: value, onChange: () => {} },
     dayLimit: dayLimit,
@@ -39,75 +48,96 @@ const defaultProps = ({ value = '', dayLimit = 3 } = {}) => {
   }
 }
 
+const dayMonthYear = date => {
+  return format(parse(date), 'dddd, MMMM D, YYYY')
+}
+
+const calDays = () => {
+  const startDate = parse(getStartDate())
+  const endDate = parse(getEndDate())
+  return getValidDays(startDate, endDate)
+}
+
 describe('<CalendarAdapter />', () => {
-  it('renders August 2018', () => {
-    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
-    expect(wrapper.text()).toMatch(/August 2018/)
+  let days
+
+  beforeEach(async () => {
+    days = calDays()
   })
 
-  it('renders September 2018', () => {
+  it('renders current month', () => {
+    const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
+    const monthYear = getMonthNameAndYear(getStartMonth(new Date()), 'en')
+    expect(wrapper.text()).toMatch(monthYear)
+  })
+
+  it('renders next month', () => {
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
     wrapper.find('.DayPicker-NavButton--next').simulate('click')
-    expect(wrapper.text()).toMatch(/September 2018/)
-    expect(wrapper.text()).not.toMatch(/August 2018/)
+
+    const currentMonthYear = getMonthNameAndYear(
+      getStartMonth(new Date()),
+      'en',
+    )
+
+    const nextMonth = addMonths(parse(getStartDate(new Date())), 1)
+    const nextMonthYear = getMonthNameAndYear(nextMonth, 'en')
+
+    expect(wrapper.text()).toMatch(nextMonthYear)
+    expect(wrapper.text()).not.toMatch(currentMonthYear)
   })
 
   it('will prefill a date if an initial value is provided', () => {
     const wrapper = mount(
-      <CalendarAdapter
-        {...defaultProps({ value: [new Date('2018-08-09T12:00:00.000')] })}
-      />,
+      <CalendarAdapter {...defaultProps({ value: [new Date(days[0])] })} />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 9, 2018')
+    expect(getDateStrings(wrapper)).toEqual(dayMonthYear(days[0]))
   })
 
   it('will prefill multiple dates if multiple initial values are provided', () => {
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [
-            new Date('2018-08-15T12:00:00.000'),
-            new Date('2018-08-16T12:00:00.000'),
-          ],
+          value: [new Date(days[0]), new Date(days[1])],
         })}
       />,
     )
 
-    expect(getDateStrings(wrapper)).toEqual(
-      'Wednesday, August 15, 2018 Thursday, August 16, 2018',
-    )
+    const day1 = dayMonthYear(days[0])
+    const day2 = dayMonthYear(days[1])
+
+    expect(getDateStrings(wrapper)).toEqual(`${day1} ${day2}`)
   })
 
   it('selects a date when it is clicked', () => {
+    const days = calDays()
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
     expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
-    // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-
-    //console.log(wrapper.html())
-
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 16, 2018')
+    expect(getDateStrings(wrapper)).toEqual(dayMonthYear(days[0]))
   })
 
   it('orders selected dates chronologically', () => {
+    const day1 = dayMonthYear(days[0])
+    const day2 = dayMonthYear(days[1])
+    const day3 = dayMonthYear(days[2])
+
     const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
     expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
     clickDate(wrapper, 2)
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 23, 2018')
+
+    expect(getDateStrings(wrapper)).toEqual(day3)
 
     clickDate(wrapper, 1)
-    expect(getDateStrings(wrapper)).toEqual(
-      'Wednesday, August 22, 2018 Thursday, August 23, 2018',
-    )
+
+    expect(getDateStrings(wrapper)).toEqual(`${day2} ${day3}`)
 
     clickDate(wrapper, 0)
 
-    expect(getDateStrings(wrapper)).toEqual(
-      'Thursday, August 16, 2018 Wednesday, August 22, 2018 Thursday, August 23, 2018',
-    )
+    expect(getDateStrings(wrapper)).toEqual(`${day1} ${day2} ${day3}`)
   })
 
   it('unselects a date when it is clicked twice', () => {
@@ -122,36 +152,35 @@ describe('<CalendarAdapter />', () => {
   })
 
   it('will not select more days once the limit is reached', () => {
+    const day2 = dayMonthYear(days[1])
+
     const wrapper = mount(
       <CalendarAdapter
-        {...defaultProps({
-          value: [new Date('2018-08-02T12:00:00.000')],
-          dayLimit: 1,
-        })}
+        {...defaultProps({ value: [new Date(days[1])], dayLimit: 1 })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day2)
 
-    // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day2)
     expect(getErrorMessageString(wrapper)).toEqual(
       'You can’t select more than 3 days. To change your selections, remove some days first.',
     )
   })
 
   it('will remove maximum date error message if a date is unselected', () => {
+    const day2 = dayMonthYear(days[1])
+
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [new Date('2018-08-02T12:00:00.000')],
+          value: [new Date(days[1])],
           dayLimit: 1,
         })}
       />,
     )
-    // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Thursday, August 2, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day2)
     expect(getErrorMessageString(wrapper)).toEqual(
       'You can’t select more than 3 days. To change your selections, remove some days first.',
     )
@@ -166,63 +195,60 @@ describe('<CalendarAdapter />', () => {
   })
 
   it('will allow more days to be selected once a day is unselected', () => {
+    const day1 = dayMonthYear(days[0])
+    const day2 = dayMonthYear(days[1])
+
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [new Date('2018-08-15T12:00:00.000')],
+          value: [new Date(days[1])],
           dayLimit: 1,
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 15, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day2)
 
     clickDate(wrapper, 1)
     expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
     // click the first available day (Aug 9th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 15, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day1)
   })
 
-  it.skip('will keep pre-filled dates when clicking new ones', () => {
+  it('will keep pre-filled dates when clicking new ones', () => {
+    const day1 = dayMonthYear(days[0])
+    const day2 = dayMonthYear(days[1])
+    const day3 = dayMonthYear(days[2])
+
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [
-            new Date('2018-08-15T12:00:00.000'),
-            new Date('2018-08-16T12:00:00.000'),
-          ],
+          value: [new Date(days[1]), new Date(days[2])],
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual(
-      'Wednesday, August 15, 2018 Thursday, August 16, 2018',
-    )
+    expect(getDateStrings(wrapper)).toEqual(`${day2} ${day3}`)
 
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual(
-      'Thursday, August 9, 2018 Wednesday, August 15, 2018 Thursday, August 16, 2018',
-    )
+    expect(getDateStrings(wrapper)).toEqual(`${day1} ${day2} ${day3}`)
   })
 
-  it.skip('will un-click pre-filled dates when clicking new ones', () => {
+  it('will un-click pre-filled dates when clicking new ones', () => {
+    const day1 = dayMonthYear(days[0])
+    const day2 = dayMonthYear(days[1])
+
     const wrapper = mount(
       <CalendarAdapter
         {...defaultProps({
-          value: [
-            new Date('2018-08-09T12:00:00.000'),
-            new Date('2018-08-15T12:00:00.000'),
-          ],
+          value: [new Date(days[1]), new Date(days[0])],
         })}
       />,
     )
-    expect(getDateStrings(wrapper)).toEqual(
-      'Thursday, August 9, 2018 Wednesday, August 15, 2018',
-    )
+    expect(getDateStrings(wrapper)).toEqual(`${day1} ${day2}`)
 
-    // click the first available day (July 17th, 2018)
     clickFirstDate(wrapper)
-    expect(getDateStrings(wrapper)).toEqual('Wednesday, August 15, 2018')
+    expect(getDateStrings(wrapper)).toEqual(day2)
   })
 
   const events = [
@@ -240,12 +266,15 @@ describe('<CalendarAdapter />', () => {
   ]
 
   events.map(({ eventType, options, toString }) => {
-    it.skip(`will remove a date when its "Remove date" button is triggered by a ${toString}`, () => {
+    days = calDays()
+    const day1 = dayMonthYear(days[0])
+
+    it(`will remove a date when its "Remove date" button is triggered by a ${toString}`, () => {
       const wrapper = mount(<CalendarAdapter {...defaultProps()} />)
       expect(wrapper.find('#selectedDays .day-box').every('.empty')).toBe(true)
 
       clickFirstDate(wrapper)
-      expect(getDateStrings(wrapper)).toEqual('Thursday, August 9, 2018')
+      expect(getDateStrings(wrapper)).toEqual(day1)
 
       wrapper
         .find('#selectedDays-list button')

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -6,11 +6,19 @@ import startOfMonth from 'date-fns/start_of_month'
 import addDays from 'date-fns/add_days'
 import subWeeks from 'date-fns/sub_weeks'
 import format from 'date-fns/format'
+import eachDay from 'date-fns/each_day'
 import { makeGMTDate, dateToISODateString } from '../components/Time'
 
 const offsetStartWeeks = 5
 const offsetEndWeeks = 8
 const offsetRespondBy = 4 // weeks + respondByDate() will add 2 additional days
+
+export const toLocale = (date, options, locale) => {
+  return makeGMTDate(format(date, 'YYYY-MM-DD')).toLocaleDateString(
+    locale,
+    options,
+  )
+}
 
 export const getStartDate = (today = new Date()) => {
   const date = wedOrThurs(addWeeks(today, offsetStartWeeks))
@@ -58,13 +66,6 @@ export const getStartMonthName = (today = new Date(), locale = 'fr') => {
   )
 }
 
-const toLocale = (date, options, locale) => {
-  return makeGMTDate(format(date, 'YYYY-MM-DD')).toLocaleDateString(
-    locale,
-    options,
-  )
-}
-
 export const getEndMonthName = (today = new Date(), locale = 'fr') => {
   const options = { month: 'long' }
   return toLocale(parse(getEndDate(today)), options, locale)
@@ -94,4 +95,17 @@ export const respondByDate = (selectedDays = [], locale = 'fr') => {
 
 export const yearMonthDay = date => {
   return format(date, 'YYYY-MM-DD')
+}
+
+export const getValidDays = (startDate, endDate) => {
+  const days = eachDay(startDate, endDate)
+  const mapped = []
+  days.forEach(date => {
+    const validDay = isWednesday(date) || isThursday(date)
+    if (validDay) {
+      mapped.push(date)
+    }
+  })
+
+  return mapped
 }


### PR DESCRIPTION
This update uses the utility methods in calendarDates matching the Calendar output against dynamic data (start / end dates etc...).