### PR TITLE
Fix our font loading

### DIFF
--- a/web/public/fonts/fonts.css
+++ b/web/public/fonts/fonts.css
@@ -1,0 +1,10 @@
+@font-face {
+  font-family: SourceSans;
+  src: url(/fonts/SourceSansPro-Regular.woff) format('woff');
+  font-weight: 400;
+}
+@font-face {
+  font-family: SourceSans;
+  src: url(/fonts/SourceSansPro-Bold.woff) format('woff');
+  font-weight: 700;
+}

--- a/web/public/fonts/fonts.css
+++ b/web/public/fonts/fonts.css
@@ -2,9 +2,11 @@
   font-family: SourceSans;
   src: url(/fonts/SourceSansPro-Regular.woff) format('woff');
   font-weight: 400;
+  font-display: block;
 }
 @font-face {
   font-family: SourceSans;
   src: url(/fonts/SourceSansPro-Bold.woff) format('woff');
   font-weight: 700;
+  font-display: block;
 }

--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -48,6 +48,7 @@ class Document extends React.Component {
             as="font"
           />
           <link rel="preload" href="/fonts/SourceSansPro-Bold.woff" as="font" />
+          <link href="/fonts/fonts.css" rel="stylesheet" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
           <meta charSet="utf-8" />
           {helmet.title.toComponent()[0].key ? (

--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -115,13 +115,9 @@ const dayPickerDefault = css`
     text-align: center;
 
     > div {
-      font-family: ${theme.weight.b}, Helvetica;
+      font-size: 1.15rem;
+      font-weight: 700;
     }
-  }
-
-  .DayPicker-Caption > div {
-    font-size: 1.15rem;
-    font-weight: 500;
   }
 
   .DayPicker-Weekdays {
@@ -181,7 +177,6 @@ const dayPickerDefault = css`
 
     &[aria-disabled='false'] {
       font-weight: 700;
-      font-family: ${theme.weight.b}, Helvetica;
       background: white;
       outline: 0px white solid;
 
@@ -353,7 +348,6 @@ const daySelection = css`
 
   h3 {
     color: ${theme.colour.black};
-    font-family: ${theme.weight.b}, Helvetica;
     font-size: ${theme.font.md};
     margin-bottom: ${theme.spacing.sm};
   }
@@ -593,8 +587,8 @@ class Calendar extends Component {
 
     const initialMonth = getInitialMonth(value, startMonth)
 
-    /* 
-    We need the highlighted day of the week to be dynamic 
+    /*
+    We need the highlighted day of the week to be dynamic
     as the month changes
     */
 
@@ -608,7 +602,7 @@ class Calendar extends Component {
       .DayPicker-Weekday:nth-of-type(${dayOfWeek1}),
       .DayPicker-Weekday:nth-of-type(${dayOfWeek2}) {
         background: ${theme.colour.white};
-        font-family: ${theme.weight.b}, Helvetica;
+        font-weight: 700;
       }
     `
 

--- a/web/src/components/ErrorMessage.js
+++ b/web/src/components/ErrorMessage.js
@@ -17,7 +17,6 @@ const errorMessage = css`
   padding: ${theme.spacing.lg};
 
   h2 {
-    font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
     margin-top: 0 !important;
   }
 `
@@ -26,7 +25,6 @@ const errorList = css`
   ${errorMessage};
 
   a {
-    font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
     color: ${theme.colour.red};
     font-weight: 700;
   }

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -18,7 +18,6 @@ const button = css`
   display: inline-block;
   font-size: ${theme.font.base};
   color: ${theme.colour.white};
-  font-family: ${theme.weight.r}, Helvetica, Arial, sans-serif;
   padding: 0;
 
   text-decoration: underline;

--- a/web/src/components/Layout.js
+++ b/web/src/components/Layout.js
@@ -16,7 +16,7 @@ injectGlobal`
     margin: 0;
     background: ${theme.colour.white};
     height: 100%;
-    font-family: ${theme.weight.r}, Helvetica, Arial, sans-serif;
+    font-family: SourceSans, Helvetica, Arial, sans-serif;
     font-size: 18px;
     box-sizing: border-box;
 
@@ -25,8 +25,8 @@ injectGlobal`
     `)};
   }
 
-  strong {
-    font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
+  button {
+    font-family: SourceSans, Helvetica, Arial, sans-serif;
   }
 
   *, *:before, *:after {
@@ -70,20 +70,6 @@ injectGlobal`
    border: 0;
    height: 1px;
    background: #DBDBDB;
-  }
-
-  @font-face {
-   font-family: 'Source Sans';
-   font-style: normal;
-   font-weight: 400;
-   src: local('SourceSans'), local('Source-Sans'), url(/fonts/SourceSansPro-Regular.woff) format('woff');
-  }
-
-  @font-face {
-   font-family: 'Source Sans Bold';
-   font-style: normal;
-   font-weight: 400;
-   src: local('SourceSansBold'), local('Source-Sans-Bold'), url(/fonts/SourceSansPro-Bold.woff) format('woff');
   }
 `
 

--- a/web/src/components/PageHeader.js
+++ b/web/src/components/PageHeader.js
@@ -33,8 +33,6 @@ const skinnyBanner = css`
 
 const pageTitle = css`
   font-size: ${theme.font.xxl};
-  font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
-  font-weight: 700;
 
   ${mediaQuery.sm(css`
     font-size: ${theme.font.lg};
@@ -53,7 +51,8 @@ const PageHeader = ({ children, i18n }) => (
         rel="noopener noreferrer"
       >
         <Trans>sending your feedback</Trans>
-      </a>.
+      </a>
+      .
     </PhaseBanner>
     {children ? <div className={pageTitle}>{children}</div> : ''}
   </div>

--- a/web/src/components/PhaseBanner.js
+++ b/web/src/components/PhaseBanner.js
@@ -9,7 +9,6 @@ const badge = css`
   height: 1.3rem;
   font-size: ${theme.font.xs};
   color: ${theme.colour.white};
-  font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
   font-weight: 700;
 `
 
@@ -28,8 +27,6 @@ const alpha = css`
 
 const message = css`
   font-size: ${theme.font.xs};
-  font-family: ${theme.weight.r}, Helvetica, Arial, sans-serif;
-  font-weight: 400;
   margin-left: ${theme.spacing.md};
   color: ${theme.colour.white};
 

--- a/web/src/components/Reminder.js
+++ b/web/src/components/Reminder.js
@@ -6,7 +6,6 @@ import importantMessage from '../assets/importantMessage.svg'
 import { withI18n } from 'lingui-react'
 
 const imBanner = css`
-  font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
   font-weight: 700;
   color: ${theme.colour.black};
   display: inline-flex;

--- a/web/src/components/forms/Button.js
+++ b/web/src/components/forms/Button.js
@@ -89,9 +89,9 @@ const govuk_button = css`
 const button = css`
   ${govuk_button};
 
-  font-family: ${theme.weight.b}, Helvetica, Arial, sans-serif;
+  font-family: SourceSans, Helvetica, Arial, sans-serif;
   font-size: ${theme.font.lg};
-  font-weight: 600;
+  font-weight: 700;
   line-height: 2;
   text-align: center;
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -64,13 +64,11 @@ const headerStyles = css`
 
 const CalendarHeader = styled(H1)`
   font-size: ${theme.font.xl};
-  font-family: ${theme.weight.r}, Helvetica;
   ${headerStyles};
 `
 
 const CalendarSubheader = styled(H2)`
   font-size: ${theme.font.lg};
-  font-family: ${theme.weight.r}, Helvetica;
   ${headerStyles};
 `
 

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -76,7 +76,6 @@ const H2Landing = styled(H2)`
 `
 
 const H2List = styled(H2)`
-  font-family: ${theme.weight.r}, Helvetica;
   font-weight: 400;
 `
 

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -65,7 +65,6 @@ const contentClass = css`
         display: block;
 
         &[id$='-header'] {
-          font-family: ${theme.weight.b}, Helvetica;
           font-size: ${theme.font.lg};
           font-weight: 700;
         }

--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -68,10 +68,6 @@ export const theme = {
     xxl: '1.728rem',
     xxxl: '1.602rem',
   },
-  weight: {
-    b: 'Source Sans Bold, sans serif',
-    r: 'Source Sans, sans serif',
-  },
   spacing: {
     xxs: '0.17rem',
     xs: '0.33rem',
@@ -140,18 +136,15 @@ export const visuallyhiddenMobile = css`
 
 export const H1 = styled.h1`
   font-size: ${theme.font.xxl};
-  font-family: ${theme.weight.b}, Helvetica;
 `
 
 export const H2 = styled.h2`
   font-size: ${theme.font.lg};
-  font-family: ${theme.weight.b}, Helvetica;
   margin-bottom: 0em;
 `
 
 export const H3 = styled.h3`
   font-size: ${theme.font.md};
-  font-family: ${theme.weight.b}, Helvetica;
 `
 
 const contentSpacing = css`
@@ -189,10 +182,6 @@ export const Content = styled.div`
   p {
     font-size: ${theme.font.lg};
   }
-`
-
-export const Bold = styled.strong`
-  font-weight: bold;
 `
 
 export const Calendar = styled.div`


### PR DESCRIPTION
## Fixed preloading fonts

Unfortunately, when #366 went in, I didn't notice that the fonts were getting loaded twice.

<img width="775" alt="screen shot 2018-08-15 at 5 56 20 pm" src="https://user-images.githubusercontent.com/2454380/44175630-cf766380-a0b4-11e8-8920-05e01dbc3e7b.png">

They _are_ getting preloaded, but the `@font-face` declaration in `injectGlobal` doesn't actually use those downloads, and re-downloads the fonts.

So, I took a look at [this example of preloading fonts](https://github.com/zachleat/web-font-loading-recipes/blob/master/preload.html) and implemented it in our app. Now we're a-OK.

## Removed theme.weight

The other thing that changed is that I am naming both fonts as the same font family, but giving them different weights. Again, this is what [the example](https://github.com/zachleat/web-font-loading-recipes/blob/master/preload.html) does.

This means that when we want to switch between fonts in our app, all we have to do is switch the `font-weight` value.

This solves a couple of problems for us:
- weights now work the same as on our fallback (system) font
- means our font renders properly across differnet browsers (ie, this fixes our weird kerning problem)

Since we can just set font weights to 700 and be done with it, I've removed the `theme.weight` object entirely and deleted everywhere it was being used in the app.

Since header elements default to `font-weight: 700`, I didn't have to explicitly define it in most cases.

Also:
- Removed `strong` declaration that was redundant
- Removed Bold element that wasn't being used

## Screenshots

Should be no visual changes on Chrome, but this fixes our weird kerning problem on Safari / Firefox.

| before | after |
|--------|-------|
| ![screen shot 2018-08-15 at 5 35 35 pm](https://user-images.githubusercontent.com/2454380/44175799-60e5d580-a0b5-11e8-95f7-8f8b525e5941.png) |      ![screen shot 2018-08-15 at 5 35 41 pm](https://user-images.githubusercontent.com/2454380/44175800-617e6c00-a0b5-11e8-940f-8e7c3f5269a4.png) |


