### PR TITLE
Fix some axe violations + get language switcher to say "English / EN"

### DIFF
--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -85,16 +85,12 @@ class LanguageSwitcher extends React.Component {
             )
           }}
         >
-          {this.getNewLanguage() === 'fr' ? (
-            <span>
-              <span className={visuallyhiddenMobile}>Français</span>
-              <span className={hiddenOnDesktop} aria-hidden="true">
-                FR
-              </span>
-            </span>
-          ) : (
-            'English'
-          )}
+          <span className={visuallyhiddenMobile}>
+            {this.getNewLanguage() === 'fr' ? 'Français' : 'English'}
+          </span>
+          <span className={hiddenOnDesktop} aria-hidden="true">
+            {this.getNewLanguage() === 'fr' ? 'FR' : 'EN'}
+          </span>
         </button>
       </form>
     )

--- a/web/src/components/Layout.js
+++ b/web/src/components/Layout.js
@@ -96,8 +96,8 @@ class Layout extends React.Component {
           }}
           render={() => <ErrorPageContent />}
         >
-          <FederalBanner />
           <div role="banner">
+            <FederalBanner />
             <PageHeader headerClass={this.props.headerClass}>
               <Trans>Request a new citizenship appointment</Trans>
             </PageHeader>

--- a/web/src/components/PageHeader.js
+++ b/web/src/components/PageHeader.js
@@ -42,7 +42,7 @@ const pageTitle = css`
 `
 
 const PageHeader = ({ children, headerClass = '', i18n }) => (
-  <header className={headerClass ? skinnyBanner : bigBanner}>
+  <div className={headerClass ? skinnyBanner : bigBanner}>
     <PhaseBanner phase="beta">
       <Trans>This is a new service, help us improve by</Trans>{' '}
       <a
@@ -56,7 +56,7 @@ const PageHeader = ({ children, headerClass = '', i18n }) => (
       </a>.
     </PhaseBanner>
     <div className={headerClass ? headerClass : pageTitle}>{children}</div>
-  </header>
+  </div>
 )
 PageHeader.propTypes = {
   i18n: PropTypes.object,

--- a/web/src/components/__tests__/PageHeader.test.js
+++ b/web/src/components/__tests__/PageHeader.test.js
@@ -10,7 +10,7 @@ describe('<PageHeader />', () => {
         <h1>Title</h1>
       </PageHeader>,
     )
-    expect(pageHeader.find('header').length).toBe(1)
+    expect(pageHeader.find('div').length).toBe(2)
     expect(pageHeader.find('h1').text()).toMatch(/Title/)
   })
 })


### PR DESCRIPTION
- I am blocked on the sentry stuff until tomorrow because I am not an admin.
- And I'm blocked on the noJS date stuff until Dave is back.

So I ran an axe audit over our site and noticed a couple low-hanging fruit I could go after. Was planning to do this before next week's audit so this seems like a good a time as any.

##  Fix axe violations 
A couple of small changes, just.

- the FederalBanner should be within a landmark region
  - in this case, I moved it into the div with the "header" role
- having a <header> element within a <div role="header"> is bad, so
  I changed to PageHeader to just be a <div> and updated its test.

This takes us from 5 issues on most pages to 2 issues (the colour
contrast of the beta tag).


## LanguageSwitcher says "English / EN" now 

Similarly to how the Français link in the language switcher
becomes "FR" on small devices, the english link now becomes "EN".

As before, a screenreader will always read out the full word even
if the link shown on the page is the shortened one.