### PR TITLE
Add crossorigin="anonymous" to preload links so that fonts don't download twice in Chrome

### DIFF
--- a/web/src/Document.js
+++ b/web/src/Document.js
@@ -46,8 +46,16 @@ class Document extends React.Component {
             rel="preload"
             href="/fonts/SourceSansPro-Regular.woff"
             as="font"
+            type="font/woff"
+            crossOrigin="anonymous"
           />
-          <link rel="preload" href="/fonts/SourceSansPro-Bold.woff" as="font" />
+          <link
+            rel="preload"
+            href="/fonts/SourceSansPro-Bold.woff"
+            as="font"
+            type="font/woff"
+            crossOrigin="anonymous"
+          />
           <link href="/fonts/fonts.css" rel="stylesheet" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
           <meta charSet="utf-8" />


### PR DESCRIPTION
For some reason, Chrome will download the preloaded fonts, and then ignore them and re-download them _again_.

Other browsers don't do this -- only Chrome.

If you want to read up on this super weird behaviour:

- https://github.com/w3c/preload/issues/32#issuecomment-196223669
- https://bugs.chromium.org/p/chromium/issues/detail?id=584198
- https://stackoverflow.com/a/36508361/9728185

And there's a good example in the MDN docs:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link