### PR TITLE
Fix email link

### DIFF
--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -42,7 +42,7 @@ const Contact = ({ children, phoneFirst = false }) => (
     {!phoneFirst ? (
       <React.Fragment>
         <p>
-          <a href="IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca">
+          <a href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca">
             IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
           </a>
         </p>

--- a/web/src/components/__tests__/Contact.test.js
+++ b/web/src/components/__tests__/Contact.test.js
@@ -37,12 +37,16 @@ describe('<Contact />', () => {
       </Contact>,
     )
 
-    expect(
-      wrapper
-        .find('p')
-        .at(0)
-        .text(),
-    ).toEqual('IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca')
+    let emailLink = wrapper
+      .find('p')
+      .at(0)
+      .find('a')
+    expect(emailLink.text()).toEqual(
+      'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
+    )
+    expect(emailLink.props().href).toEqual(
+      'mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
+    )
 
     expect(
       wrapper
@@ -66,11 +70,16 @@ describe('<Contact />', () => {
         .text(),
     ).toEqual('<TelLink />')
 
-    expect(
-      wrapper
-        .find('p')
-        .at(1)
-        .text(),
-    ).toEqual('IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca')
+    let emailLink = wrapper
+      .find('p')
+      .at(1)
+      .find('a')
+
+    expect(emailLink.text()).toEqual(
+      'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
+    )
+    expect(emailLink.props().href).toEqual(
+      'mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
+    )
   })
 })


### PR DESCRIPTION
Without the `mailto:` prefix in the href, we are just sending people to a 404 page if they click the email link on the confirmation page.