### PR TITLE
Move to corporate CDS sentry account

### DIFF
--- a/web/src/client.js
+++ b/web/src/client.js
@@ -9,7 +9,7 @@ import Raven from 'raven-js'
 if (window) {
   window.Raven = Raven
   window.Raven.config(
-    'https://f8b5f68731864265b10502eb0b29c042@sentry.io/1215804',
+    'https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616',
   ).install()
 }
 


### PR DESCRIPTION
We were not using the CDS corporate Sentry account, but now we are.

NOT IN THIS PR:

- stop sending errors in dev mode !!!
- send formatted errors that make sense

But for now, this is just somewhere where everyone on the team can see it.