### PR TITLE
Change the type of source map for prod and stg

### DIFF
--- a/web/razzle.config.js
+++ b/web/razzle.config.js
@@ -4,6 +4,12 @@ module.exports = {
     if (config.devServer) {
       config.devServer.host = '0.0.0.0'
     }
+    if (
+      process.env.RAZZLE_STAGE === 'production' ||
+      process.env.RAZZLE_STAGE === 'staging'
+    ) {
+      config.devtool = 'source-map'
+    }
     if (process.env.BUNDLE_CHECK) {
       /* This allows us to analyze the the webpack bundle of all our apis and imports. 
         You can change the analyzerMode to be 'server' and this may let you see more info like


### PR DESCRIPTION
Currently our source maps in sentry are not returning coherent enough errors, changing the type of source map that is defaulted with razzle to something readable like ```source-map``` should give us more information when debugging errors. 

This link has more information:
https://webpack.js.org/configuration/devtool/