### PR TITLE
Use location object for email and phone across the app

### DIFF
--- a/web/email_templates/applicant-plain.html
+++ b/web/email_templates/applicant-plain.html
@@ -11,8 +11,8 @@ What happens next?
 IRCC will send you a new appointment. You will always be contacted at least 3 weeks before your appointment.
 
 If you have any questions, please contact:
-IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
-1-888-242-2100
+${email}
+${phone}
 
 ---
 
@@ -27,5 +27,5 @@ Quelles sont les étapes suivantes?
 IRCC vous enverra un nouveau rendez-vous. Nous communiquerons avec vous au moins 3 semaines avant votre rendez-vous.
 
 Si vous avez des questions, communiquez avec:
-IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca
-1-888-242-2100
+${email}
+${phone}

--- a/web/src/components/Contact.js
+++ b/web/src/components/Contact.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { css } from 'emotion'
 import { theme, mediaQuery } from '../styles'
 import { Trans } from 'lingui-react'
+import { getEmail, getEmailParts, getPhone } from '../locations/vancouver'
 
 const telStyles = css`
   > span {
@@ -62,20 +63,17 @@ const Contact = ({ children, phoneFirst = false }) => (
           <strong>
             <Trans>Email —</Trans>
           </strong>{' '}
-          <a
-            id="email"
-            href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
-          >
-            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC
+          <a id="email" href={`mailto:${getEmail()}`}>
+            {getEmailParts()[0]}
             <wbr />
-            @cic.gc.ca
+            @{getEmailParts()[1]}
           </a>
         </p>
         <p>
           <strong>
             <Trans>Phone —</Trans>
           </strong>{' '}
-          <TelLink tel="1-888-242-2100" />
+          <TelLink tel={getPhone()} />
         </p>
       </React.Fragment>
     ) : (
@@ -84,19 +82,16 @@ const Contact = ({ children, phoneFirst = false }) => (
           <strong>
             <Trans>Phone —</Trans>
           </strong>{' '}
-          <TelLink tel="1-888-242-2100" />
+          <TelLink tel={getPhone()} />
         </p>
         <p>
           <strong>
             <Trans>Email —</Trans>
           </strong>{' '}
-          <a
-            idea="email"
-            href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca"
-          >
-            IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC
+          <a idea="email" href={`mailto:${getEmail()}`}>
+            {getEmailParts()[0]}
             <wbr />
-            @cic.gc.ca
+            @{getEmailParts()[1]}
           </a>
         </p>
       </React.Fragment>

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -6,6 +6,7 @@ import { Trans, withI18n } from 'lingui-react'
 import CanadaWordmark from '../assets/CanadaWordmark.svg'
 import styled, { css } from 'react-emotion'
 import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
+import { getEmail } from '../locations/vancouver'
 
 const footer = css`
   background-color: ${theme.colour.white};
@@ -105,7 +106,7 @@ const Footer = ({ topBarBackground, i18n, context = {} }) => (
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
     <footer className={footer}>
       <div className={bottomLinks}>
-        <a href="mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca">
+        <a href={`mailto:${getEmail()}`}>
           <Trans>Contact</Trans>
         </a>
         <a href={i18n._('https://www.canada.ca/en/transparency/privacy.html')}>

--- a/web/src/components/__tests__/Contact.test.js
+++ b/web/src/components/__tests__/Contact.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import Contact, { TelLink } from '../Contact'
+import { getEmail } from '../../locations/vancouver'
 
 describe('<TelLink />', () => {
   it('renders span and an anchor link', () => {
@@ -41,12 +42,8 @@ describe('<Contact />', () => {
       .find('p')
       .at(0)
       .find('a')
-    expect(emailLink.text()).toEqual(
-      'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
-    )
-    expect(emailLink.props().href).toEqual(
-      'mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
-    )
+    expect(emailLink.text()).toEqual(getEmail())
+    expect(emailLink.props().href).toEqual(`mailto:${getEmail()}`)
 
     expect(
       wrapper
@@ -75,11 +72,7 @@ describe('<Contact />', () => {
       .at(1)
       .find('a')
 
-    expect(emailLink.text()).toEqual(
-      'IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
-    )
-    expect(emailLink.props().href).toEqual(
-      'mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
-    )
+    expect(emailLink.text()).toEqual(getEmail())
+    expect(emailLink.props().href).toEqual(`mailto:${getEmail()}`)
   })
 })

--- a/web/src/components/__tests__/Footer.test.js
+++ b/web/src/components/__tests__/Footer.test.js
@@ -3,6 +3,7 @@ import { mount, render } from 'enzyme'
 import { FooterBase as Footer } from '../Footer'
 import { getStore } from './LanguageSwitcher.test.js'
 import { i18n } from 'lingui-i18n/dist'
+import { getEmail } from '../../locations/vancouver'
 
 describe('<Footer />', () => {
   it('renders footer', () => {
@@ -28,9 +29,7 @@ describe('<Footer />', () => {
         .find('a')
         .first()
         .prop('href'),
-    ).toEqual(
-      'mailto:IRCC.DNCitVANNotification-NotificationVANCitRN.IRCC@cic.gc.ca',
-    )
+    ).toEqual(`mailto:${getEmail()}`)
   })
 
   it('renders "and Conditions" in English', () => {

--- a/web/src/email/email-template.js
+++ b/web/src/email/email-template.js
@@ -1,4 +1,5 @@
 import { respondByDate } from '../utils/calendarDates'
+import { getEmail, getPhone } from '../locations/vancouver'
 const inlineCss = require('inline-css')
 const fs = require('fs')
 const path = require('path')
@@ -127,6 +128,9 @@ export const buildParams = async options => {
     humanReadable(selectedDays, 'fr'),
     '\r\n',
   )
+
+  options.formValues.email = getEmail()
+  options.formValues.phone = getPhone()
 
   const markup = await new Promise(resolve => {
     renderMarkup(options).then(results => {

--- a/web/src/locations/vancouver.js
+++ b/web/src/locations/vancouver.js
@@ -11,3 +11,21 @@ export const vancouver = {
     dec: ['tues', 'wed'],
   },
 }
+
+export const getEmail = (location = vancouver) => {
+  if (location && location.email) {
+    return location.email
+  }
+}
+
+export const getEmailParts = (location = vancouver) => {
+  const email = getEmail(location)
+  let split = email.split('@')
+  return split
+}
+
+export const getPhone = (location = vancouver) => {
+  if (location && location.phone) {
+    return location.phone
+  }
+}


### PR DESCRIPTION
This updates moves from using hardcoded values for email and phone to use the location file / object.

For now a couple of utility methods (getEmail, getPhone) have been added to that file as well.  Those will get moved out once we determine how we're moving forward with other locations.