### PR TITLE
Track language toggle

### DIFF
--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -12,6 +12,8 @@ import {
   focusRing,
 } from '../styles'
 
+import { logEvent } from '../utils/analytics'
+
 const button = css`
   ${focusRing};
   display: inline-block;
@@ -79,9 +81,11 @@ class LanguageSwitcher extends React.Component {
           className={button}
           onClick={e => {
             e.preventDefault()
-            this.setState({ language: this.getNewLanguage() }, () =>
+            const lang = this.getNewLanguage()
+            this.setState({ language: lang }, () =>
               setStore('language', this.state.language),
             )
+            logEvent('Navigation', 'Toggle Language', lang)
           }}
         >
           <span className={visuallyhiddenMobile}>

--- a/web/src/components/Layout.js
+++ b/web/src/components/Layout.js
@@ -76,7 +76,7 @@ injectGlobal`
 class Layout extends React.Component {
   componentDidMount() {
     if (process.env.NODE_ENV === 'production' && process.env.RAZZLE_GA_ID) {
-      if (!window.GA_INITIALIZED) {
+      if (window && !window.GA_INITIALIZED) {
         initGA(process.env.RAZZLE_GA_ID)
         window.GA_INITIALIZED = true
       }

--- a/web/src/utils/analytics.js
+++ b/web/src/utils/analytics.js
@@ -1,19 +1,20 @@
 import ReactGA from 'react-ga'
+import { windowExists } from '../utils/windowExists'
 
 export const initGA = ga_id => {
   ReactGA.initialize(ga_id)
 }
 
 export const logPageView = () => {
-  // eslint-disable-next-line no-console
-  console.log(`Logging pageview for ${window.location.pathname}`)
   ReactGA.set({ page: window.location.pathname })
   ReactGA.pageview(window.location.pathname)
 }
 
-export const logEvent = (category = '', action = '') => {
-  if (category && action) {
-    ReactGA.event({ category, action })
+export const logEvent = (category = '', action = '', label = '') => {
+  if (!windowExists() || !window.GA_INITIALIZED) return
+
+  if (category && action && label) {
+    ReactGA.event({ category, action, label })
   }
 }
 


### PR DESCRIPTION
Sends Google Analytics event to track when users click the language toggle link.

Adds a label parameter to the logEvent function so we can track value

i.e. logEvent('Navigation', 'Toggle Language', 'FR')

Also added a few checks for window as Razzle was complaining.  Likely a timing issue.

<img width="914" alt="screen shot 2018-08-01 at 2 58 25 pm" src="https://user-images.githubusercontent.com/62242/43542988-917ed652-959c-11e8-8eac-7811150241e1.png">
