### PR TITLE
Fixed Calendar Bug + Updated Cypress test

### DIFF
--- a/web/cypress/integration/main/cal-clear-show-errors.js
+++ b/web/cypress/integration/main/cal-clear-show-errors.js
@@ -20,6 +20,12 @@ context('Calendar Errors clear when selecting incorrect amount of days', () => {
       }
     })
 
+    // submit the form with no dates
+    cy.get('#selectedDays-form').submit({ force: true })
+
+    // trigger the not enough days error
+    cy.get('#submit-error h2 span').should('contain', 'You must select 3 days.')
+
     // select 2 days
     cy.get('.DayPicker-Day[aria-disabled=false]')
       .eq(0)

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -155,6 +155,9 @@ class CalendarPage extends Component {
   }
 
   static validate(values) {
+    if (values.selectedDays === undefined) {
+      values.selectedDays = []
+    }
     const validate = new Validator(
       trimInput(values),
       CalendarFields,


### PR DESCRIPTION
## This PR consists of:

- We had fixed this earlier, but now it's showing a blank error message again, so added a test case that submits with no days selected and looks for the error message.

## Error Message was showing up blank when submitting calendar with no days selected

| Before | After |
|--------|-------|
|   ![screen shot 2018-08-13 at 12 13 01](https://user-images.githubusercontent.com/30609058/44045083-7f6e7834-9ef5-11e8-83d3-715bb0c8e65a.png)     |   ![screen shot 2018-08-13 at 12 13 04](https://user-images.githubusercontent.com/30609058/44045084-7f80680a-9ef5-11e8-8c25-68c26443d242.png)    |

## Updating the Cypress tests to reflect this use case
- test has been updated to support the no dates selected use case