### PR TITLE
Cal validation

### DIFF
--- a/web/src/__tests__/Validation.tests.js
+++ b/web/src/__tests__/Validation.tests.js
@@ -70,7 +70,7 @@ describe('Validation', () => {
     const validate = new Validator(vals, CalendarFields, defaultMessages)
     validate.passes()
     expect(validate.errors.first('selectedDays')).toEqual(
-      'selectedDaysMinMaxErrorMessage',
+      'selectedDaysCountErrorMessage',
     )
   })
 
@@ -84,7 +84,7 @@ describe('Validation', () => {
     validate.passes()
 
     expect(validate.errors.first('selectedDays')).toEqual(
-      'selectedDaysMinMaxErrorMessage',
+      'selectedDaysCountErrorMessage',
     )
   })
 
@@ -155,6 +155,30 @@ describe('Validation', () => {
     const passed = validate.passes()
     expect(validate.errors.first('selectedDays')).toEqual(
       'selectedDaysEmptyErrorMessage',
+    )
+  })
+
+  it('Shows correct error message for 1 date passed', () => {
+    const vals = {
+      selectedDays: ['2018-01-02'],
+    }
+
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    const passed = validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysCountErrorMessage',
+    )
+  })
+
+  it('Shows correct error message for 2 dates passed', () => {
+    const vals = {
+      selectedDays: ['2018-01-02','2018-01-03'],
+    }
+
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    const passed = validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysCountErrorMessage',
     )
   })
 })

--- a/web/src/__tests__/Validation.tests.js
+++ b/web/src/__tests__/Validation.tests.js
@@ -8,129 +8,153 @@ import {
 
 import Validator from 'validatorjs'
 
-it('Gets ar array of field names from Object Keys', () => {
-  expect(getFieldNames(RegistrationFields)[0]).toEqual('fullName')
-  expect(getFieldNames(CalendarFields)[0]).toEqual('selectedDays')
-})
+describe('Validation', () => {
+  it('Gets ar array of field names from Object Keys', () => {
+    expect(getFieldNames(RegistrationFields)[0]).toEqual('fullName')
+    expect(getFieldNames(CalendarFields)[0]).toEqual('selectedDays')
+  })
 
-it('Show correct error message when passing bad data', () => {
-  const vals = {
-    fullName: 'John Li',
-    email: 'not.an.email',
-    paperFileNumber: '123',
-  }
+  it('Show correct error message when passing bad data', () => {
+    const vals = {
+      fullName: 'John Li',
+      email: 'not.an.email',
+      paperFileNumber: '123',
+    }
 
-  const validate = new Validator(vals, RegistrationFields, defaultMessages)
-  const success = validate.passes()
+    const validate = new Validator(vals, RegistrationFields, defaultMessages)
+    const success = validate.passes()
 
-  expect(success).toEqual(false)
-  expect(validate.errors.first('paperFileNumber')).toEqual(
-    'paperFileNumberInvalidErrorMessage',
-  )
-  expect(validate.errors.first('email')).toEqual('emailInvalidErrorMessage')
-})
+    expect(success).toEqual(false)
+    expect(validate.errors.first('paperFileNumber')).toEqual(
+      'paperFileNumberInvalidErrorMessage',
+    )
+    expect(validate.errors.first('email')).toEqual('emailInvalidErrorMessage')
+  })
 
-it('Show correct error message when passing invalid fields', () => {
-  const vals = {
-    fullName: 'John Li',
-    reason: 'not on the list',
-  }
-  const validate = new Validator(vals, RegistrationFields, defaultMessages)
-  validate.passes()
-  expect(validate.errors.first('reason')).toEqual('inErrorMessage')
-})
+  it('Show correct error message when passing invalid fields', () => {
+    const vals = {
+      fullName: 'John Li',
+      reason: 'not on the list',
+    }
+    const validate = new Validator(vals, RegistrationFields, defaultMessages)
+    validate.passes()
+    expect(validate.errors.first('reason')).toEqual('inErrorMessage')
+  })
 
-it('Validates empty dates', () => {
-  const vals = {
-    selectedDays: null,
-  }
-  const validate = new Validator(vals, CalendarFields, defaultMessages)
-  validate.passes()
-  expect(validate.errors.first('selectedDays')).toEqual(
-    'selectedDaysEmptyErrorMessage',
-  )
-})
+  it('Validates empty dates', () => {
+    const vals = {
+      selectedDays: null,
+    }
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysEmptyErrorMessage',
+    )
+  })
 
-it('Looks for dates to be passed as an array', () => {
-  const vals = {
-    selectedDays: true,
-  }
-  const validate = new Validator(vals, CalendarFields, defaultMessages)
-  validate.passes()
-  expect(validate.errors.first('selectedDays')).toEqual(
-    'The selectedDays attribute has errors.',
-  )
-})
+  it('Looks for dates to be passed as an array', () => {
+    const vals = {
+      selectedDays: true,
+    }
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'The selectedDays attribute has errors.',
+    )
+  })
 
-it('Validates when not enough dates have been passed', () => {
-  const vals = {
-    selectedDays: ['2018-06-29', '2018-07-31'],
-  }
-  const validate = new Validator(vals, CalendarFields, defaultMessages)
-  validate.passes()
-  expect(validate.errors.first('selectedDays')).toEqual(
-    'selectedDaysMinMaxErrorMessage',
-  )
-})
+  it('Validates when not enough dates have been passed', () => {
+    const vals = {
+      selectedDays: ['2018-06-29', '2018-07-31'],
+    }
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysMinMaxErrorMessage',
+    )
+  })
 
