### PR TITLE
Fix up the bundle anayzer to generate two different files in the same directory

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,8 +12,7 @@
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
     "add-locale": "lingui add-locale", 
-    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn dev",
-    "stats-prod": "mkdir -p reports && BUNDLE_CHECK=true yarn start"
+    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn build"
 
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,8 +11,8 @@
     "test": "node --icu-data-dir=./node_modules/full-icu node_modules/jest/bin/jest.js",
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
-    "add-locale": "lingui add-locale", 
-    "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn build"
+    "add-locale": "lingui add-locale",
+    "stats": "BUNDLE_CHECK=true yarn build"
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,6 @@
     "compile": "NODE_ENV=development lingui compile",
     "add-locale": "lingui add-locale", 
     "stats": "mkdir -p reports && BUNDLE_CHECK=true yarn build"
-
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -1,4 +1,3 @@
-console.log('rzzle runs')
 module.exports = {
   modify: (config, { target, dev }, webpack) => {
     if (process.env.CI) config.performance = { hints: false }

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -1,3 +1,4 @@
+console.log('rzzle runs')
 module.exports = {
   modify: (config, { target, dev }, webpack) => {
     if (process.env.CI) config.performance = { hints: false }
@@ -14,7 +15,14 @@ module.exports = {
         new BundleAnalyzerPlugin({
           analyzerMode: 'static',
           generateStatsFile: true,
-          reportFilename: '../../reports/report.html',
+          reportFilename:
+            target === 'web'
+              ? '../../reports/sourceReport.html'
+              : '../reports/modulesReport.html',
+          statsFilename:
+            target === 'web'
+              ? '../../reports/sourceStats.json'
+              : '../reports/modulesStats.json',
         }),
       )
     }


### PR DESCRIPTION
-Last bundle analyzer PR had some issues with it, the prod command didn't work without yarn build. and one report was generated in the right place and the other one wasn't. So in this PR I am only adding one command to the package.json file instead of previously two, so we should only need to see the prod version of the bundle. This is also way cleaner since this means a server doesn't need to run to generate the reports. 