### PR TITLE
Fix accuracy of the Paper File Number helper text on the form page

### DIFF
--- a/web/locale/en/messages.json
+++ b/web/locale/en/messages.json
@@ -734,7 +734,7 @@
       ]
     ]
   },
-  "This number is at the top of the email we sent you.": {
+  "This number is at the top of the email attachment we sent you.": {
     "translation": "",
     "origin": [
       [

--- a/web/locale/fr/messages.json
+++ b/web/locale/fr/messages.json
@@ -734,8 +734,8 @@
       ]
     ]
   },
-  "This number is at the top of the email we sent you.": {
-    "translation": "Il s’agit du numéro qui est affiché en haut du courriel que nous vous avons envoyé.",
+  "This number is at the top of the email attachment we sent you.": {
+    "translation": "Il s’agit du numéro qui est affiché en haut du fichier que nous vous avons envoyé par courriel.",
     "origin": [
       [
         "src/pages/RegistrationPage.js",

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -284,7 +284,7 @@ class RegistrationPage extends React.Component {
                       />
                       <span id="paperFileNumber-details">
                         <Trans>
-                          This number is at the top of the email we sent you.
+                          This number is at the top of the email attachment we sent you.
                         </Trans>
                       </span>
                     </label>


### PR DESCRIPTION
Trello: https://trello.com/c/ncgirHyW/234-fix-accuracy-of-the-paper-file-number-helper-text-on-the-form-page-xs 

This PR updates the descriptive text for the "Paper file number" field for accuracy.

English: `This number is at the top of the email attachment we sent you.`
French: `Il s'agit du numéro qui est affiché en haut du email pièce jointe que nous vous avons envoyé.`

Merge only once translation is confirmed (cc @anikbrazeau) ✅ **Translation confirmed**