### PR TITLE
Beta Colour Contrast 

### DIFF
--- a/web/src/components/PhaseBanner.js
+++ b/web/src/components/PhaseBanner.js
@@ -15,7 +15,7 @@ const badge = css`
 
 const beta = css`
   ${badge};
-  background-color: #22a7f0;
+  background-color: #006de4;
   height: 1.3rem;
   padding: 0.2rem ${theme.spacing.sm} 0.2rem ${theme.spacing.sm};
 `


### PR DESCRIPTION
# This PR Consists of:

## Updating Beta Badge Color

| Before | After |
|--------|-------|
|    <img width="601" alt="screen shot 2018-07-18 at 13 59 06" src="https://user-images.githubusercontent.com/30609058/42899008-c58662fe-8a92-11e8-91f3-83121d348e52.png"> |   <img width="594" alt="screen shot 2018-07-18 at 13 58 00" src="https://user-images.githubusercontent.com/30609058/42899009-c59a049e-8a92-11e8-9a44-5da7ef909e0e.png">   |

- The old color was failing AA and AAA accessibility standards
- The new color meets both AA and AAA accessibility standards