### PR TITLE
Add tests that include tripping validation errors

### DIFF
--- a/web/cypress/fixtures/user.json
+++ b/web/cypress/fixtures/user.json
@@ -3,5 +3,6 @@
 "fullName": "Leanne Graham",
 "email": "cdc@example.com",
 "paperFileNumber": "123456",
+"reason": "workOrSchool",
 "explanation": "On business trip!"
 }

--- a/web/cypress/integration/main/validation-error-query-params.spec.js
+++ b/web/cypress/integration/main/validation-error-query-params.spec.js
@@ -1,0 +1,79 @@
+context(
+  'Full Run-through using only query parameters including validation errors',
+  () => {
+    // hardcoding the days since we're not validating on correct dates
+    let selectedDays = {
+      '2018-01-01': 'Monday, January 1, 2018',
+      '2018-01-02': 'Tuesday, January 2, 2018',
+      '2018-01-03': 'Wednesday, January 3, 2018',
+    }
+
+    it('should be able to trigger validation errors, recover, and reach the confirmation page with all of the submitted data', () => {
+      cy.visit('/')
+      cy.get('main a span').should('have.text', 'Start now')
+      cy.get('main a').click({ force: true })
+      cy.url().should('contain', '/register')
+
+      cy.fixture('user').then(data => {
+        // no query parameter value set for email or paper file number
+        cy.visit(
+          `/register?fullName=${data.fullName}&email=&paperFileNumber=&reason=${
+            data.reason
+          }&explanation=${data.explanation}`,
+        )
+      })
+
+      cy.get('#submit-error h2 span').should(
+        'contain',
+        'Some information is missing.',
+      )
+      cy.get('#submit-error ul li:first-of-type').should(
+        'contain',
+        'Email address',
+      )
+      cy.get('#submit-error ul li:last-of-type').should(
+        'contain',
+        'Paper file number',
+      )
+
+      cy.fixture('user').then(data => {
+        cy.visit(
+          `/register?fullName=${data.fullName}&email=${
+            data.email
+          }&paperFileNumber=${data.paperFileNumber}&reason=${
+            data.reason
+          }&explanation=${data.explanation}`,
+        )
+      })
+
+      cy.url().should('contain', '/calendar')
+
+      const queryParamReducer = (accumulator, currentValue) =>
+        `${accumulator}selectedDays=${currentValue}&`
+
+      const calendarQueryString = Object.keys(selectedDays).reduce(
+        queryParamReducer,
+        '/calendar?',
+      )
+      // the calendar will accept any 3 days, as long as they are formatted correctly
+      cy.visit(calendarQueryString)
+
+      cy.url().should('contain', '/review')
+
+      cy.fixture('user').then(data => {
+        cy.get('main').should('contain', data.fullName)
+        cy.get('main').should('contain', data.email)
+        cy.get('main').should('contain', data.paperFileNumber)
+        cy.get('main').should('contain', data.explanation)
+        Object.values(selectedDays).map(val =>
+          cy.get('main').should('contain', val),
+        )
+      })
+
+      cy.get('#review-form').submit({ force: true })
+
+      // should hit the confirm page now
+      cy.url().should('contain', '/confirmation')
+    })
+  },
+)

--- a/web/cypress/integration/main/validation-error.spec.js
+++ b/web/cypress/integration/main/validation-error.spec.js
@@ -1,0 +1,82 @@
+context('Full Run-through including validation errors', () => {
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  it('should be able to trigger validation errors, recover, and reach the confirmation page with all of the submitted data', () => {
+    cy.get('main a span').should('have.text', 'Start now')
+    cy.get('main a').click({ force: true })
+
+    cy.fixture('user').then(data => {
+      cy.get('#fullName').type(data.fullName, { force: true })
+      // don't enter email or paper file number
+      cy.get('#reason-2').click({ force: true })
+      cy.get('#explanation').type(data.explanation, { force: true })
+      cy.get('#register-form').submit({ force: true })
+    })
+
+    cy.get('#submit-error h2 span').should(
+      'contain',
+      'Some information is missing.',
+    )
+    cy.get('#submit-error ul li:first-of-type').should(
+      'contain',
+      'Email address',
+    )
+    cy.get('#submit-error ul li:last-of-type').should(
+      'contain',
+      'Paper file number',
+    )
+
+    cy.fixture('user').then(data => {
+      cy.get('#email').type(data.email, { force: true })
+      cy.get('#paperFileNumber').type(data.paperFileNumber, { force: true })
+      cy.get('#register-form').submit({ force: true })
+    })
+
+    cy.url().should('contain', '/calendar')
+
+    cy.get('.DayPicker-Day[aria-disabled=false]').then(el => {
+      const count = el.length
+
+      if (count < 3) {
+        cy.get('.DayPicker-NavButton--next').click({ force: true })
+      }
+
+      cy.get('.DayPicker-Day[aria-disabled=false]')
+        .eq(0)
+        .click({ force: true })
+      cy.get('.DayPicker-Day[aria-disabled=false]')
+        .eq(1)
+        .click({ force: true })
+
+      cy.get('#calendar-form').submit({ force: true })
+
+      // trigger the not enough days error
+      cy.get('#submit-error h2 span').should(
+        'contain',
+        'You must select 3 days.',
+      )
+
+      cy.get('.DayPicker-Day[aria-disabled=false]')
+        .eq(2)
+        .click({ force: true })
+
+      cy.get('#calendar-form').submit({ force: true })
+    })
+
+    cy.url().should('contain', '/review')
+
+    cy.fixture('user').then(data => {
+      cy.get('main').should('contain', data.fullName)
+      cy.get('main').should('contain', data.email)
+      cy.get('main').should('contain', data.paperFileNumber)
+      cy.get('main').should('contain', data.explanation)
+    })
+
+    cy.get('#review-form').submit({ force: true })
+
+    // should hit the confirm page now
+    cy.url().should('contain', '/confirmation')
+  })
+})


### PR DESCRIPTION
We recently had a problem where validation errors would cause values not be saved.

We've since released a fix for this, and these tests are confirming the correct behaviour.

It's not doing a lot of code reuse, so I can do some refactoring if needed.

## gif

![test-1](https://user-images.githubusercontent.com/2454380/43913302-b08729e6-9bd2-11e8-87c8-47dc922f0ee9.gif)
