### PR TITLE
Prevent IE11 from focusing on Canada government logo

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,7 +29,7 @@
     "sm:production": "COMMIT_HASH=`git rev-parse --short HEAD` && . $(readlink .env.production) && SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN RAZZLE_STAGE=production-$COMMIT_HASH yarn sentry_map"
   },
   "dependencies": {
-    "@cdssnc/gcui": "^0.0.30",
+    "@cdssnc/gcui": "^0.0.31",
     "@jaredpalmer/after": "^1.3.1",
     "@sentry/cli": "^1.34.0",
     "aws-sdk": "^2.291.0",

--- a/web/src/components/FederalBanner.js
+++ b/web/src/components/FederalBanner.js
@@ -50,6 +50,7 @@ const FederalBanner = ({ context = {} }) => (
         lang={context.store.language}
         flag={theme.colour.white}
         text={theme.colour.white}
+        focusable="false"
       />
     </div>
     <LanguageSwitcher />

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -107,9 +107,9 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@cdssnc/gcui@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@cdssnc/gcui/-/gcui-0.0.30.tgz#29f7668ce0e0acc8f614fcc9f027064d7129194a"
+"@cdssnc/gcui@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@cdssnc/gcui/-/gcui-0.0.31.tgz#44e5710d0602e419ba3994f71f888adcf39eaea8"
   dependencies:
     core-js "^2.5.7"
     emotion "^9.1.3"


### PR DESCRIPTION
In our last round of accessbility testing, there was a bug uncovered where IE11 would automatically focus on our Canadian Federal logo (ie, an svg), even though this is a non-interactive element and does not have a focus indicator.

Fix is to add a `focusable="false"` attribute to the svg.
- https://github.com/PolymerElements/iron-iconset-svg/issues/46

Went into GCUI to make the change, and added tests for it in there.
- https://github.com/cds-snc/gcui

Tested this fix using Browserstack and it behaves as expected.

---

Note: was planning to do some experimenting on cutting down the GCUI bundle size, but now that we have a rollout in a couple weeks, I'm putting that one on the back-burner.

