### PR TITLE
Calendar day date aria-label

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Trans, withI18n } from 'lingui-react'
 import FieldAdapterPropTypes from './_Field'
-import DayPicker, { DateUtils } from 'react-day-picker'
+import DayPicker, { DateUtils, LocaleUtils } from 'react-day-picker'
 import { css } from 'emotion'
 import Time, { makeGMTDate, dateToHTMLString } from './Time'
 import ErrorMessage from './ErrorMessage'
@@ -489,6 +489,11 @@ const renderDayBoxes = ({
   return dayBoxes
 }
 
+// format aria-label for Day cell
+const formatDay = (day, locale) => {
+  return dateToHTMLString(day, locale)
+}
+
 const renderMonthName = ({ date, locale }) => {
   return (
     <div className="DayPicker-Caption" role="heading" aria-level="3">
@@ -602,6 +607,7 @@ class Calendar extends Component {
           className={css`
             ${dayPickerDefault} ${dayPicker};
           `}
+          localeUtils={{ ...LocaleUtils, formatDay }}
           captionElement={renderMonthName}
           locale={locale}
           months={dateInfo.months}


### PR DESCRIPTION
Updates aria-label for calendar day cell to be consistent with date formatting used throughout the app.  Also handles translation.

Keep existing functionality for Day cell untouched.

# Before
<img width="767" alt="prev" src="https://user-images.githubusercontent.com/62242/42898370-f123694a-8a90-11e8-838d-a964f17d169b.png">

# After

## EN
<img width="747" alt="label-en" src="https://user-images.githubusercontent.com/62242/42898264-a7ad915a-8a90-11e8-9433-6a08957f13cd.png">

## FR
<img width="795" alt="label-fr" src="https://user-images.githubusercontent.com/62242/42898268-a9356f98-8a90-11e8-85ea-6187bb3864d2.png">



