### PR TITLE
Add bundle analyzer 

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -4,3 +4,4 @@ node_modules
 # Vim swap files
 *.swp
 .env*
+reports

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
     "add-locale": "lingui add-locale", 
-    "stats" : "BUNDLE_CHECK=true yarn dev"
+    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn dev"
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
     "add-locale": "lingui add-locale", 
-    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn dev"
+    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn dev",
+    "stats-prod": "mkdir -p reports && BUNDLE_CHECK=true yarn start"
+
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "test": "node --icu-data-dir=./node_modules/full-icu node_modules/jest/bin/jest.js",
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
-    "add-locale": "lingui add-locale"
+    "add-locale": "lingui add-locale", 
+    "stats" : "BUNDLE_CHECK=true yarn dev"
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",
@@ -80,7 +81,8 @@
     "lingui-cli": "^1.4.4",
     "prettier": "^1.11.1",
     "raf": "^3.4.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "webpack-bundle-analyzer": "^2.13.1"
   },
   "jest": {
     "verbose": true,
@@ -90,7 +92,7 @@
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/node_modules/razzle/config/jest/fileTransform.js"
     },
     "globals": {
-      "RAZZLE_PAPER_FILE_NUMBER_PATTERN": "[a-zA-Z]{1}" 
+      "RAZZLE_PAPER_FILE_NUMBER_PATTERN": "[a-zA-Z]{1}"
     },
     "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
     "testMatch": [

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -14,6 +14,7 @@ module.exports = {
         new BundleAnalyzerPlugin({
           analyzerMode: 'static',
           generateStatsFile: true,
+          reportFilename: '../../reports/report.html',
         }),
       )
     }

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -4,6 +4,19 @@ module.exports = {
     if (config.devServer) {
       config.devServer.host = '0.0.0.0'
     }
+    if (process.env.BUNDLE_CHECK) {
+      /* This allows us to analyze the the webpack bundle of all our apis and imports. 
+        You can change the analyzerMode to be 'server' and this may let you see more info like
+        what the files looked gzipped,parsed and standard etc.. */
+      const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+        .BundleAnalyzerPlugin
+      config.plugins.push(
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          generateStatsFile: true,
+        }),
+      )
+    }
     return config
   },
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1624,6 +1624,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bfj-node4@^5.2.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/bfj-node4/-/bfj-node4-5.3.1.tgz#e23d8b27057f1d0214fc561142ad9db998f26830"
+  dependencies:
+    bluebird "^3.5.1"
+    check-types "^7.3.0"
+    tryer "^1.0.0"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1969,6 +1977,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+check-types@^7.3.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -2162,7 +2174,7 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.12.1:
+commander@^2.11.0, commander@^2.12.1, commander@^2.13.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
@@ -2853,6 +2865,10 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+ejs@^2.5.7:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
+
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.50"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz#7438b76f92b41b919f3fbdd350fbd0757dacddf7"
@@ -3514,6 +3530,10 @@ filesize@3.5.11:
   version "3.5.11"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.11.tgz#1919326749433bb3cf77368bd158caabcc19e9ee"
 
+filesize@^3.5.11:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
+
 fill-range@^2.1.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
@@ -3869,6 +3889,13 @@ gzip-size@3.0.0:
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   dependencies:
     duplexer "^0.1.1"
+
+gzip-size@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -6344,6 +6371,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opener@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
+
 opn@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.1.0.tgz#72ce2306a17dbea58ff1041853352b4a8fc77519"
@@ -8498,6 +8529,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+tryer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -8801,6 +8836,23 @@ webidl-conversions@^3.0.0:
 webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-bundle-analyzer@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.13.1.tgz#07d2176c6e86c3cdce4c23e56fae2a7b6b4ad526"
+  dependencies:
+    acorn "^5.3.0"
+    bfj-node4 "^5.2.0"
+    chalk "^2.3.0"
+    commander "^2.13.0"
+    ejs "^2.5.7"
+    express "^4.16.2"
+    filesize "^3.5.11"
+    gzip-size "^4.1.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    opener "^1.4.3"
+    ws "^4.0.0"
 
 webpack-dev-middleware@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Added the bundle analyzer for our razzle-webpack config. This will allow us to see just how much resource each library and js file takes up. 

-Currently spits out a stats json and a report.html file in the ircc/web/build folder. 
-This can be run using ```yarn stats```
-You can even try running this on the production build by changing the ```stats``` command to use ```start``` instead of ```dev```, they give slightly different results. 
-This is only for the web folder, not sure about adding it to the api folder given our deployment strategy is changing, but it shouldn't be the most difficult thing to add in the future. 
-the bundle analyzer has different config options in of itself, can configure it to host a server instance instead of a static html report (which shows a bit more information like what the designated library size is when gzipped, parsed or not)