### PR TITLE
Keep language query consistent on Landing Page

### DIFF
--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -107,6 +107,16 @@ describe('WithProvider', () => {
       expect(key).toBe('about')
       expect(val).toEqual({ field: 'value' })
     })
+
+    it('path key remains "/" when root path and no global key exists ', () => {
+      // other fields will be ignored
+      let { key, val } = WithProvider.returnKeyAndValue(
+        { field: 'value' },
+        { path: '/' },
+      )
+      expect(key).toBe('/')
+      expect(val).toEqual({ field: 'value' })
+    })
   })
 
   describe('.getDefaultLanguageFromHeader()', () => {

--- a/web/src/pages/__tests__/NoJS.test.js
+++ b/web/src/pages/__tests__/NoJS.test.js
@@ -117,6 +117,36 @@ describe('NoJS Flow', () => {
   )
 })
 
+describe('NoJS Landing Page', () => {
+  it(
+    'preserves language settings in nojs mode',
+    async () => {
+      await page.goto(`${baseUrl}/`)
+      let html = await page.$eval('h1 span', e => e.innerHTML)
+      expect(html).toBe('Request a new citizenship appointment')
+
+      await page.goto(`${baseUrl}/?language=fr`)
+      html = await page.$eval('h1 span', e => e.innerHTML)
+      expect(html).toBe(
+        'Demander un nouveau rendez-vous d’examen de citoyenneté',
+      )
+
+      await page.goto(`${baseUrl}/`)
+      html = await page.$eval('h1 span', e => e.innerHTML)
+      expect(html).toBe(
+        'Demander un nouveau rendez-vous d’examen de citoyenneté',
+      )
+
+      await page.goto(`${baseUrl}/?utm_source=TEST&utm_medium=test`)
+      html = await page.$eval('h1 span', e => e.innerHTML)
+      expect(html).toBe(
+        'Demander un nouveau rendez-vous d’examen de citoyenneté',
+      )
+    },
+    200000,
+  )
+})
+
 afterAll(() => {
   if (browser && browser.close) {
     browser.close()

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -151,7 +151,7 @@ function withProvider(WrappedComponent) {
       }
 
       // match.path === "/about" or similar
-      let key = match.path.slice(1)
+      let key = match.path.length > 1 ? match.path.slice(1) : match.path
       return { key, val: query }
     }
 


### PR DESCRIPTION
##  Keep language query consistent on Landing Page

On the landing page, the pathname is "/".
Since it would be trimmed in the `returnKeyAndValue` function, we would be passing key === '' to `validateCookie`. This meant that [`validateCookie` would error out](https://github.com/cds-snc/ircc-rescheduler/blob/master/web/src/withProvider.js#L176).

In practical terms, this meant that visiting the root URL "/" and passing in a query parameter would cause the language to switch back to English.

## bug

![french](https://user-images.githubusercontent.com/2454380/44287431-d6c77980-a23a-11e8-9df2-2bda1fa558e1.gif)

The fix for this is to never return an empty string as a key from `returnKeyAndValue`.

- added unit test
- added puppeteer test which reloads the home page several times and checks the language setting is preserved