### PR TITLE
Remove forceRender call until bug is fixed

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -571,7 +571,7 @@ class Calendar extends Component {
       errorMessage: null,
     })
 
-    this.props.forceRender()
+    //this.props.forceRender()
   }
 
   render() {


### PR DESCRIPTION
When returning to the calendar that already has 3 selected days, the calendar does not allow days to be unselected.

I haven't properly debugged the problem but this would revert it back to how it was before https://github.com/cds-snc/ircc-rescheduler/pull/302

# gif

![bug](https://user-images.githubusercontent.com/2454380/43586649-261194a0-9636-11e8-869d-73db3a1d61b3.gif)


