### PR TITLE
gitHash returns hash as variable rather than logging it

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -67,12 +67,14 @@ These options are set when running in production mode (`yarn start`), whether lo
 
 - `RAZZLE_GA_ID`: Our Google Analytics ID code. If left unset, the app won’t send pageviews to Google. Not generally needed during local development but can be turned on to test functionality.
 
+- `SENTRY_AUTH_TOKEN`: In order to upload our sourcemaps to sentry, we have to set an auth token. We upload source maps as part of deploys so that we can trace errors back to specific versions. This is not used once the app is running, so it doesn't use the `RAZZLE_` prefix.
 
 ##### sample `web/.env.production` file
 
 ```
 RAZZLE_COOKIE_SECRET='DONE_KEPT_IT_REAL_FROM_THE_JUMP_'
 RAZZLE_GA_ID='UA-111111111-1'
+SENTRY_AUTH_TOKEN='notARealAuthToken'
 ```
 
 ## How to use

--- a/web/src/utils/__tests__/cleanInput.test.js
+++ b/web/src/utils/__tests__/cleanInput.test.js
@@ -1,4 +1,4 @@
-import { trimInput, cleanArray } from '../../utils/cleanInput'
+import { trimInput, cleanArray } from '../cleanInput'
 
 describe('Clean inputs', () => {
   it('handles an object of strings with whitespace at the start', () => {

--- a/web/src/utils/__tests__/url.tests.js
+++ b/web/src/utils/__tests__/url.tests.js
@@ -1,4 +1,4 @@
-import { checkURLParams } from '../../utils/url'
+import { checkURLParams } from '../url'
 
 describe('Checks query params', () => {
   it("Will ignore params that don't exists in fields", () => {

--- a/web/src/utils/gitHash.js
+++ b/web/src/utils/gitHash.js
@@ -3,7 +3,7 @@ const { execSync } = require('child_process')
 export default () => {
   try {
     return execSync('git rev-parse --short HEAD', {
-      stdio: [process.stdin, process.stdout, null],
+      stdio: ['pipe', 'pipe', null],
     })
       .toString()
       .trim()


### PR DESCRIPTION
## Return hash value instead of logging it

By setting the returned value to `process.stdout`, it seems like the result of the execSync call was being logged to the screen while the value returned to the app was `000000`.

[The docs say that the default value is 'pipe'](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options), so I've reset the first two std values to 'pipe'

Note: I tried to write tests for this, but ran into two problems
1. I can't predict whether this will be run from a git repo or not, so I don't know what value to expect
2. I couldn't figure out how to get the logged hash from the original function while still in a test

I think it's okay as-is, but open to suggestions.