### PR TITLE
Add sourcemaps for sentry logging

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",
     "@jaredpalmer/after": "^1.3.1",
+    "@sentry/webpack-plugin": "^1.5.2",
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.1",

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -25,6 +25,19 @@ module.exports = {
         }),
       )
     }
+    if (process.env.RAZZLE_SENTRY_API) {
+      const SentryPlugin = require('@sentry/webpack-plugin')
+      config.plugins.push(
+        new SentryPlugin({
+          organization: 'canadian-digital-service',
+          project: 'ircc-rescheduler',
+          release: 'a2315885b9c3429a918336c1324afa4a',
+          include: '.',
+          ignore: ['node_modules', 'webpack.config.js'],
+          apiKey: process.env.RAZZLE_SENTRY_API,
+        }),
+      )
+    }
     return config
   },
 }

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -17,9 +17,21 @@ import {
   sendMail,
 } from './email/sendmail'
 import Raven from 'raven'
-Raven.config(
-  'https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616',
-).install()
+Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {
+  dataCallback: function(data) {
+    var stacktrace = data.exception && data.exception[0].stacktrace
+
+    if (stacktrace && stacktrace.frames) {
+      stacktrace.frames.forEach(function(frame) {
+        if (frame.filename.startsWith('/')) {
+          frame.filename = 'app:///' + path.basename(frame.filename)
+        }
+      })
+    }
+
+    return data
+  },
+}).install()
 
 // eslint-disable-next-line security/detect-non-literal-require
 const assets = require(process.env.RAZZLE_ASSETS_MANIFEST ||

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -171,6 +171,21 @@
     react-router-dom "^4.2.2"
     serialize-javascript "^1.5.0"
 
+"@sentry/cli@^1.30.2":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.34.0.tgz#81aa5e8239efde11148bec5474b08329c36be32a"
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    node-fetch "^2.1.2"
+    progress "2.0.0"
+    proxy-from-env "^1.0.0"
+
+"@sentry/webpack-plugin@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.5.2.tgz#c1f66afb919b8881b1b1ab7363939978ee662ce2"
+  dependencies:
+    "@sentry/cli" "^1.30.2"
+
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -6339,6 +6354,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -7267,7 +7286,7 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-progress@^2.0.0:
+progress@2.0.0, progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 


### PR DESCRIPTION
Use the sentry webpack plugin to update our artifacts in sentry with the proper sourcemaps.

Notes to keep in mind:
-Running this requires an api key with ```project:write selected under scopes.``` under the sentry ui when you generate one. 
https://docs.sentry.io/clients/javascript/sourcemaps/
-The api key is an environment variable



