### PR TITLE
Calendar Error Regression

### DIFF
--- a/web/cypress/integration/main/cal-change-unselect.spec.js.js
+++ b/web/cypress/integration/main/cal-change-unselect.spec.js.js
@@ -1,0 +1,48 @@
+/* When returning to the calendar that already has 3 selected days, 
+   the calendar does should allow days to be unselected. */
+
+/* See Bug: https://github.com/cds-snc/ircc-rescheduler/pull/318 */
+
+context('Calendar Dates unselect after review', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('should be able to select and unselect dates', () => {
+    cy.visit('/calendar')
+    cy.url().should('contain', '/calendar')
+    cy.get('.DayPicker-Day[aria-disabled=false]').then(el => {
+      const count = el.length
+      // make sure we're on a month that has 3 selectable days
+      if (count < 3) {
+        cy.get('.DayPicker-NavButton--next').click({ force: true })
+      }
+    })
+
+    // select 3 days
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(0)
+      .click({ force: true })
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(1)
+      .click({ force: true })
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(2)
+      .click({ force: true })
+
+    // submit the form
+    cy.get('#selectedDays-form').submit({ force: true })
+    cy.visit('/calendar')
+
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(1)
+      .click({ force: true })
+
+    // test unselecting a day should now be 2
+    cy.get('#selectedDays-list li .day-box:not(.empty)').then(el => {
+      const count = el.length
+      expect(count).eq(2)
+    })
+    //
+  })
+})

--- a/web/cypress/integration/main/cal-clear-show-errors.js
+++ b/web/cypress/integration/main/cal-clear-show-errors.js
@@ -1,0 +1,53 @@
+/* When submitting <3 days submitting than selecting too many days
+   errors should clear and show the appropriate message
+*/
+
+/* See Bug: https://github.com/cds-snc/ircc-rescheduler/pull/302 */
+
+context('Calendar Errors clear when selecting incorrect amount of days', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('should be able to select and unselect dates', () => {
+    cy.visit('/calendar')
+    cy.url().should('contain', '/calendar')
+    cy.get('.DayPicker-Day[aria-disabled=false]').then(el => {
+      const count = el.length
+      // make sure we're on a month that has 3 selectable days
+      if (count < 3) {
+        cy.get('.DayPicker-NavButton--next').click({ force: true })
+      }
+    })
+
+    // select 2 days
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(0)
+      .click({ force: true })
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(1)
+      .click({ force: true })
+
+    // submit the form
+    cy.get('#selectedDays-form').submit({ force: true })
+
+    // trigger the not enough days error
+    cy.get('#submit-error h2 span').should('contain', 'You must select 3 days.')
+
+    // try to select some more days
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(2)
+      .click({ force: true })
+
+    cy.get('.DayPicker-Day[aria-disabled=false]')
+      .eq(3)
+      .click({ force: true })
+
+    // this should trigger the too many days error
+    cy.get('#selectedDays-error h2 span')
+      .should('be.visible')
+      .should('contain', 'You can’t select more than 3 days.')
+
+    cy.get('#submit-error').should('not.be.visible')
+  })
+})

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -538,7 +538,6 @@ class Calendar extends Component {
 
     // !selected means that this current day is not marked as 'selected' on the calendar
     if (!selected) {
-      console.log('force render', selectedDays.length)
       // If we have already selected the maximum number of days,
       // add an error message to the internal state and then return early
       if (selectedDays.length >= dayLimit) {
@@ -572,7 +571,8 @@ class Calendar extends Component {
       errorMessage: null,
     })
 
-    this.props.forceRender()
+    // force a render to keep calendar errors in sync
+    this.props.forceRender(selectedDays)
   }
 
   render() {

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -538,6 +538,7 @@ class Calendar extends Component {
 
     // !selected means that this current day is not marked as 'selected' on the calendar
     if (!selected) {
+      console.log('force render', selectedDays.length)
       // If we have already selected the maximum number of days,
       // add an error message to the internal state and then return early
       if (selectedDays.length >= dayLimit) {
@@ -571,7 +572,7 @@ class Calendar extends Component {
       errorMessage: null,
     })
 
-    //this.props.forceRender()
+    this.props.forceRender()
   }
 
   render() {

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -152,10 +152,12 @@ class CalendarPage extends Component {
     this.onSubmit = this.onSubmit.bind(this)
     this.validate = CalendarPage.validate
     this.forceRender = this.forceRender.bind(this)
+    this.state = { calValues: [] }
   }
 
-  forceRender() {
-    this.forceUpdate()
+  forceRender(values) {
+    // call setState to force a render
+    this.setState({ calValues: values })
   }
 
   async onSubmit(values, event) {
@@ -196,12 +198,19 @@ class CalendarPage extends Component {
       }
     }
 
+    let calValues = calendar
+
+    // use values from state if this is a forced render
+    if (this.state.calValues.length) {
+      calValues.selectedDays = this.state.calValues
+    }
+
     return (
       <Layout>
         <CalHeader locale={locale} path={this.props.match.path} />
         <Form
           onSubmit={this.onSubmit}
-          initialValues={calendar}
+          initialValues={calValues}
           render={({
             handleSubmit,
             reset,
@@ -242,7 +251,11 @@ class CalendarPage extends Component {
             }
 
             return (
-              <form id="calendar-form" onSubmit={handleSubmit} className={fullWidth}>
+              <form
+                id="calendar-form"
+                onSubmit={handleSubmit}
+                className={fullWidth}
+              >
                 <div>
                   <div
                     id="submit-error"


### PR DESCRIPTION
Fixes issue where Calendar errors for too many days selected ends up behind by one click.

The previous fix for this used forced render which fixed the error issue but, created an issue where users could not unselect dates after they we're saved to the cookie.

In this version we're passing the selected stated back to the force render and than updating state (using either the saved or state for the Calendar initial values).

This allows the Calendar to do a full re-render while maintaing the correct dates.