### PR TITLE
Update review days to show sorted dates selected

### DIFF
--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -11,6 +11,8 @@ import Chevron from '../components/Chevron'
 import Summary from '../components/Summary'
 import Reminder from '../components/Reminder'
 import SubmissionForm from '../components/SubmissionForm'
+import { sortSelectedDays } from '../utils/calendarDates'
+import { dateToISODateString } from '../components/Time'
 
 const contentClass = css`
   p {
@@ -64,6 +66,12 @@ class ReviewPage extends React.Component {
 
     const { sending } = this.state
 
+    const days = sortSelectedDays(
+      selectedDays.map(day => {
+        return new Date(dateToISODateString(day))
+      }),
+    )
+
     return (
       <Layout contentClass={contentClass}>
         <Title path={this.props.match.path} />
@@ -84,7 +92,7 @@ class ReviewPage extends React.Component {
             paperFileNumber={paperFileNumber}
             explanation={explanation}
             reason={this.translateReason(reason)}
-            selectedDays={selectedDays}
+            selectedDays={days}
           />
           <Reminder>
             <Trans>


### PR DESCRIPTION
This fixes the sort order of the dates on the Review Page. 

Previously this page would display dates in the order that the user selected the dates.

**Note:**
Ultimately it would be nice to have a single function to handle this for all the possible output (Calendar, Review Page + Email).  Maybe updating sortSelectedDays to check if the items in the array are dates already.  Would need to determine what each page / component is looking for.