### PR TITLE
Fixed Wordbreak on confirmation mobile screens

### DIFF
--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -43,8 +43,8 @@ const contact = css`
   }
 
   ${mediaQuery.xs(css`
-    a[id='email'],
-    a[id='telephone'] {
+    a#email,
+    a#telephone {
       display: block;
     }
     wbr {

--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -24,7 +24,7 @@ const telStyles = css`
 const TelLink = ({ tel }) => (
   <span className={telStyles}>
     <span>{tel}</span>
-    <a name="telephone" href={`tel:+${tel}`} rel="nofollow">
+    <a id="telephone" href={`tel:+${tel}`} rel="nofollow">
       {tel}
     </a>
   </span>
@@ -42,9 +42,9 @@ const contact = css`
     display: none;
   }
 
-  ${mediaQuery.sm(css`
-    a[name='email'],
-    a[name='telephone'] {
+  ${mediaQuery.xs(css`
+    a[id='email'],
+    a[id='telephone'] {
       display: block;
     }
     wbr {
@@ -63,7 +63,7 @@ const Contact = ({ children, phoneFirst = false }) => (
             <Trans>Email —</Trans>
           </strong>{' '}
           <a
-            name="email"
+            id="email"
             href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
           >
             IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC
@@ -91,7 +91,7 @@ const Contact = ({ children, phoneFirst = false }) => (
             <Trans>Email —</Trans>
           </strong>{' '}
           <a
-            name="email"
+            idea="email"
             href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
           >
             IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC

--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -24,7 +24,7 @@ const telStyles = css`
 const TelLink = ({ tel }) => (
   <span className={telStyles}>
     <span>{tel}</span>
-    <a href={`tel:+${tel}`} rel="nofollow">
+    <a name="telephone" href={`tel:+${tel}`} rel="nofollow">
       {tel}
     </a>
   </span>
@@ -35,23 +35,22 @@ TelLink.propTypes = {
 
 const contact = css`
   margin-bottom: ${theme.spacing.lg};
-
-  /* These are technically the same, but use both */
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-
-  -ms-word-break: break-all;
-  word-break: break-word;
-
-  /* Adds a hyphen where the word breaks, if supported (No Blink) */
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
-
   p:first-of-type {
     margin-bottom: ${theme.spacing.sm};
   }
+  wbr {
+    display: none;
+  }
+
+  ${mediaQuery.sm(css`
+    a[name='email'],
+    a[name='telephone'] {
+      display: block;
+    }
+    wbr {
+      display: inline;
+    }
+  `)};
 `
 
 const Contact = ({ children, phoneFirst = false }) => (
@@ -63,8 +62,13 @@ const Contact = ({ children, phoneFirst = false }) => (
           <strong>
             <Trans>Email —</Trans>
           </strong>{' '}
-          <a href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca">
-            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
+          <a
+            name="email"
+            href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
+          >
+            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC
+            <wbr />
+            @cic.gc.ca
           </a>
         </p>
         <p>
@@ -86,8 +90,13 @@ const Contact = ({ children, phoneFirst = false }) => (
           <strong>
             <Trans>Email —</Trans>
           </strong>{' '}
-          <a href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca">
-            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
+          <a
+            name="email"
+            href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
+          >
+            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC
+            <wbr />
+            @cic.gc.ca
           </a>
         </p>
       </React.Fragment>


### PR DESCRIPTION
# This PR consists of:

## Fixing the horrendous wordbreak on the confirmation page:

| Before | After |
|--------|-------|
|   <img width="250" alt="screen shot 2018-08-02 at 14 01 08" src="https://user-images.githubusercontent.com/30609058/43601981-a9ea4d50-965c-11e8-9fa6-ad250c204042.png">     |   <img width="244" alt="screen shot 2018-08-02 at 14 01 56" src="https://user-images.githubusercontent.com/30609058/43601980-a9d6ab06-965c-11e8-937e-2622506b5c5b.png">    |


(Merging this PR closes #319 )