### PR TITLE
Translation [Month] language toggle issue

### DIFF
--- a/web/cypress/integration/main/cal-introtext.spec.js.js
+++ b/web/cypress/integration/main/cal-introtext.spec.js.js
@@ -1,0 +1,16 @@
+/* When toggling the language the inrto text Month name should be in the correct language. */
+
+import { getStartMonthName } from '../../../src/utils/calendarDates'
+
+context('Calendar intro text', () => {
+  it('should show intro text in the correct language', () => {
+    cy.visit('/calendar')
+
+    cy.url().should('contain', '/calendar')
+    const monthEn = getStartMonthName(new Date(), 'en')
+    const monthFr = getStartMonthName(new Date(), 'fr')
+    cy.get('#calendar-intro').should('contain', `in ${monthEn}`)
+    cy.get('#language-toggle').click({ force: true })
+    cy.get('#calendar-intro').should('contain', `dans ${monthFr}`)
+  })
+})

--- a/web/src/__tests__/After.test.js
+++ b/web/src/__tests__/After.test.js
@@ -3,8 +3,6 @@ import MemoryRouter from 'react-router-dom/MemoryRouter'
 import { After } from '@jaredpalmer/after'
 import routes from '../routes'
 import { mount } from 'enzyme'
-// TODO: switch the project over to unfetch.
-import fetch from 'unfetch' // eslint-disable-line no-unused-vars
 
 describe('After.js', () => {
   it.skip('renders without exploding', () => {

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -110,7 +110,7 @@ const CalHeader = ({
       </CalendarHeader>
 
       {windowExists() && (
-        <CalendarSubheader>
+        <CalendarSubheader id="calendar-intro">
           <Trans>Citizenship appointments in</Trans> {headerMonth}{' '}
           <Trans>are scheduled on </Trans>
           {headerNote}.
@@ -178,11 +178,24 @@ class CalendarPage extends Component {
     this.forceRender = this.forceRender.bind(this)
     this.changeMonth = this.changeMonth.bind(this)
     this.initialMonth = this.initialMonth.bind(this)
-    this.state = { headerMonth: '', headerNote: [], calValues: false }
+    this.state = {
+      month: this.initialMonth(),
+      headerMonth: '',
+      headerNote: [],
+      calValues: false,
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.context.store.language !== prevProps.context.store.language
+    ) {
+      this.changeMonth()
+    }
   }
 
   componentDidMount() {
-    this.changeMonth(this.initialMonth())
+    this.changeMonth()
   }
 
   forceRender(values) {
@@ -207,10 +220,11 @@ class CalendarPage extends Component {
     return initialMonth
   }
 
-  changeMonth(month) {
+  changeMonth(month = this.state.month) {
     let {
       context: { store: { language: locale = 'en' } = {} } = {},
     } = this.props
+
     const days = getDaysOfWeekForLocation(undefined, month)
     const dayText = days.map((day, i) => {
       return (
@@ -225,7 +239,9 @@ class CalendarPage extends Component {
         </React.Fragment>
       )
     })
+
     this.setState({
+      month: month,
       headerMonth: getMonthName(month, locale),
       headerNote: dayText,
     })

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -292,7 +292,7 @@ export const getMonthNameAndYear = (date, locale = 'fr') => {
   return toLocale(format(parse(date), 'YYYY-MM-DD'), options, locale)
 }
 
-export const getMonthName = (date, locale = 'fr') => {
+export const getMonthName = (date = new Date(), locale = 'fr') => {
   const options = { month: 'long' }
   return toLocale(format(parse(date)), options, locale)
 }


### PR DESCRIPTION
When toggling the language the month name was not getting translated for the text Citizenship appointments in [MONTH] are scheduled on Tuesdays and Wednesdays.

If you used the next month button the issue corrects itself.

This update adds componentDidUpdate to check for a change in the locale prop.

Cypress tests have been added.