### PR TITLE
Shorten cookie expiration to a day

### DIFF
--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -1,7 +1,7 @@
 import cookieEncrypter from 'cookie-encrypter'
 
 const inTenMinutes = () => new Date(new Date().getTime() + 10 * 60 * 1000)
-const inOneWeek = () => new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000)
+const inOneDay = () => new Date(new Date().getTime() + 1 * 24 * 60 * 60 * 1000)
 
 export const SECRET =
   process.env.RAZZLE_COOKIE_SECRET ||
@@ -16,7 +16,7 @@ export const setStoreCookie = (setCookieFunc, cookie, options = {}) => {
     secure:
       !process.env.RAZZLE_COOKIE_HTTP && process.env.NODE_ENV === 'production',
     expires:
-      process.env.NODE_ENV === 'production' ? inOneWeek() : inTenMinutes(),
+      process.env.NODE_ENV === 'production' ? inOneDay() : inTenMinutes(),
   }
 
   setCookieFunc('store', cookie, { ...defaults, ...options })


### PR DESCRIPTION
Since values are being saved for a week, but our calendar updates every day, you can get into a state where:
- you select the first available dates
- you come back nearly a week later and you have dates selected that are greyed-out on the calendar

Shortening cookies to 1 day will resolve the bulk of these problems for us.