### PR TITLE
Add Sentry notification for missing data redirects

### DIFF
--- a/web/src/server.js
+++ b/web/src/server.js
@@ -72,10 +72,16 @@ server
     const validateCal = new Validator(input, CalendarFields)
 
     if (!validateReg.passes()) {
+      Raven.captureMessage('Missing Data - Register Page', {
+        level: 'info', // one of 'info', 'warning', or 'error'
+      })
       return res.redirect('/register?not-valid=true')
     }
 
     if (!validateCal.passes()) {
+      Raven.captureMessage('Missing Data - Calendar Page', {
+        level: 'info', // one of 'info', 'warning', or 'error'
+      })
       return res.redirect('/calendar?not-valid=true')
     }
 

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -55,6 +55,20 @@ const handleMailError = e => {
   }
 }
 
+const gatherFieldErrors = errObj => {
+  const errs = Object.keys(errObj).map(key => {
+    return key
+  })
+  return errs.join(', ')
+}
+
+const captureMessage = (title = '', validate) => {
+  const errStr = gatherFieldErrors(validate.errors.errors)
+  Raven.captureMessage(`${title} = ${errStr}`, {
+    level: 'warning',
+  })
+}
+
 server
   .use(helmet.frameguard({ action: 'deny' })) //// Sets "X-Frame-Options: DENY".
   .use(helmet.noSniff()) // Sets "X-Content-Type-Options: nosniff".
@@ -72,16 +86,12 @@ server
     const validateCal = new Validator(input, CalendarFields)
 
     if (!validateReg.passes()) {
-      Raven.captureMessage('Missing Data - Register Page', {
-        level: 'info', // one of 'info', 'warning', or 'error'
-      })
+      captureMessage('Register Page', validateReg)
       return res.redirect('/register?not-valid=true')
     }
 
     if (!validateCal.passes()) {
-      Raven.captureMessage('Missing Data - Calendar Page', {
-        level: 'info', // one of 'info', 'warning', or 'error'
-      })
+      captureMessage('Calendar Page', validateCal)
       return res.redirect('/calendar?not-valid=true')
     }
 


### PR DESCRIPTION


Routing users back to fill in missing data shouldn't happen given a typical user flow.  If we end up flagging missing data and redirecting we should be notified we can look further into potential issues.

This update sends a simple message to Sentry for these case so the information is logged and we will receive an email notification.

**Sample of info showing in Sentry:**

<img width="898" alt="screen shot 2018-08-15 at 10 04 49 am" src="https://user-images.githubusercontent.com/62242/44152586-ea1a84f0-a073-11e8-8da5-f349c37877ce.png">