### PR TITLE
Add unique url param for form submitted with data missing

### DIFF
--- a/web/cypress/integration/main/review-missing-data.spec.js
+++ b/web/cypress/integration/main/review-missing-data.spec.js
@@ -1,0 +1,34 @@
+context('Review Page with Missing Data', () => {
+  it('should be redirect to register page if data is missing', () => {
+    cy.visit('/review')
+    // submit with no data filled in
+    cy.get('#review-form').submit({ force: true })
+
+    // should hit the register page with a query param set
+    cy.url().should('contain', '/register?not-valid')
+  })
+
+  it('should be redirect to calendar page if data is missing', () => {
+    cy.visit('/register')
+
+    // fill in first page with data
+    cy.fixture('user').then(data => {
+      cy.get('#fullName').type(data.fullName, { force: true })
+      cy.get('#email').type(data.email, { force: true })
+      cy.get('#paperFileNumber').type(data.paperFileNumber, { force: true })
+      cy.get('#reason-2').click({ force: true })
+      cy.get('#explanation').type(data.explanation, { force: true })
+      cy.get('#register-form').submit({ force: true })
+    })
+
+    cy.url().should('contain', '/calendar')
+
+    // jump to the review page simulating reaching that page with missing calendar data
+    cy.visit('/review')
+    // submit with no data filled in
+    cy.get('#review-form').submit({ force: true })
+
+    // should hit the register page with a query param set
+    cy.url().should('contain', '/calendar?not-valid')
+  })
+})

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -72,11 +72,11 @@ server
     const validateCal = new Validator(input, CalendarFields)
 
     if (!validateReg.passes()) {
-      return res.redirect('/register')
+      return res.redirect('/register?not-valid=true')
     }
 
     if (!validateCal.passes()) {
-      return res.redirect('/calendar')
+      return res.redirect('/calendar?not-valid=true')
     }
 
     try {


### PR DESCRIPTION
When the form is submitted previously we could not tell when a redirect from missing data was happening.  This adds a not-valid=true to the redirect from the server to help surface issues faster in Google Analytics.

Also added end-to-end tests to ensure this functions as expected.