### PR TITLE
Ignore Puppeteer tests in `yarn test`

### DIFF
--- a/web/jest-no-js.config.js
+++ b/web/jest-no-js.config.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const jestDefaultConfig = require('./jest.config.js')
+
+module.exports = {
+  ...jestDefaultConfig,
+  testPathIgnorePatterns: ['/node_modules/', 'NoJS.test.js'],
+}

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = {
+  verbose: true,
+  transform: {
+    '^.+\\.(js|jsx)$':
+      '<rootDir>/node_modules/razzle/config/jest/babelTransform.js',
+    '^.+\\.css$': '<rootDir>/node_modules/razzle/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)':
+      '<rootDir>/node_modules/razzle/config/jest/fileTransform.js',
+  },
+  globals: {
+    RAZZLE_PAPER_FILE_NUMBER_PATTERN: '[a-zA-Z]{1}',
+  },
+  setupTestFrameworkScriptFile: '<rootDir>/test/setupTests.js',
+  testMatch: [
+    '<rootDir>/**/__tests__/**/*.js',
+    '<rootDir>/src/**/?(*.)(spec|test).js',
+    '<rootDir>/test/**/?(*.)(spec|test).js',
+  ],
+  moduleFileExtensions: ['jsx', 'js', 'json'],
+  collectCoverageFrom: ['src/**/*.{js,jsx}'],
+}

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,9 @@
     "postinstall": "razzle build",
     "start": "NODE_ENV=production node --icu-data-dir=./node_modules/full-icu build/server.js",
     "build:start": "yarn build && yarn start",
-    "test:full": "start-server-and-test build:start http://localhost:3004 test",
-    "test": "node --icu-data-dir=./node_modules/full-icu node_modules/jest/bin/jest.js",
+    "test:full": "start-server-and-test build:start http://localhost:3004 test:base",
+    "test": "yarn test:base -c jest-no-js.config.js",
+    "test:base": "node --icu-data-dir=./node_modules/full-icu node_modules/jest/bin/jest.js",
     "extract": "NODE_ENV=development lingui extract",
     "compile": "NODE_ENV=development lingui compile",
     "add_locale": "lingui add-locale",
@@ -94,31 +95,6 @@
     "start-server-and-test": "^1.7.0",
     "supertest": "^3.1.0",
     "webpack-bundle-analyzer": "^2.13.1"
-  },
-  "jest": {
-    "verbose": true,
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/node_modules/razzle/config/jest/babelTransform.js",
-      "^.+\\.css$": "<rootDir>/node_modules/razzle/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/node_modules/razzle/config/jest/fileTransform.js"
-    },
-    "globals": {
-      "RAZZLE_PAPER_FILE_NUMBER_PATTERN": "[a-zA-Z]{1}"
-    },
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setupTests.js",
-    "testMatch": [
-      "<rootDir>/**/__tests__/**/*.js",
-      "<rootDir>/src/**/?(*.)(spec|test).js",
-      "<rootDir>/test/**/?(*.)(spec|test).js"
-    ],
-    "moduleFileExtensions": [
-      "jsx",
-      "js",
-      "json"
-    ],
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
-    ]
   },
   "lingui": {
     "srcPathIgnorePatterns": [


### PR DESCRIPTION
Since adding the puppeteer tests, our `yarn test` command would fail when running without building and starting the app first.

By ignoring the NoJS.test.js file, we can run the rest of our jest tests from the command line without the faff of spinning the app up and down.

This deceptively simple problem turned out to be a bit more complicated than just doing a regex or passing a new command line argument.

In the end, I created a dedicated `jest.config.js` file that jest will use on CI test runs, and a second config file that ignores the NoJS tests so that we can run the other ones locally. Using the spread operator to reuse nearly the same config options between both files.

File matching using regex is also still working as before. ie, if I just wanted to run calendar-related tests, I can still use `yarn test Calendar`.

More info on jest configuration can be found here:
- https://jestjs.io/docs/en/configuration.html