-it('Validates when too many dates have been passed', () => {
-  const vals = {
-    selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'],
-  }
+  it('Validates when too many dates have been passed', () => {
+    const vals = {
+      selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04'],
+    }
 
-  const validate = new Validator(vals, CalendarFields, defaultMessages)
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
 
-  validate.passes()
+    validate.passes()
 
-  expect(validate.errors.first('selectedDays')).toEqual(
-    'selectedDaysMinMaxErrorMessage',
-  )
-})
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysMinMaxErrorMessage',
+    )
+  })
 
-it('Validates when correct amount of dates have been passed', () => {
-  const vals = {
-    selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03'],
-  }
+  it('Validates when correct amount of dates have been passed', () => {
+    const vals = {
+      selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03'],
+    }
 
-  const validate = new Validator(vals, CalendarFields, defaultMessages)
-  expect(validate.passes()).toEqual(true)
-})
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    expect(validate.passes()).toEqual(true)
+  })
 
-it('Gives back an error object with array of messages', () => {
-  const vals = {
-    selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03'],
-  }
+  it('Gives back an error object with array of messages', () => {
+    const vals = {
+      selectedDays: ['2018-01-01', '2018-01-02', '2018-01-03'],
+    }
 
-  const validate = new Validator(vals, RegistrationFields, defaultMessages)
-  validate.passes()
-  expect(validate.errors.all().fullName[0]).toEqual('fullNameErrorMessage')
-})
+    const validate = new Validator(vals, RegistrationFields, defaultMessages)
+    validate.passes()
+    expect(validate.errors.all().fullName[0]).toEqual('fullNameErrorMessage')
+  })
 
-it('Gives back an first error in the array for each key', () => {
-  const vals = {}
+  it('Gives back an first error in the array for each key', () => {
+    const vals = {}
 
-  const validate = new Validator(vals, RegistrationFields, defaultMessages)
-  validate.passes()
-  expect(getFieldErrorStrings(validate)['fullName']).toEqual(
-    'fullNameErrorMessage',
-  )
-})
+    const validate = new Validator(vals, RegistrationFields, defaultMessages)
+    validate.passes()
+    expect(getFieldErrorStrings(validate)['fullName']).toEqual(
+      'fullNameErrorMessage',
+    )
+  })
 
-it('Gets ar array of field names from Object Keys', () => {
-  expect(getFieldNames(RegistrationFields)[0]).toEqual('fullName')
-  expect(getFieldNames(CalendarFields)[0]).toEqual('selectedDays')
-})
+  it('Gets ar array of field names from Object Keys', () => {
+    expect(getFieldNames(RegistrationFields)[0]).toEqual('fullName')
+    expect(getFieldNames(CalendarFields)[0]).toEqual('selectedDays')
+  })
 
-it('Handles whitespace', () => {
-  const vals = {
-    fullName: 'John Li',
-    email: 'test@test.com ',
-  }
+  it('Handles whitespace', () => {
+    const vals = {
+      fullName: 'John Li',
+      email: 'test@test.com ',
+    }
 
-  const validate = new Validator(vals, RegistrationFields, defaultMessages)
-  const success = validate.passes()
+    const validate = new Validator(vals, RegistrationFields, defaultMessages)
+    const success = validate.passes()
 
-  expect(success).toEqual(false)
+    expect(success).toEqual(false)
 
-  expect(validate.errors.first('email')).toEqual('emailInvalidErrorMessage')
+    expect(validate.errors.first('email')).toEqual('emailInvalidErrorMessage')
+  })
+
+  it('Fails to validate if 1 date passed', () => {
+    const vals = {
+      selectedDays: ['2018-01-01'],
+    }
+
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    const passed = validate.passes()
+    expect(passed).toEqual(false)
+  })
+
+  it('Shows correct error message for 0 dates passed', () => {
+    const vals = {
+      selectedDays: [],
+    }
+
+    const validate = new Validator(vals, CalendarFields, defaultMessages)
+    const passed = validate.passes()
+    expect(validate.errors.first('selectedDays')).toEqual(
+      'selectedDaysEmptyErrorMessage',
+    )
+  })
 })

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -207,45 +207,72 @@ class CalendarPage extends Component {
             values,
             errors,
             submitError,
-          }) => (
-            <form onSubmit={handleSubmit} className={fullWidth}>
-              <div>
-                <div
-                  id="submit-error"
-                  tabIndex="-1"
-                  className={focusRing}
-                  ref={errorContainer => {
-                    this.errorContainer = errorContainer
-                  }}
-                >
-                  <ErrorList message={submitError || ''}>
-                    {Object.keys(this.validate(values)).map((formId, i) => (
-                      <HashLink to={`#${formId}`} key={i}>
-                        {labelNames(formId) ? labelNames(formId) : formId}
-                        <br />
-                      </HashLink>
-                    ))}
-                  </ErrorList>
-                </div>
-                <Field
-                  name="selectedDays"
-                  id="selectedDays"
-                  tabIndex={-1}
-                  component={CalendarAdapter}
-                  dayLimit={DAY_LIMIT}
-                />
-              </div>
-              <CalBottom
-                submit={() => {
-                  return (
-                    <Button disabled={submitting}>
-                      <Trans>Review request</Trans>
-                    </Button>
+          }) => {
+            let err
+
+            if (submitError && values && values.selectedDays) {
+              switch (values.selectedDays.length) {
+                case 1:
+                  err = (
+                    <React.Fragment>
+                      {submitError}{' '}
+                      <Trans>Please select 2 more days to continue.</Trans>
+                    </React.Fragment>
                   )
-                }}
-              />
-            </form>
-          )}
+                  break
+                case 2:
+                  err = (
+                    <React.Fragment>
+                      {submitError}{' '}
+                      <Trans>Please select 1 more day to continue.</Trans>
+                    </React.Fragment>
+                  )
+                  break
+                default:
+                  err = submitError
+              }
+            }
+
+            return (
+              <form onSubmit={handleSubmit} className={fullWidth}>
+                <div>
+                  <div
+                    id="submit-error"
+                    tabIndex="-1"
+                    className={focusRing}
+                    ref={errorContainer => {
+                      this.errorContainer = errorContainer
+                    }}
+                  >
+                    <ErrorList message={err || ''}>
+                      {Object.keys(this.validate(values)).map((formId, i) => (
+                        <HashLink to={`#${formId}`} key={i}>
+                          {labelNames(formId) ? labelNames(formId) : formId}
+                          <br />
+                        </HashLink>
+                      ))}
+                    </ErrorList>
+                  </div>
+                  <Field
+                    name="selectedDays"
+                    id="selectedDays"
+                    tabIndex={-1}
+                    component={CalendarAdapter}
+                    dayLimit={DAY_LIMIT}
+                  />
+                </div>
+                <CalBottom
+                  submit={() => {
+                    return (
+                      <Button disabled={submitting}>
+                        <Trans>Review request</Trans>
+                      </Button>
+                    )
+                  }}
+                />
+              </form>
+            )
+          }}
         />
       </Layout>
     )

--- a/web/src/validation.js
+++ b/web/src/validation.js
@@ -73,7 +73,11 @@ errorMessages.explanationMaxErrorMessage = (
 )
 
 errorMessages.selectedDaysEmptyErrorMessage = (
-  <Trans>You must select 3 days. Please select 2 more days to continue.</Trans>
+  <Trans>You must select 3 days.</Trans>
+)
+
+errorMessages.selectedDaysCountErrorMessage = (
+  <Trans>You must select 3 days.</Trans>
 )
 
 errorMessages.selectedDaysMinMaxErrorMessage = (
@@ -152,14 +156,11 @@ export const getFieldErrorStrings = validate => {
  * Custom Validation
  *--------------------------------------------*/
 
-Validator.register(
-  'date_count',
-  function(value, requirement, attribute) {
-    // requirement parameter defaults to null
-    return Number(value.length) === 3
-  },
-  'selectedDaysMinMaxErrorMessage',
-)
+const dateCount = (value, requirement, attribute) => {
+  return Number(value.length) === 3
+}
+
+Validator.register('date_count', dateCount, 'selectedDaysCountErrorMessage')
 
 Validator.register(
   'paper_file_number',


### PR DESCRIPTION
Fixes Calendar validation regression to display appropriate error message based on the number of dates selected.

i.e. You must select 3 days. Please select 1 more day to continue. 

The error messages use a combination of validatorjs + some logic within the Form page to add additional information about the # of dates selected.

validatorjs uses true/false to determine an error an expects a string back for the message so there isn't a way to customize based on a condition.  I was going to add some additional validators for different counts but adding the logic into the Form seems to be the cleaner option.

