### PR TITLE
Set up the sentry logging for source maps

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,12 +12,14 @@
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
     "add-locale": "lingui add-locale",
-    "stats": "BUNDLE_CHECK=true yarn build"
+    "stats": "BUNDLE_CHECK=true yarn build",
+    "push-source-map": "sentry-cli releases  -o canadian-digital-service -p ircc-rescheduler files  RAZZLE_STAGE  upload-sourcemaps ../build/"
   },
   "dependencies": {
     "@cdssnc/gcui": "^0.0.30",
     "@jaredpalmer/after": "^1.3.1",
     "aws-sdk": "^2.279.1",
+    "@sentry/cli": "^1.34.0",
     "body-parser": "^1.18.3",
     "cookie-encrypter": "^1.0.1",
     "cookie-parser": "^1.4.3",

--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -25,19 +25,19 @@ module.exports = {
         }),
       )
     }
-    if (process.env.RAZZLE_SENTRY_API) {
+    /* if (process.env.RAZZLE_SENTRY_API) {
       const SentryPlugin = require('@sentry/webpack-plugin')
       config.plugins.push(
         new SentryPlugin({
           organization: 'canadian-digital-service',
           project: 'ircc-rescheduler',
-          release: 'a2315885b9c3429a918336c1324afa4a',
+          release: 'process.env.RAZZLE_SENTRY_STAGE',
           include: '.',
           ignore: ['node_modules', 'webpack.config.js'],
           apiKey: process.env.RAZZLE_SENTRY_API,
         }),
       )
-    }
+    }*/
     return config
   },
 }

--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -69,7 +69,9 @@ class Document extends React.Component {
           {process.env.NODE_ENV === 'production' && (
             <script
               dangerouslySetInnerHTML={{
-                __html: `Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616').install()`,
+                __html: `Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {release: ${
+                  process.env.RAZZLE_STAGE
+                }}).install()`,
               }}
             />
           )}

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -31,6 +31,7 @@ Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {
 
     return data
   },
+  release: process.env.RAZZLE_STAGE,
 }).install()
 
 // eslint-disable-next-line security/detect-non-literal-require

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -171,6 +171,15 @@
     react-router-dom "^4.2.2"
     serialize-javascript "^1.5.0"
 
+"@sentry/cli@^1.34.0":
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.34.0.tgz#81aa5e8239efde11148bec5474b08329c36be32a"
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    node-fetch "^2.1.2"
+    progress "2.0.0"
+    proxy-from-env "^1.0.0"
+
 "@types/node@*":
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
@@ -6035,6 +6044,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
@@ -6932,7 +6945,7 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
-progress@^2.0.0:
+progress@2.0.0, progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 


### PR DESCRIPTION
In this PR:
-Proper release definitions mapped by environment variables added in ```Document.js``` and ```Server.js```.
-Add sentry cli command that will enable artifact deployment to sentry.
-Cli command still needs to be added to the build deployment scripts.
