### PR TITLE
Ensure 3 dates for calendar view

### DIFF
--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -52,9 +52,38 @@ const dayMonthYear = date => {
   return format(parse(date), 'dddd, MMMM D, YYYY')
 }
 
-/* eslint-enable security/detect-object-injection */
 const calDays = (date = new Date()) => {
-  return getEnabledDays(undefined, date)
+  return useMonth(getEnabledDays(undefined, date))
+}
+
+/* eslint-disable security/detect-object-injection */
+const collectDates = (accumulator, currentValue) => {
+  const index = getMonthNameAndYear(currentValue, 'en')
+  if (typeof accumulator[index] === 'undefined') {
+    accumulator[index] = []
+  }
+
+  accumulator[index].push(currentValue)
+
+  return accumulator
+}
+
+// find a month that has at least 3 dates we can use for tests
+const useMonth = dates => {
+  const groupedDates = dates.reduce(collectDates, {})
+
+  let month = false
+
+  Object.keys(groupedDates).forEach(function(key) {
+    if (month) {
+      return
+    }
+    if (groupedDates[key].length >= 3) {
+      month = groupedDates[key]
+    }
+  })
+
+  return month
 }
 
 describe('<CalendarAdapter />', () => {


### PR DESCRIPTION
This reverts the Calendar tests to bring back some code that was used to ensure that the Calendar tests have enough dates to work with per month view.

These functions got removed during some cleanup work.