### PR TITLE
Load Raven Async

### DIFF
--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -70,9 +70,17 @@ class Document extends React.Component {
             process.env.RAZZLE_STAGE && (
               <script
                 dangerouslySetInnerHTML={{
-                  __html: `Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {release: '${`${
-                    process.env.RAZZLE_STAGE
-                  }-${gitHashString}`}'}).install()`,
+                  __html: `window.SENTRY_SDK = {
+                    url: 'https://cdn.ravenjs.com/3.26.4/raven.min.js',
+                    dsn: 'https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616',
+                    options: {
+                      release: '${`${
+                        process.env.RAZZLE_STAGE
+                      }-${gitHashString}`}'
+                    }
+                  }
+                  ;(function(a,b,g,e,h){var k=a.SENTRY_SDK,f=function(a){f.data.push(a)};f.data=[];var l=a[e];a[e]=function(c,b,e,d,h){f({e:[].slice.call(arguments)});l&&l.apply(a,arguments)};var m=a[h];a[h]=function(c){f({p:c.reason});m&&m.apply(a,arguments)};var n=b.getElementsByTagName(g)[0];b=b.createElement(g);b.src=k.url;b.crossorigin="anonymous";b.addEventListener("load",function(){try{a[e]=l;a[h]=m;var c=f.data,b=a.Raven;b.config(k.dsn,k.options).install();var g=a[e];if(c.length)for(var d=0;d<c.length;d++)c[d].e?g.apply(b.TraceKit,c[d].e):c[d].p&&b.captureException(c[d].p)}catch(p){console.log(p)}});n.parentNode.insertBefore(b,n)})(window,document,"script","onerror","onunhandledrejection");
+                  `,
                 }}
               />
             )}


### PR DESCRIPTION
This update modifies the Raven install to make it load async

When recording load times in Google Chrome the initial costly events are caused by the Raven install.  It's preferable to offset the install in order to get to HTML parsing sooner.

By moving to async loading we can continue to capture error logs while boosting the amount of time it takes to get to the HTML parsing.

Details:
https://docs.sentry.io/clients/javascript/install/#async-loading

**Before**

Top events are all Raven
<img width="1007" alt="non-async" src="https://user-images.githubusercontent.com/62242/44041064-e0db206e-9eea-11e8-9026-51f24f834d0b.png">

**After**
JS spike is smaller + HTML Parse happens sooner
<img width="1141" alt="async" src="https://user-images.githubusercontent.com/62242/44041122-048cf4ba-9eeb-11e8-8303-1d194b4d01e4.png">

**Note:**
We should test with a known event that will cause an error / Sentry log


