### PR TITLE
get pm2 to start the services using our package.json scripts

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,7 +2,8 @@ module.exports = {
     apps : [{
       name        : "api",
       cwd         : "./api",
-      script      : "index.js",
+      script      : "npm",
+      args        : "start",
       watch       : true,
       env: {
         "NODE_ENV": "development"
@@ -12,8 +13,9 @@ module.exports = {
       }
     },{
       name       : "web",
-      cwd        : "./web/build",
-      script     : "server.js",
+      cwd        : "./web",
+      script     : "npm",
+      args       : "start",
       instances  : "max",
       exec_mode  : "cluster",
       watch      : true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build_web": "yarn --cwd ./web && yarn --cwd ./web build",
     "build_api": "yarn --cwd ./api",
-    "restart": "yarn build_web && yarn build_api && pm2 kill && pm2 startOrRestart ecosystem.config.js --env production --update-env",
+    "restart": "yarn build_web && yarn build_api && pm2 kill && pm2 startOrRestart ecosystem.config.js",
     "postinstall": "yarn restart"
   },
   "devDependencies": {


### PR DESCRIPTION
This should fix the issue with starting node with the full-icu path - which loads translations for date formats - by calling `npm start` which passes in that argument.