### PR TITLE
Calendar Max 3 days error.

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -662,10 +662,16 @@ class Calendar extends Component {
     )
   }
 }
+
+Calendar.defaultProps = {
+  forceRender: () => {}, //used to for a parent re-render after clicking on a day
+}
+
 Calendar.propTypes = {
   ...FieldAdapterPropTypes,
   dayLimit: PropTypes.number.isRequired,
-  forceRender: PropTypes.function,
+  forceRender: PropTypes.func,
 }
+
 const CalendarAdapter = withI18n()(Calendar)
 export { CalendarAdapter as default, renderDayBoxes }

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -566,10 +566,14 @@ class Calendar extends Component {
     }
 
     this.props.input.value = selectedDays
+
     this.props.input.onChange(this.props.input.value)
+
     await this.setState({
       errorMessage: null,
     })
+
+    this.props.forceRender()
   }
 
   render() {
@@ -661,6 +665,7 @@ class Calendar extends Component {
 Calendar.propTypes = {
   ...FieldAdapterPropTypes,
   dayLimit: PropTypes.number.isRequired,
+  forceRender: PropTypes.function,
 }
 const CalendarAdapter = withI18n()(Calendar)
 export { CalendarAdapter as default, renderDayBoxes }

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -151,6 +151,11 @@ class CalendarPage extends Component {
     super(props)
     this.onSubmit = this.onSubmit.bind(this)
     this.validate = CalendarPage.validate
+    this.forceRender = this.forceRender.bind(this)
+  }
+
+  forceRender() {
+    this.forceUpdate()
   }
 
   async onSubmit(values, event) {
@@ -256,8 +261,15 @@ class CalendarPage extends Component {
                     name="selectedDays"
                     id="selectedDays"
                     tabIndex={-1}
-                    component={CalendarAdapter}
-                    dayLimit={DAY_LIMIT}
+                    render={({ input }) => {
+                      return (
+                        <CalendarAdapter
+                          forceRender={this.forceRender}
+                          input={input}
+                          dayLimit={DAY_LIMIT}
+                        />
+                      )
+                    }}
                   />
                 </div>
                 <CalBottom

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -261,15 +261,9 @@ class CalendarPage extends Component {
                     name="selectedDays"
                     id="selectedDays"
                     tabIndex={-1}
-                    render={({ input }) => {
-                      return (
-                        <CalendarAdapter
-                          forceRender={this.forceRender}
-                          input={input}
-                          dayLimit={DAY_LIMIT}
-                        />
-                      )
-                    }}
+                    component={CalendarAdapter}
+                    dayLimit={DAY_LIMIT}
+                    forceRender={this.forceRender}
                   />
                 </div>
                 <CalBottom


### PR DESCRIPTION
This update fixes the issue where the calendar error for max three days was one click behind if you had already submitted the form and we're seeing the you must select 3 days warning.

As noted here https://github.com/cds-snc/ircc-rescheduler/pull/283#issuecomment-407166015


