### PR TITLE
Only install production dependencies when deploying

### DIFF
--- a/shipitfile.js
+++ b/shipitfile.js
@@ -43,7 +43,9 @@ module.exports = shipit => {
         ? ' && yarn sm:production'
         : ' && yarn sm:staging'
     await shipit.remote(
-      `cd ${shipit.releasePath}/web && yarn && yarn build ${uploadSourceMaps}`,
+      `cd ${
+        shipit.releasePath
+      }/web && yarn install --production && yarn build ${uploadSourceMaps}`,
     )
   })
 


### PR DESCRIPTION
Up to now, we've been installing all production and dev dependencies when deploying the application.

Dev dependencies are used for things like testing or linting, but they aren't needed when running the application. Skipping dev dependencies will make our deployments faster and hopefully get them to actually work again 🤞 
