### PR TITLE
Move Raven script load + install out of bundle to document

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,6 @@
     "moment": "2.22.0",
     "nodemailer": "^4.6.7",
     "prop-types": "^15.6.1",
-    "raven-js": "^3.25.2",
     "razzle": "^2.1.0",
     "react": "16.3.1",
     "react-apollo": "^2.1.2",

--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -31,6 +31,21 @@ class Document extends React.Component {
         <body {...bodyAttrs}>
           <AfterRoot />
           <AfterData data={data} />
+          {process.env.NODE_ENV === 'production' && (
+            <script
+              src="https://cdn.ravenjs.com/3.26.2/raven.min.js"
+              crossorigin="anonymous"
+            />
+          )}
+
+          {process.env.NODE_ENV === 'production' && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616').install()`,
+              }}
+            />
+          )}
+
           <script
             type="text/javascript"
             src={assets.client.js}

--- a/web/src/client.js
+++ b/web/src/client.js
@@ -5,14 +5,6 @@ import { BrowserRouter } from 'react-router-dom'
 import { ensureReady, After } from '@jaredpalmer/after'
 import routes from './routes'
 
-import Raven from 'raven-js'
-if (window) {
-  window.Raven = Raven
-  window.Raven.config(
-    'https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616',
-  ).install()
-}
-
 ensureReady(routes).then(data =>
   hydrate(
     <BrowserRouter>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7435,10 +7435,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.25.2:
-  version "3.26.3"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.3.tgz#0efb49969b5b11ab965f7b0d6da4ca102b763cb0"
-
 raw-body@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"


### PR DESCRIPTION
This moves out sentry logging out of the client bundle and into the html document.

Previously if there was a bundle failure tracking would fail as it was built into the bundle itself.

## Before
![image](https://user-images.githubusercontent.com/62242/42963990-cbb94412-8b63-11e8-9fe5-4ecb60f0f176.png)

<hr>

## After
With Raven moved out of the bundle errors are now tracked.



<img width="642" alt="screen shot 2018-07-19 at 2 57 04 pm" src="https://user-images.githubusercontent.com/62242/42964109-1921c206-8b64-11e8-81a7-43a01787f93c.png">


credit @Amirroracle for testing :+1:
