### PR TITLE
Header Focus on ErrorList

### DIFF
--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -223,7 +223,7 @@ class RegistrationPage extends React.Component {
                 >
                   <ErrorList message={submitError || ''}>
                     {Object.keys(this.validate(values)).map((formId, i) => (
-                      <a href={`#${formId}`} key={i}>
+                      <a href={`#${formId}-header`} key={i}>
                         {labelNames(formId) ? labelNames(formId) : formId}
                         <br />
                       </a>


### PR DESCRIPTION
## This PR consists of:

| Before | After |
|--------|-------|
| ![errorfocus-before](https://user-images.githubusercontent.com/30609058/42595468-60e0714a-8520-11e8-9485-35022549462a.gif)|   ![errorfocus-after](https://user-images.githubusercontent.com/30609058/42595467-60c6d5a0-8520-11e8-83f0-0afa2755e94c.gif)    |

- Anchor links in the ErrorList were previously pointing towards the input field. This makes sense when working with a screen reader, but was confusing on the desktop side for users. Anchor links have been modified to point at the header above the input field and error message