### PR TITLE
Rewrite ambiguous "Contact" language in the confirmation email

### DIFF
--- a/web/email_templates/applicant-plain.html
+++ b/web/email_templates/applicant-plain.html
@@ -10,7 +10,7 @@ ${datesPlain}
 What's next?
 Your local IRCC office will send you a new appointment, or email you to ask for more information.
 
-Contact
+If you have any questions, please contact:
 IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
 1-888-242-2100
 
@@ -26,6 +26,6 @@ ${datesPlainFR}
 Quelles sont les étapes suivantes?
 Votre bureau local d’IRCC vous enverra les détails de votre nouveau rendez-vous ou communiquera avec vous par courriel pour vous demander des renseignements supplémentaires.
 
-Coordonnées
+Si vous avez des questions, communiquez avec:
 IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
 1-888-242-2100

--- a/web/email_templates/applicant-rich.html
+++ b/web/email_templates/applicant-rich.html
@@ -44,7 +44,7 @@
     <h3>What's next?</h3>
     <p>Your local IRCC office will send you a new appointment, or email you to ask for more information.</p>
 
-    <h3>Contact</h3>
+    <h3>If you have any questions, please contact:</h3>
     <p>IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca</p>
     <p>1-888-242-2100</p>
 
@@ -57,7 +57,7 @@
     </div>
     <h3>Quelles sont les étapes suivantes?</h3>
     <p>Votre bureau local d’IRCC vous enverra les détails de votre nouveau rendez-vous ou communiquera <br />avec vous par courriel pour vous demander des renseignements supplémentaires.</p>
-    <h3>Coordonnées</h3>
+    <h3>Si vous avez des questions, communiquez avec:</h3>
     <p>IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca</p>
     <p>1-888-242-2100</p>
 


### PR DESCRIPTION
Trello card: https://trello.com/c/sO78JfXh/255-rewrite-ambiguous-contact-language-in-the-confirmation-email-and-confirmation-page-etc

This PR addresses an issue discovered in testing: that some users are reading the "Contact" language in the email as a direction, not a resource if they need it. 

New copy fixes that (French has been updated as well, as the changes duplicate existing content)