### PR TITLE
Reset error messages when a validate passes

### DIFF
--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -122,7 +122,8 @@ class RegistrationPage extends React.Component {
       )
 
       if (validate.passes()) {
-        return {}
+        RegistrationPage.errStrings = {}
+        return RegistrationPage.errStrings
       }
 
       RegistrationPage.errStrings = getFieldErrorStrings(validate)


### PR DESCRIPTION
If a user triggered an error message at some point while
entering data, that error message would be saved to local state
and never be reset.

In practice, this meant that users would not be able to save
correct values once the invalid error message had been triggered.

In practice, this was the error:
- if a user entered a bad paper file number and pressed "submit",
  they would see a validation message
- once they corrected the mistake, they would progress through
  to the review page
- on the review page, they would see that their value was not
  saved
- if they clicked "change" they would still not be able to save
  a new paper file number

This is bad news, but resetting the error messages solves this issue.