### PR TITLE
Hide chevrons from screenreaders

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -457,7 +457,7 @@ const renderDayBoxes = ({
             )}`}
           >
             <div className={removeDate}>
-              <img src={MobileCancel} alt={removeDayAltText} />
+              <img src={MobileCancel} alt="" />
             </div>
           </button>
         </li>

--- a/web/src/components/Chevron.js
+++ b/web/src/components/Chevron.js
@@ -12,6 +12,7 @@ const Chevron = ({ width = 8, height = 8, dir = 'right' }) => {
       transform={flip}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 9.42 15.62"
+      aria-hidden="true"
     >
       <g>
         <path d="M6.63,7.81,1,.5H3.17L8.79,7.81,3.17,15.12H1.05Z" />

--- a/web/src/components/Chevron.js
+++ b/web/src/components/Chevron.js
@@ -2,14 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const Chevron = ({ width = 8, height = 8, dir = 'right' }) => {
-  const flip = dir === 'right' ? '' : 'scale(-2, 2) translate(0,-1)'
+  const flip =
+    dir === 'right' ? {} : { transform: 'scale(-2, 2) translate(0px, -1px)' }
 
   return (
     <svg
       width={height}
       height={width}
-      style={{ display: 'inline-block', marginRight: '5px' }}
-      transform={flip}
+      style={{ display: 'inline-block', marginRight: '5px', ...flip }}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 9.42 15.62"
       aria-hidden="true"

--- a/web/src/components/Layout.js
+++ b/web/src/components/Layout.js
@@ -39,6 +39,7 @@ injectGlobal`
     line-height: 1.4;
   }
 
+  a,
   a:visited {
     color: ${theme.colour.link};
   }

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -371,7 +371,7 @@ describe('renderDayBoxes', () => {
 
     let imgs = button.find('img')
     expect(imgs.length).toBe(1)
-    expect(imgs.at(0).props().alt).toEqual('Remove day')
+    expect(imgs.at(0).props().alt).toEqual('')
   })
 
   it('renders days in french', () => {
@@ -394,6 +394,6 @@ describe('renderDayBoxes', () => {
 
     let imgs = button.find('img')
     expect(imgs.length).toBe(1)
-    expect(imgs.at(0).props().alt).toEqual('Supprimer cette journée')
+    expect(imgs.at(0).props().alt).toEqual('')
   })
 })


### PR DESCRIPTION
## This PR

- hides chevrons from screenreaders (explicitly, so that accessibility tests are happy)
- fixes layout bug in Safari and IE11
- sets default link colour (before we were relying on browser defaults)
- removes alt-text from "remove day" `imgs` since the ANDI accessibility scan is flagging that as a potential issue

## Screenshots

### Safari 

| before | after |
|--------|-------|
| ![screen shot 2018-07-30 at 2 21 42 pm](https://user-images.githubusercontent.com/2454380/43416251-c30383be-9405-11e8-890e-f00fc698f341.png)  | ![screen shot 2018-07-30 at 2 21 55 pm](https://user-images.githubusercontent.com/2454380/43416252-c406edc8-9405-11e8-9ad9-3ed8e09b7746.png) |

### IE 11

| before | after | after after |
|--------|-------|-------------|
| <img width="847" alt="screen shot 2018-07-30 at 2 46 08 pm" src="https://user-images.githubusercontent.com/2454380/43416813-57414006-9407-11e8-81a5-35d01f9e0efc.png">  | <img width="838" alt="screen shot 2018-07-30 at 2 44 26 pm" src="https://user-images.githubusercontent.com/2454380/43416817-58ee90a2-9407-11e8-89f0-5f107d9776dd.png">  |  <img width="844" alt="screen shot 2018-07-30 at 2 37 05 pm" src="https://user-images.githubusercontent.com/2454380/43416814-582efe68-9407-11e8-9f98-4a915e0a14ad.png">  |





