### PR TITLE
Fix some of the lingui translations we had for strings

### DIFF
--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -3,7 +3,6 @@ import withContext from '../withContext'
 import { contextPropTypes } from '../context'
 import PropTypes from 'prop-types'
 import { Trans, withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
 import { WordMark } from '@cdssnc/gcui'
 import styled, { css } from 'react-emotion'
 import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
@@ -95,15 +94,10 @@ const Footer = withI18n()(({ topBarBackground, i18n, context = {} }) => (
         <a href="mailto:cds-snc@tbs-sct.gc.ca">
           <Trans>Contact</Trans>
         </a>
-        <a
-          href={translateText(
-            i18n,
-            'https://www.canada.ca/en/transparency/privacy.html',
-          )}
-        >
+        <a href={i18n._('https://www.canada.ca/en/transparency/privacy.html')}>
           <Trans>Privacy</Trans>
         </a>
-        <a href={translateText(i18n, 'https://digital.canada.ca/legal/terms/')}>
+        <a href={i18n._('https://digital.canada.ca/legal/terms/')}>
           <Trans>Terms</Trans>
           {context.store &&
           context.store.language &&

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -4,7 +4,6 @@ import { contextPropTypes } from '../context'
 import { Helmet } from 'react-helmet'
 import { css } from 'react-emotion'
 import { Trans, withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
 import {
   theme,
   visuallyhidden,
@@ -66,9 +65,7 @@ class LanguageSwitcher extends React.Component {
       <form>
         <Helmet>
           <html lang={this.state.language} />
-          <title>
-            {translateText(i18n, 'Request a new citizenship appointment')}
-          </title>
+          <title>{i18n._('Request a new citizenship appointment')}</title>
         </Helmet>
         <h2 className={visuallyhidden}>
           <Trans>Language Selection</Trans>

--- a/web/src/components/PageHeader.js
+++ b/web/src/components/PageHeader.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 import { Trans, withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
 import PhaseBanner from './PhaseBanner'
 
 const bigBanner = css`
@@ -47,8 +46,7 @@ const PageHeader = ({ children, headerClass = '', i18n }) => (
     <PhaseBanner phase="beta">
       <Trans>This is a new service, help us improve by</Trans>{' '}
       <a
-        href={translateText(
-          i18n,
+        href={i18n._(
           'https://docs.google.com/forms/d/e/1FAIpQLSdEF3D7QCZ1ecPVKdqz_-dQAvlVdwdCQtHHLzg_v2q5q7XBlg/viewform',
         )}
         target="_blank"

--- a/web/src/components/Reminder.js
+++ b/web/src/components/Reminder.js
@@ -4,7 +4,6 @@ import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 import importantMessage from '../assets/importantMessage.svg'
 import { withI18n } from 'lingui-react'
-import { translateText } from '../utils/linguiUtils'
 
 const imBanner = css`
   font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
@@ -36,7 +35,7 @@ const Reminder = withI18n()(({ children, i18n, className = '' }) => (
     <img
       src={importantMessage}
       className={icon}
-      alt={translateText(i18n, 'Important message')}
+      alt={i18n._('Important message')}
     />
     <span>{children}</span>
   </div>

--- a/web/src/components/__tests__/Footer.test.js
+++ b/web/src/components/__tests__/Footer.test.js
@@ -1,11 +1,17 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { mount, render } from 'enzyme'
 import { FooterBase as Footer } from '../Footer'
 import { getStore } from './LanguageSwitcher.test.js'
+import { i18n } from 'lingui-i18n/dist'
+import { I18nProvider } from 'lingui-react'
 
 describe('<Footer />', () => {
   it('renders footer', () => {
-    const footer = mount(<Footer context={getStore('en')} />)
+    const footer = render(
+      <I18nProvider>
+        <Footer context={getStore('en')} i18n={i18n} />
+      </I18nProvider>,
+    )
     expect(footer.find('footer').length).toBe(1)
     expect(footer.find('hr').length).toBe(0)
   })
@@ -13,14 +19,20 @@ describe('<Footer />', () => {
   it('renders footer with topBar', () => {
     // have to use 'mount' instead of 'shallow' to render nested components
     const footer = mount(
-      <Footer topBarBackground="black" context={getStore('en')} />,
+      <I18nProvider>
+        <Footer topBarBackground="black" context={getStore('en')} i18n={i18n} />
+      </I18nProvider>,
     )
     expect(footer.find('footer').length).toBe(1)
     expect(footer.find('hr').length).toBe(1)
   })
 
   it('renders "and Conditions" in English', () => {
-    const footer = mount(<Footer context={getStore('en')} />)
+    const footer = mount(
+      <I18nProvider>
+        <Footer context={getStore('en')} i18n={i18n} />
+      </I18nProvider>,
+    )
     expect(
       footer
         .find('a')
@@ -30,7 +42,11 @@ describe('<Footer />', () => {
   })
 
   it('renders without "and Conditions" in French', () => {
-    const footer = mount(<Footer context={getStore('fr')} />)
+    const footer = mount(
+      <I18nProvider>
+        <Footer context={getStore('fr')} i18n={i18n} />
+      </I18nProvider>,
+    )
     expect(
       footer
         .find('a')

--- a/web/src/components/__tests__/LanguageSwitcher.test.js
+++ b/web/src/components/__tests__/LanguageSwitcher.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { LanguageSwitcherBase as LanguageSwitcher } from '../LanguageSwitcher'
+import { i18n } from 'lingui-i18n/dist'
 
 export const getStore = lang => ({
   store: { language: lang },
@@ -10,21 +11,27 @@ export const getStore = lang => ({
 describe('<LanguageSwitcher />', () => {
   describe('with { language: "en" } in the app context', () => {
     it('displays a button with "Français"', () => {
-      const wrapper = shallow(<LanguageSwitcher context={getStore('en')} />)
+      const wrapper = shallow(
+        <LanguageSwitcher context={getStore('en')} i18n={i18n} />,
+      )
       expect(wrapper.find('button').text()).toMatch(/Français/)
     })
   })
 
   describe('with { language: "fr" } in the app context', () => {
     it('displays a button with "English"', () => {
-      const wrapper = shallow(<LanguageSwitcher context={getStore('fr')} />)
+      const wrapper = shallow(
+        <LanguageSwitcher context={getStore('fr')} i18n={i18n} />,
+      )
       expect(wrapper.find('button').text()).toMatch(/English/)
     })
   })
 
   describe('with { language: "" } in the app context', () => {
     it('displays a button with "Français"', () => {
-      const wrapper = shallow(<LanguageSwitcher context={getStore('')} />)
+      const wrapper = shallow(
+        <LanguageSwitcher context={getStore('')} i18n={i18n} />,
+      )
       expect(wrapper.find('button').text()).toMatch(/Français/)
     })
   })

--- a/web/src/components/__tests__/PageHeader.test.js
+++ b/web/src/components/__tests__/PageHeader.test.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { PageHeaderBase as PageHeader } from '../PageHeader'
+import { i18n } from 'lingui-i18n/dist'
 
 describe('<PageHeader />', () => {
   it('renders', () => {
     const pageHeader = shallow(
-      <PageHeader>
+      <PageHeader i18n={i18n}>
         <h1>Title</h1>
       </PageHeader>,
     )

--- a/web/src/components/__tests__/Reminder.test.js
+++ b/web/src/components/__tests__/Reminder.test.js
@@ -1,10 +1,16 @@
 import React from 'react'
 import { render } from 'enzyme'
 import Reminder from '../Reminder'
+import { I18nProvider } from 'lingui-react'
+import { i18n } from 'lingui-i18n/dist'
 
 describe('<Reminder />', () => {
   it('renders reminder message', () => {
-    const reminder = render(<Reminder>Message</Reminder>)
+    const reminder = render(
+      <I18nProvider>
+        <Reminder i18n={i18n}>Message</Reminder>
+      </I18nProvider>,
+    )
     expect(reminder.find('img').length).toBe(1)
     expect(reminder.find('span').length).toBe(1)
   })


### PR DESCRIPTION
So the essence of this ticket is that @pcraig3 fixed the issue of needing a translate method for when we need a string at runtime since the ```i18n``` object was null at times. So I can now just use ```i18n_()``` to get a translated string at runtime and this also means that ```yarn extract && yarn compile``` will generate the string in the designated json files. 