### PR TITLE
Add aria-level to month name

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -48,7 +48,7 @@
     "razzle": "^2.1.0",
     "react": "16.3.1",
     "react-apollo": "^2.1.2",
-    "react-day-picker": "^7.1.4",
+    "react-day-picker": "^7.1.10",
     "react-dom": "^16.4.0",
     "react-emotion": "^9.2.3",
     "react-final-form": "^3.6.4",

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -10,7 +10,12 @@ import { theme, mediaQuery, incrementColor, focusRing } from '../styles'
 import Cancel from '../assets/cancel.svg'
 import MobileCancel from '../assets/mobileCancel.svg'
 import { getDateInfo } from '../utils/linguiUtils'
-import { getStartMonth, toMonth, getStartDate } from '../utils/calendarDates'
+import {
+  getStartMonth,
+  toMonth,
+  getMonthNameAndYear,
+  getStartDate,
+} from '../utils/calendarDates'
 import parse from 'date-fns/parse'
 
 const dayPickerDefault = css`
@@ -484,6 +489,19 @@ const renderDayBoxes = ({
   return dayBoxes
 }
 
+const renderMonthName = ({ date, locale }) => {
+  return (
+    <div className="DayPicker-Caption" role="heading" aria-level="3">
+      <div>{getMonthNameAndYear(date, locale)}</div>
+    </div>
+  )
+}
+
+renderMonthName.propTypes = {
+  date: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
+}
+
 class Calendar extends Component {
   constructor(props) {
     super(props)
@@ -584,6 +602,7 @@ class Calendar extends Component {
           className={css`
             ${dayPickerDefault} ${dayPicker};
           `}
+          captionElement={renderMonthName}
           locale={locale}
           months={dateInfo.months}
           weekdaysLong={dateInfo.weekdaysLong}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7529,9 +7529,9 @@ react-apollo@^2.1.2:
     lodash "^4.17.10"
     prop-types "^15.6.0"
 
-react-day-picker@^7.1.4:
-  version "7.1.9"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.1.9.tgz#04b0d956faf1bf85bb6ec6f9ca7966433be13f36"
+react-day-picker@^7.1.10:
+  version "7.1.10"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.1.10.tgz#c763b1acb141ce960e25654b7033c2207f0fc1c3"
   dependencies:
     prop-types "^15.6.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,13 +212,6 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-cors@^2.8.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
-  dependencies:
-    object-assign "^4"
-    vary "^1"
-
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -751,10 +744,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -1212,10 +1201,6 @@ validate-glob-opts@^0.2.1:
   resolved "https://registry.yarnpkg.com/validate-glob-opts/-/validate-glob-opts-0.2.1.tgz#4ffa23ea096db0381f28edbf5c283fa40fb75b07"
   dependencies:
     is-plain-obj "^1.1.0"
-
-vary@^1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 whereis@^0.4.0:
   version "0.4.1"


### PR DESCRIPTION
- Adds aria-level attribute to the Calendar Month Name
- Upgraded react-day-picker to the latest version ``` "react-day-picker": "^7.1.10" ```

<img width="503" alt="aria-level" src="https://user-images.githubusercontent.com/62242/42889530-aea6093c-8a78-11e8-8d98-6b208025d8db.png">
