### PR TITLE
Clean up PhaseBanner test

### DIFF
--- a/web/src/components/__tests__/PhaseBanner.test.js
+++ b/web/src/components/__tests__/PhaseBanner.test.js
@@ -3,12 +3,6 @@ import { mount } from 'enzyme'
 import PhaseBanner from '../PhaseBanner'
 
 describe('<PhaseBanner />', () => {
-  it('will not render with ONLY children...Console error prompt to specify phase= ', () => {
-    const phaseBanner = mount(<PhaseBanner>contact us</PhaseBanner>)
-    expect(phaseBanner.find('span').at(1).length).toBe(0)
-    expect(phaseBanner.find('span').at(2).length).toBe(0)
-  })
-
   it('will render an alpha badge + children', () => {
     const phaseBanner = mount(
       <PhaseBanner phase="alpha"> this is an alpha banner.</PhaseBanner>,
@@ -45,11 +39,29 @@ describe('<PhaseBanner />', () => {
     ).toMatch(/this is a beta banner./)
   })
 
-  it('will not render with invalid phase, Error Message will prompt for valid phase value', () => {
+  it('will not render a badge if invalid phase submitted, will log error message', () => {
+    const mockFn = jest.fn()
+    console.error = mockFn // eslint-disable-line no-console
     const phaseBanner = mount(
       <PhaseBanner phase="omega">This is an omega banner</PhaseBanner>,
     )
     expect(phaseBanner.find('span').at(1).length).toBe(0)
     expect(phaseBanner.find('span').at(2).length).toBe(0)
+    // first argument of call to console.error
+    expect(mockFn.mock.calls[0][0]).toMatch(
+      "Warning: Failed prop type: Invalid phase 'omega', try 'alpha' or 'beta'",
+    )
+  })
+
+  it('will not render a badge if no phase submitted, will log error message', () => {
+    const mockFn = jest.fn()
+    console.error = mockFn // eslint-disable-line no-console
+    const phaseBanner = mount(<PhaseBanner>contact us</PhaseBanner>)
+    expect(phaseBanner.find('span').at(1).length).toBe(0)
+    expect(phaseBanner.find('span').at(2).length).toBe(0)
+    // first argument of call to console.error
+    expect(mockFn.mock.calls[0][0]).toMatch(
+      "Warning: Failed prop type: Please specify whether your project is in 'alpha' or 'beta'",
+    )
   })
 })


### PR DESCRIPTION
Stops printing out the console.error message in the console, but it _does_ test that the right error message is being logged.

The tests still pass as they did before, they're just a bit nicer now.

| before | after |
|--------|-------|
|  ![test-1](https://user-images.githubusercontent.com/2454380/43426817-1497068c-9425-11e8-8277-9356df6a701e.gif)  | ![test-2](https://user-images.githubusercontent.com/2454380/43426816-14895410-9425-11e8-8bcb-af169235c472.gif) |