### PR TITLE
Remove cookie encryption

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -63,8 +63,6 @@ RAZZLE_COOKIE_HTTP=true
 
 These options are set when running in production mode (`yarn start`), whether locally or on the server.
 
-- `RAZZLE_COOKIE_SECRET`: A secret used to encrypt user data. Must be 32 characters long. If left unset, a default secret will be used (ie, for local development).
-
 - `RAZZLE_GA_ID`: Our Google Analytics ID code. If left unset, the app won’t send pageviews to Google. Not generally needed during local development but can be turned on to test functionality.
 
 - `SENTRY_AUTH_TOKEN`: In order to upload our sourcemaps to sentry, we have to set an auth token. We upload source maps as part of deploys so that we can trace errors back to specific versions. This is not used once the app is running, so it doesn't use the `RAZZLE_` prefix.
@@ -72,7 +70,6 @@ These options are set when running in production mode (`yarn start`), whether lo
 ##### sample `web/.env.production` file
 
 ```
-RAZZLE_COOKIE_SECRET='DONE_KEPT_IT_REAL_FROM_THE_JUMP_'
 RAZZLE_GA_ID='UA-111111111-1'
 SENTRY_AUTH_TOKEN='notARealAuthToken'
 ```

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,6 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-lingui-react": "^1.0.13",
     "body-parser": "^1.18.3",
-    "cookie-encrypter": "^1.0.1",
     "cookie-parser": "^1.4.3",
     "date-fns": "^1.29.0",
     "emotion": "^9.2.6",

--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -1,16 +1,8 @@
-import cookieEncrypter from 'cookie-encrypter'
-
 const inTenMinutes = () => new Date(new Date().getTime() + 10 * 60 * 1000)
 const inOneDay = () => new Date(new Date().getTime() + 1 * 24 * 60 * 60 * 1000)
 
-export const SECRET =
-  process.env.RAZZLE_COOKIE_SECRET ||
-  'Hey I just met you And this is crazy'.slice(0, 32)
-
 export const setStoreCookie = (setCookieFunc, cookie, options = {}) => {
-  cookie = cookieEncrypter.encryptCookie(JSON.stringify(cookie), {
-    key: SECRET,
-  })
+  cookie = JSON.stringify(cookie)
 
   let defaults = {
     secure:
@@ -26,16 +18,11 @@ export const getStoreCookie = (cookies, key) => {
   let cookie = cookies && cookies.store ? cookies.store : false
 
   if (cookie) {
-    /* Cookie will only be encryped when NODE_ENV is *not* 'development' */
     try {
-      cookie = JSON.parse(
-        cookieEncrypter.decryptCookie(cookie, { key: SECRET }),
-      )
+      cookie = JSON.parse(cookie)
     } catch (e) {
       return false
     }
-
-    /* console.log('found cookie! ', cookie) */
   }
   // eslint-disable-next-line security/detect-object-injection
   return cookie && key && cookie[key] ? cookie[key] : cookie
@@ -48,7 +35,6 @@ export const setSSRCookie = (res, key, val, prevCookie) => {
   // create new cookie by merging with previous values
   let cookie = { ...prevCookie, ...newCookie }
 
-  /* console.log('set cookie! ', cookie) */
   setStoreCookie(res.cookie.bind(res), cookie)
 
   return cookie

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -1,6 +1,6 @@
 import express from 'express'
 import cookieParser from 'cookie-parser'
-import { SECRET, getStoreCookie } from './cookies'
+import { getStoreCookie } from './cookies'
 import { render } from '@jaredpalmer/after'
 import { renderToString } from 'react-dom/server'
 import routes from './routes'
@@ -62,7 +62,7 @@ server
   .use(helmet.xssFilter()) // Sets "X-XSS-Protection: 1; mode=block".
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR || './public'))
-  .use(cookieParser(SECRET))
+  .use(cookieParser())
   .use(bodyParser.urlencoded({ extended: false }))
   .post('/submit', async (req, res) => {
     let input = Object.assign({}, req.body) // make a new object

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2394,10 +2394,6 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0,
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
-cookie-encrypter@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cookie-encrypter/-/cookie-encrypter-1.0.1.tgz#4e4555a9c8ebb5662d1662a57f861381cc4cd3aa"
-
 cookie-parser@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"


### PR DESCRIPTION
#  Remove cookie encryption
We don't need it.

- Cookies are only served to our rescheduler domain (means that other
  sites can't look at them).
- Our rescheduler domain only sends cookies over HTTPS, so the site
  traffic is encrypted end-to-end

There shouldn't be a way to actually get the content of the cookies
unless you're the person who entered the values in the first place.