### PR TITLE
Bottom button text never breaks across lines

### DIFF
--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -230,18 +230,34 @@ export const BottomContainer = styled.div`
     margin-left: ${theme.spacing.xxxl};
   }
 
-  ${mediaQuery.xs(css`
+  ${mediaQuery.lg(css`
+    > div {
+      margin-left: ${theme.spacing.xxl};
+    }
+  `)};
+
+  ${mediaQuery.md(css`
+    align-items: flex-start;
+    flex-direction: column;
+
+    > div {
+      margin-left: ${theme.spacing.lg};
+      margin-top: ${theme.spacing.xl};
+    }
+  `)};
+
+  ${mediaQuery.sm(css`
+    align-items: center;
     text-align: center;
     flex-direction: column;
 
-    > a,
+    > form,
     > div {
       width: 100%;
     }
 
     > div {
       margin-left: 0;
-      margin-top: ${theme.spacing.xl};
     }
   `)};
 `


### PR DESCRIPTION
@emanelfy noticed that our "send request →" and "cancel request" button text would break across lines for some screen sizes. 

Did some CSS changes so that the line breaks earlier. There are other ways to solve this (fixed widths, non-breaking spaces, etc), but this seemed easy enough. Tested on the french version of the review page since that one has the largest amount of button text.

| before | after |
|--------|-------|
|  words break across lines 👎    |  words never break across lines 👍   |
| ![buttons-2](https://user-images.githubusercontent.com/2454380/42887188-5afede58-8a73-11e8-92fd-418ec96c7ccd.gif) |  ![buttons](https://user-images.githubusercontent.com/2454380/42887167-4e94c22c-8a73-11e8-85c7-dc1f3d8b5b2a.gif)  |





