### PR TITLE
Remove extra raven download

### DIFF
--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -59,12 +59,6 @@ class Document extends React.Component {
           ) : null}
           <AfterRoot />
           <AfterData data={data} />
-          {process.env.NODE_ENV === 'production' && (
-            <script
-              src="https://cdn.ravenjs.com/3.26.2/raven.min.js"
-              crossOrigin="anonymous"
-            />
-          )}
           {/* dangerouslySetInnerHTML is used here to avoid the markup being escaped by After.js */}
           {process.env.NODE_ENV === 'production' &&
             process.env.RAZZLE_STAGE && (


### PR DESCRIPTION
Since now we are loading Raven async, we no longer need to download Raven independently.

Fixes downloading Raven twice 👇 

<img width="771" alt="screen shot 2018-08-13 at 5 12 36 pm" src="https://user-images.githubusercontent.com/2454380/44058439-1c506c72-9f1c-11e8-8647-bdb54e186658.png">
