### PR TITLE
Modify calendar available dates to be dynamic by month

### DIFF
--- a/web/cypress/integration/main/cal-clear-show-errors.js
+++ b/web/cypress/integration/main/cal-clear-show-errors.js
@@ -15,7 +15,7 @@ context('Calendar Errors clear when selecting incorrect amount of days', () => {
     cy.get('.DayPicker-Day[aria-disabled=false]').then(el => {
       const count = el.length
       // make sure we're on a month that has 3 selectable days
-      if (count < 3) {
+      if (count < 4) {
         cy.get('.DayPicker-NavButton--next').click({ force: true })
       }
     })

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -11,7 +11,7 @@ import MobileCancel from '../assets/mobileCancel.svg'
 import { getDateInfo } from '../utils/linguiUtils'
 import {
   getStartMonth,
-  toMonth,
+  getEndDate,
   getMonthNameAndYear,
   getStartDate,
   getInitialMonth,
@@ -587,17 +587,21 @@ class Calendar extends Component {
     const dateInfo = getDateInfo(i18n)
     const locale = i18n !== undefined ? i18n._language : 'en'
     const startMonth = parse(getStartMonth())
-    const endDate = parse(toMonth())
+    const endDate = parse(getEndDate())
     value = value || []
 
     const initialMonth = getInitialMonth(value, startMonth)
 
-    let dayOfWeek1, dayOfWeek2
-    ;[dayOfWeek1, dayOfWeek2] = this.state.daysOfWeek
+    /* 
+    We need the highlighted day of the week to be dynamic 
+    as the month changes
+    */
+
+    let [dayOfWeek1 = undefined, dayOfWeek2 = undefined] = this.state.daysOfWeek
       ? this.state.daysOfWeek
       : getDaysOfWeekForLocation(undefined, initialMonth)
 
-    const styles = css`
+    const weekdayStyles = css`
       ${dayPickerDefault};
 
       .DayPicker-Weekday:nth-of-type(${dayOfWeek1}),
@@ -628,7 +632,7 @@ class Calendar extends Component {
         >
           <DayPicker
             className={css`
-              ${styles} ${dayPicker};
+              ${weekdayStyles} ${dayPicker};
             `}
             localeUtils={{ ...LocaleUtils, formatDay }}
             captionElement={renderMonthName}
@@ -693,8 +697,8 @@ class Calendar extends Component {
 }
 
 Calendar.defaultProps = {
-  forceRender: () => {},
-  changeMonth: () => {}, //used to for a parent re-render after clicking on a day
+  forceRender: () => {}, //used to for a parent re-render after clicking on a day
+  changeMonth: () => {},
 }
 
 Calendar.propTypes = {

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -256,11 +256,6 @@ const dayPickerDefault = css`
   }
 `
 
-const dayPicker = css`
-  .DayPicker-Month {
-  }
-`
-
 const noDates = css`
   display: none;
 `

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -632,7 +632,7 @@ class Calendar extends Component {
         >
           <DayPicker
             className={css`
-              ${weekdayStyles} ${dayPicker};
+              ${weekdayStyles};
             `}
             localeUtils={{ ...LocaleUtils, formatDay }}
             captionElement={renderMonthName}

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -1,8 +1,5 @@
 import React, { Component } from 'react'
 import format from 'date-fns/format'
-import eachDay from 'date-fns/each_day'
-import isWednesday from 'date-fns/is_wednesday'
-import isThursday from 'date-fns/is_thursday'
 import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 import { Checkbox } from '../components/forms/MultipleChoice'
@@ -12,6 +9,7 @@ import {
   getStartDate,
   getEndDate,
   getMonthNameAndYear,
+  getValidDays,
 } from '../utils/calendarDates'
 
 const calList = css`
@@ -62,43 +60,40 @@ const isValidDateString = (props, propName, componentName) => {
 }
 
 const Calendar = ({ startDate, endDate, dates, locale }) => {
-  const days = eachDay(startDate, endDate)
+  //const days = eachDay(startDate, endDate)
+  const days = getValidDays(startDate, endDate)
   const mapped = {}
 
   days.forEach((date, index) => {
-    const validDay = isWednesday(date) || isThursday(date)
+    const monthName = getMonthNameAndYear(date, locale)
+    const idMonth = format(date, 'MM')
+    const val = dateToISODateString(date)
+    const checked = dates.includes(val)
 
-    if (validDay) {
-      const monthName = getMonthNameAndYear(date, locale)
-      const idMonth = format(date, 'MM')
-      const val = dateToISODateString(date)
-      const checked = dates.includes(val)
+    const el = (
+      <li key={val}>
+        <Checkbox
+          name="selectedDays"
+          id={`selectedDays-${idMonth}-${index}`}
+          value={val}
+          label={
+            <Time
+              date={date}
+              locale={locale}
+              options={{ weekday: 'long', day: 'numeric', month: 'long' }}
+            />
+          }
+          onChange={() => {}}
+          checked={checked}
+        />
+      </li>
+    )
 
-      const el = (
-        <li key={val}>
-          <Checkbox
-            name="selectedDays"
-            id={`selectedDays-${idMonth}-${index}`}
-            value={val}
-            label={
-              <Time
-                date={date}
-                locale={locale}
-                options={{ weekday: 'long', day: 'numeric', month: 'long' }}
-              />
-            }
-            onChange={() => {}}
-            checked={checked}
-          />
-        </li>
-      )
-
-      // eslint-disable-next-line security/detect-object-injection
-      let vals = mapped[monthName] || []
-      vals.push(el)
-      // eslint-disable-next-line security/detect-object-injection
-      mapped[monthName] = vals
-    }
+    // eslint-disable-next-line security/detect-object-injection
+    let vals = mapped[monthName] || []
+    vals.push(el)
+    // eslint-disable-next-line security/detect-object-injection
+    mapped[monthName] = vals
   })
 
   /*eslint-disable */

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -60,8 +60,7 @@ const isValidDateString = (props, propName, componentName) => {
 }
 
 const Calendar = ({ startDate, endDate, dates, locale }) => {
-  //const days = eachDay(startDate, endDate)
-  const days = getValidDays(startDate, endDate)
+  const days = getValidDays(undefined, startDate, endDate)
   const mapped = {}
 
   days.forEach((date, index) => {

--- a/web/src/components/CalendarNoJS.js
+++ b/web/src/components/CalendarNoJS.js
@@ -6,10 +6,8 @@ import { Checkbox } from '../components/forms/MultipleChoice'
 import PropTypes from 'prop-types'
 import Time, { dateToISODateString } from './Time'
 import {
-  getStartDate,
-  getEndDate,
   getMonthNameAndYear,
-  getValidDays,
+  getEnabledDays,
 } from '../utils/calendarDates'
 
 const calList = css`
@@ -36,31 +34,8 @@ const column = css`
   }
 `
 
-const isValidDate = (
-  date,
-  propName = 'startDate',
-  componentName = 'CalendarNoJS',
-) => {
-  const regEx = /^\d{4}-\d{2}-\d{2}$/
-
-  return regEx.test(date)
-}
-
-const isValidDateString = (props, propName, componentName) => {
-  if (!isValidDate(props['startDate'], propName, componentName)) {
-    return new Error(
-      'Invalid prop `' +
-        propName +
-        '` supplied to' +
-        ' `' +
-        componentName +
-        '`. Validation failed.',
-    )
-  }
-}
-
-const Calendar = ({ startDate, endDate, dates, locale }) => {
-  const days = getValidDays(undefined, startDate, endDate)
+const Calendar = ({ dates, locale }) => {
+  const days = getEnabledDays()
   const mapped = {}
 
   days.forEach((date, index) => {
@@ -114,8 +89,6 @@ const Calendar = ({ startDate, endDate, dates, locale }) => {
 }
 
 Calendar.propTypes = {
-  startDate: isValidDateString,
-  endDate: isValidDateString,
   dates: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   locale: PropTypes.string,
 }
@@ -125,14 +98,9 @@ Calendar.propTypes = {
 class CalendarNoJs extends Component {
   render() {
     const { dates, locale } = this.props
-    const startDate = dateToISODateString(getStartDate())
-    const endDate = dateToISODateString(getEndDate())
-
     return (
       <Calendar
         dates={dates && dates.selectedDays ? dates.selectedDays : []}
-        startDate={startDate}
-        endDate={endDate}
         locale={locale}
       />
     )

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -5,7 +5,8 @@ import {
   getMonthNameAndYear,
   getStartMonth,
   getStartDate,
-  getValidDays,
+  getDisabledDays,
+  getEnabledDays,
   getEndDate,
 } from '../../utils/calendarDates'
 
@@ -87,7 +88,7 @@ const useMonth = dates => {
 const calDays = (date = new Date()) => {
   const startDate = parse(getStartDate(date))
   const endDate = parse(getEndDate(date))
-  return useMonth(getValidDays(undefined, startDate, endDate))
+  return useMonth(getEnabledDays(undefined, startDate, endDate))
 }
 
 describe('<CalendarAdapter />', () => {

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -5,7 +5,6 @@ import {
   getMonthNameAndYear,
   getStartMonth,
   getStartDate,
-  getDisabledDays,
   getEnabledDays,
   getEndDate,
 } from '../../utils/calendarDates'

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -87,7 +87,7 @@ const useMonth = dates => {
 const calDays = (date = new Date()) => {
   const startDate = parse(getStartDate(date))
   const endDate = parse(getEndDate(date))
-  return useMonth(getValidDays(startDate, endDate))
+  return useMonth(getValidDays(undefined, startDate, endDate))
 }
 
 describe('<CalendarAdapter />', () => {

--- a/web/src/locations/vancouver.js
+++ b/web/src/locations/vancouver.js
@@ -8,5 +8,6 @@ export const vancouver = {
     sep: ['wed', 'thurs'],
     oct: ['tues', 'wed'],
     nov: ['tues', 'wed'],
+    dec: ['tues', 'wed'],
   },
 }

--- a/web/src/locations/vancouver.js
+++ b/web/src/locations/vancouver.js
@@ -1,0 +1,12 @@
+export const vancouver = {
+  email: 'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
+  phone: '1-888-242-2100',
+  recurring: {
+    jun: ['wed', 'thurs'],
+    jul: ['wed', 'thurs'],
+    aug: ['wed', 'thurs'],
+    sep: ['wed', 'thurs'],
+    oct: ['tues', 'thurs'],
+    nov: ['mon', 'fri'],
+  },
+}

--- a/web/src/locations/vancouver.js
+++ b/web/src/locations/vancouver.js
@@ -6,7 +6,7 @@ export const vancouver = {
     jul: ['wed', 'thurs'],
     aug: ['wed', 'thurs'],
     sep: ['wed', 'thurs'],
-    oct: ['tues', 'thurs'],
-    nov: ['mon', 'fri'],
+    oct: ['tues', 'wed'],
+    nov: ['tues', 'wed'],
   },
 }

--- a/web/src/utils/__tests__/calendarDates.test.js
+++ b/web/src/utils/__tests__/calendarDates.test.js
@@ -7,6 +7,8 @@ import {
   respondByDate,
   getMonthNameAndYear,
   getInitialMonth,
+  checkLocationDays,
+  getDaysOfWeekForLocation,
 } from '../calendarDates'
 
 describe('Utilities functions CalendarDates.js', () => {
@@ -37,7 +39,7 @@ describe('Utilities functions CalendarDates.js', () => {
 
   it('gets to month', () => {
     const today = new Date('September 05, 2018')
-    expect(toMonth(today)).toEqual('2018-12-05')
+    expect(toMonth(today)).toEqual('2018-12-11')
   })
 
   it('gets confirmation date', () => {
@@ -83,5 +85,40 @@ describe('Utilities functions CalendarDates.js', () => {
     const selected = new Date('Sunday, November 3, 1957')
     const result = getInitialMonth([selected], today)
     expect(result).toEqual(today)
+  })
+
+  it('gets valid days for location', () => {
+    const location = {
+      recurring: {
+        sep: ['wed', 'thurs', 'fri'],
+        oct: ['tues', 'thurs'],
+        nov: ['mon', 'fri'],
+      },
+    }
+
+    const date2 = checkLocationDays(
+      location,
+      'sep',
+      new Date('Monday, September 3, 2018'),
+    )
+
+    expect(date2.valid).toEqual(false)
+  })
+
+  it('gets days of week for location', () => {
+    const location = {
+      recurring: {
+        sep: ['wed', 'thurs', 'fri'],
+        oct: ['tues', 'thurs'],
+        nov: ['mon', 'fri'],
+      },
+    }
+
+    const result = getDaysOfWeekForLocation(
+      location,
+      new Date('Monday, September 3, 2018'),
+    )
+
+    expect(result).toEqual([4, 5, 6])
   })
 })

--- a/web/src/utils/__tests__/calendarDates.test.js
+++ b/web/src/utils/__tests__/calendarDates.test.js
@@ -2,7 +2,6 @@ import {
   getStartDate,
   getEndDate,
   getStartMonth,
-  toMonth,
   yearMonthDay,
   respondByDate,
   getMonthNameAndYear,
@@ -35,11 +34,6 @@ describe('Utilities functions CalendarDates.js', () => {
   it('gets start month', () => {
     const today = new Date('September 05, 2018')
     expect(yearMonthDay(getStartMonth(today))).toEqual('2018-10-01')
-  })
-
-  it('gets to month', () => {
-    const today = new Date('September 05, 2018')
-    expect(toMonth(today)).toEqual('2018-12-11')
   })
 
   it('gets confirmation date', () => {

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -45,8 +45,7 @@ export const getEndDate = (today = new Date()) => {
 }
 
 export const getStartMonth = (today = new Date()) => {
-  const baseDate = parse(getStartDate(today))
-  return startOfMonth(firstValidDay(undefined, baseDate))
+  return startOfMonth(parse(getStartDate(today)))
 }
 
 export const getInitialMonth = (selectedDates, startMonth) => {

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -129,7 +129,19 @@ export const getDaysOfWeekForLocation = (
   return []
 }
 
-export const getValidDays = (
+export const getDisabledDays = (location = vancouver, date = new Date()) => {
+  const startDate = parse(getStartDate(date))
+  const endDate = parse(getEndDate(date))
+  return getAllowedDays(location, startDate, endDate, true)
+}
+
+export const getEnabledDays = (location = vancouver, date = new Date()) => {
+  const startDate = parse(getStartDate(date))
+  const endDate = parse(getEndDate(date))
+  return getAllowedDays(location, startDate, endDate)
+}
+
+const getAllowedDays = (
   location = vancouver,
   startDate,
   endDate,
@@ -228,12 +240,6 @@ export const dayFromDayNumber = num => {
     default:
       return false
   }
-}
-
-export const getDisabledDays = (date = new Date()) => {
-  const startDate = parse(getStartDate(date))
-  const endDate = parse(getEndDate(date))
-  return getValidDays(undefined, startDate, endDate, true)
 }
 
 export const sortSelectedDays = selectedDays => {

--- a/web/src/utils/gitHash.js
+++ b/web/src/utils/gitHash.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line security/detect-child-process
 const { execSync } = require('child_process')
 
 export default () => {

--- a/web/src/utils/url.js
+++ b/web/src/utils/url.js
@@ -4,6 +4,7 @@ const getQueryStringParams = query => {
         .split('&')
         .reduce((params, param) => {
           let [key, value] = param.split('=')
+          // eslint-disable-next-line security/detect-object-injection
           params[key] = value
             ? decodeURIComponent(value.replace(/\+/g, ' '))
             : ''

--- a/web/test/server.test.js
+++ b/web/test/server.test.js
@@ -20,7 +20,7 @@ describe('Server Side Rendering', () => {
 
   it('renders the calendar page at /calendar', async () => {
     let response = await request(server).get('/calendar')
-    expect(response.text).toMatch(/Citizenship appointments are scheduled on/)
+    expect(response.text).toMatch(/Make sure you stay available on all of the days you select/)
   })
 
   it('renders the review page at /review', async () => {


### PR DESCRIPTION
This update moves to an initial location based setup.

Appointment day availability is now based on an object with a recurring property.

Days available are grouped by month.

Example:
```
const vancouver = {
  email: 'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
  phone: '1-888-242-2100',
  recurring: {
    jun: ['wed', 'thurs'],
    jul: ['wed', 'thurs'],
    aug: ['wed', 'thurs'],
    sep: ['wed', 'thurs'],
    oct: ['tues', 'thurs'],
    nov: ['mon', 'fri'],
  },
}

```

Calendar day highlighting and Calendar page note about what days appointments can be scheduled on is now also dynamic.

Note: Translations have not been exported yet.