### PR TITLE
Listen for "accept-language" browser header

### DIFF
--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -227,6 +227,14 @@ describe('WithProvider', () => {
         expect(result).toEqual({ field: 'value' })
       })
 
+      it('returns trimmed string values when validation passes trimmed value', () => {
+        let result = WithProvider.validateCookie('page', { field: ' value ' })
+        expect(result).toEqual({ field: 'value' })
+
+        let result2 = WithProvider.validateCookie('page', { field: 'value   ' })
+        expect(result2).toEqual({ field: 'value' })
+      })
+
       let invalidVals = [0, false, {}, ['value'], null, '', 'value']
       invalidVals.map(v => {
         it(`throws error for regular field with a non-empty object value: ${v}`, () => {

--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -109,6 +109,70 @@ describe('WithProvider', () => {
     })
   })
 
+  describe('.getDefaultLanguageFromHeader()', () => {
+    const WithProvider = withProvider(FakeComponentEmpty)
+
+    let emptyHeaders = [undefined, false, null, '', {}]
+    emptyHeaders.map(v => {
+      it(`returns false when an empty header is passed in: ${v}`, () => {
+        expect(WithProvider.getDefaultLanguageFromHeader(v)).toBe(false)
+      })
+    })
+
+    let nonMatchingHeaders = [
+      { 'accept-encoding': 'gzip, deflate' },
+      { accept: 'text/html' },
+      // in express, they all come through as lower-case, so we aren't matching this
+      { 'Accept-Language': 'en' },
+    ]
+    nonMatchingHeaders.map(v => {
+      it(`returns false when header passed in without 'accept-language': ${JSON.stringify(
+        v,
+      )}`, () => {
+        expect(WithProvider.getDefaultLanguageFromHeader(v)).toBe(false)
+      })
+    })
+
+    let nonMatchingLanguages = [
+      { 'accept-language': 'de' },
+      { 'accept-language': 'es-MX,es,en;' },
+      { 'accept-language': 'zh,en;q=0.9,fr;q=0.8' },
+    ]
+    nonMatchingLanguages.map(v => {
+      it(`returns false when 'accept-language' header passed in that doesn't start with "en" or "fr"': ${
+        v['accept-language']
+      }`, () => {
+        expect(WithProvider.getDefaultLanguageFromHeader(v)).toBe(false)
+      })
+    })
+
+    let enLanguages = [
+      { 'accept-language': 'en' },
+      { 'accept-language': 'en-CA,en-US,en' },
+      { 'accept-language': 'en-US,en;q=0.9,fr;q=0.8' },
+    ]
+    enLanguages.map(v => {
+      it(`returns "en" when 'accept-language' header passed in that starts with "en"': ${
+        v['accept-language']
+      }`, () => {
+        expect(WithProvider.getDefaultLanguageFromHeader(v)).toBe('en')
+      })
+    })
+
+    let frLanguages = [
+      { 'accept-language': 'fr' },
+      { 'accept-language': 'fr-CA,fr-FR,fr' },
+      { 'accept-language': 'fr-CA,fr;q=0.9,en;q=0.6' },
+    ]
+    frLanguages.map(v => {
+      it(`returns "fr" when 'accept-language' header passed in that starts with "fr"': ${
+        v['accept-language']
+      }`, () => {
+        expect(WithProvider.getDefaultLanguageFromHeader(v)).toBe('fr')
+      })
+    })
+  })
+
   describe('.validateQuery()', () => {
     const EmptyWithProvider = withProvider(FakeComponentEmpty)
     const WithProviderFields = withProvider(FakeComponentWithFields)

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -46,6 +46,15 @@ function withProvider(WrappedComponent) {
         }
       }
 
+      // if no cookies exist, check for default accept-language header
+      if (!newCookie && !prevCookie) {
+        let language = WithProvider.getDefaultLanguageFromHeader(req.headers)
+        // if default language found, set a new cookie
+        newCookie = language
+          ? setSSRCookie(res, 'language', language, prevCookie)
+          : newCookie
+      }
+
       let initStore = newCookie || prevCookie || contextDefault.store
 
       return {
@@ -144,6 +153,18 @@ function withProvider(WrappedComponent) {
       // match.path === "/about" or similar
       let key = match.path.slice(1)
       return { key, val: query }
+    }
+
+    static getDefaultLanguageFromHeader(headers) {
+      if (headers && headers['accept-language']) {
+        // grab the first two characters
+        let val = headers['accept-language'].slice(0, 2)
+        let errors = WithProvider.validate({ language: val })
+
+        return !Object.keys(errors).length ? val : false
+      }
+
+      return false
     }
 
     static validateCookie(key, val = null) {


### PR DESCRIPTION
If someone explicitly sets a default language, or passes in a "language" query parameter, we save that to a cookie.

However, when they come to our site for the first time:
- they won't have any cookies
- they probably aren't passing in a query param
- they may have a language setting in their browser

So that's the case we want to check.

If there are no cookies and their "Accept-Language" header (comes through as lowercase in express) starts with either "en", or "fr", then we'll pick a default language for them.

Note that it is possible someone will have a header like:
- `"es,en-US,en"`
- `"zh, fr-CA, en"`

In both of those cases, the string "fr" or "en" exists in their accept-language header, but it's not being picked up.

Since I doubt that that is happening to us, I am opting for simpler logic and not handling that case.

Also wrote a bunch of tests to check for various possible header values.