### PR TITLE
Only validate query parameters when a query param key matches a field on the page

### DIFF
--- a/web/cypress/integration/main/keep-data-query-params.spec.js
+++ b/web/cypress/integration/main/keep-data-query-params.spec.js
@@ -1,0 +1,36 @@
+context('Keep user submitted data around', () => {
+  it('when not-relevant query parameters are submitted', () => {
+    cy.visit('/register')
+
+    cy.fixture('user').then(data => {
+      cy.get('#fullName').type(data.fullName, { force: true })
+      cy.get('#email').type(data.email, { force: true })
+      cy.get('#paperFileNumber').type(data.paperFileNumber, { force: true })
+      cy.get('#reason-2').click({ force: true })
+      cy.get('#explanation').type(data.explanation, { force: true })
+      cy.get('#register-form').submit({ force: true })
+    })
+    cy.url().should('contain', '/calendar')
+    // click "Go back" link
+    cy.get('main nav a.chevron-link').click({ force: true })
+    cy.url().should('contain', '/register')
+
+    // Make sure data is still on the page
+    cy.fixture('user').then(data => {
+      cy.get('#fullName').should('have.value', data.fullName)
+      cy.get('#email').should('have.value', data.email)
+      cy.get('#paperFileNumber').should('have.value', data.paperFileNumber)
+      cy.get('#explanation').should('have.value', data.explanation)
+    })
+
+    // Visit same page with additional query parameter
+    cy.visit('/register?not-valid=true')
+    // Make sure data is still on the page
+    cy.fixture('user').then(data => {
+      cy.get('#fullName').should('have.value', data.fullName)
+      cy.get('#email').should('have.value', data.email)
+      cy.get('#paperFileNumber').should('have.value', data.paperFileNumber)
+      cy.get('#explanation').should('have.value', data.explanation)
+    })
+  })
+})

--- a/web/cypress/integration/main/review-missing-data.spec.js
+++ b/web/cypress/integration/main/review-missing-data.spec.js
@@ -1,5 +1,5 @@
 context('Review Page with Missing Data', () => {
-  it('should be redirect to register page if data is missing', () => {
+  it('should be redirected to register page if data is missing', () => {
     cy.visit('/review')
     // submit with no data filled in
     cy.get('#review-form').submit({ force: true })
@@ -8,7 +8,7 @@ context('Review Page with Missing Data', () => {
     cy.url().should('contain', '/register?not-valid')
   })
 
-  it('should be redirect to calendar page if data is missing', () => {
+  it('should be redirected to calendar page if data is missing', () => {
     cy.visit('/register')
 
     // fill in first page with data

--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -1,4 +1,4 @@
-import withProvider from '../withProvider'
+import withProvider, { _isNonEmptyObject } from '../withProvider'
 
 class FakeComponentEmpty {
   constructor() {}
@@ -34,6 +34,22 @@ class FakeComponentWithFieldsAndValidate {
   }
   constructor() {}
 }
+
+describe('_isNonEmptyObject', () => {
+  let invalidVals = [0, false, {}, ['value'], null, '', 'value']
+  invalidVals.map(v => {
+    it(`returns false for non-empty object value: ${JSON.stringify(v)}`, () => {
+      expect(_isNonEmptyObject(v)).toEqual(false)
+    })
+  })
+
+  let validVals = [{ a: 'b' }, { a: '' }, { a: null }]
+  validVals.map(v => {
+    it(`returns true for non-empty object value: ${JSON.stringify(v)}`, () => {
+      expect(_isNonEmptyObject(v)).toEqual(true)
+    })
+  })
+})
 
 describe('WithProvider', () => {
   describe('.globalFields and .validate()', () => {
@@ -301,10 +317,10 @@ describe('WithProvider', () => {
 
       let invalidVals = [0, false, {}, ['value'], null, '', 'value']
       invalidVals.map(v => {
-        it(`throws error for regular field with a non-empty object value: ${v}`, () => {
-          expect(() => {
-            WithProvider.validateCookie('page', v)
-          }).toThrowError(/^validate: `val` must be a non-empty object$/)
+        it(`returns false for regular field with a non-empty object value: ${JSON.stringify(
+          v,
+        )}`, () => {
+          expect(WithProvider.validateCookie('page', v)).toBe(false)
         })
       })
 

--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -323,6 +323,14 @@ describe('WithProvider', () => {
         expect(result).toEqual({ field: '' })
       })
 
+      it('returns false when no keys are valid', () => {
+        let result = WithProvider.validateCookie('page', {
+          field2: 'value2',
+          field3: 'value3',
+        })
+        expect(result).toEqual(false)
+      })
+
       it('does not mutate original object', () => {
         // original object has too many keys
         let val1 = { field: 'value', field2: 'value2' }

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -23,6 +23,19 @@ const _whitelist = ({ val, fields }) => {
     }, {})
 }
 
+export const _isNonEmptyObject = val => {
+  /* make sure passed-in value is a non-empty object */
+  if (
+    val === null ||
+    typeof val !== 'object' ||
+    Array.isArray(val) ||
+    Object.keys(val).length === 0
+  ) {
+    return false
+  }
+  return true
+}
+
 function withProvider(WrappedComponent) {
   class WithProvider extends Component {
     static async getInitialProps({ res, req, match }) {
@@ -198,23 +211,10 @@ function withProvider(WrappedComponent) {
       if (
         fields &&
         fields.length && // there are fields explicitly defined
-        typeof validate === 'function' // there is a validate function passed-in
+        typeof validate === 'function' && // there is a validate function passed-in
+        _isNonEmptyObject(val) && // val is a non-empty object
+        Object.keys(val).some(k => fields.includes(k)) // at least one query param key exists in fields
       ) {
-        // if not a global setting, val must be a non-empty object
-        if (
-          val === null ||
-          typeof val !== 'object' ||
-          Array.isArray(val) ||
-          Object.keys(val).length === 0
-        ) {
-          throw new Error('validate: `val` must be a non-empty object')
-        }
-
-        // return false unless at least one query param key exists in fields
-        if (!Object.keys(val).some(k => fields.includes(k))) {
-          return false
-        }
-
         // whitelist query keys so that arbitrary keys aren't saved to the store
         val = _whitelist({ val, fields })
 

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -210,6 +210,11 @@ function withProvider(WrappedComponent) {
           throw new Error('validate: `val` must be a non-empty object')
         }
 
+        // return false unless at least one query param key exists in fields
+        if (!Object.keys(val).some(k => fields.includes(k))) {
+          return false
+        }
+
         // whitelist query keys so that arbitrary keys aren't saved to the store
         val = _whitelist({ val, fields })
 


### PR DESCRIPTION
Because of the way we are handling query parameters (ie, assuming that they represent data the user os trying to submit), we've ended up in a few cases where user data has been lost based on query parameters that users haven't entered.

This PR will ignore query parameters that don't contain any keys related to values on the page.

Added a new unit test and a new cypress test.

## screenshot

![query-param](https://user-images.githubusercontent.com/2454380/44289503-89e7a100-a242-11e8-8ccb-c92ce392aee8.gif)
