### PR TITLE
[WIP] Add `location` global field

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "date-fns": "^1.29.0",
+    "deepmerge": "^2.1.1",
     "emotion": "^9.2.6",
     "emotion-server": "^9.2.6",
     "express": "^4.16.3",

--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -85,33 +85,33 @@ describe('WithProvider', () => {
       expect(val).toBe(undefined)
     })
 
-    it('"language" key and "en" val when global field passed in', () => {
+    it('"GLOBALS" key and {language: "en"} val when global language field passed in', () => {
       let { key, val } = WithProvider.returnKeyAndValue(
         { language: 'en' },
         match,
       )
-      expect(key).toBe('language')
-      expect(val).toBe('en')
+      expect(key).toBe('GLOBALS')
+      expect(val).toEqual({ language: 'en' })
     })
 
-    it('"language" key and "portuguese" val when global field passed in', () => {
+    it('"GLOBALS" key and {language: "portuguese"} val when global language field passed in', () => {
       // ie, it's not running the validateCookie function
       let { key, val } = WithProvider.returnKeyAndValue(
         { language: 'portuguese' },
         match,
       )
-      expect(key).toBe('language')
-      expect(val).toBe('portuguese')
+      expect(key).toBe('GLOBALS')
+      expect(val).toEqual({ language: 'portuguese' })
     })
 
-    it('"language" key and "en" val when global field passed in as well as other keys', () => {
+    it('"GLOBALS" key and {language: "en"} val when global language field passed in as well as other keys', () => {
       // other fields will be ignored
       let { key, val } = WithProvider.returnKeyAndValue(
         { language: 'en', field: 'value' },
         match,
       )
-      expect(key).toBe('language')
-      expect(val).toBe('en')
+      expect(key).toBe('GLOBALS')
+      expect(val).toEqual({ language: 'en' })
     })
 
     it('path key and query value when no global key exists ', () => {
@@ -263,26 +263,30 @@ describe('WithProvider', () => {
 
     // static validateCookie(key, val = null, fields = [], validate = null)
     it('returns correct language for "en"', () => {
-      let result = WithProvider.validateCookie('language', 'en')
-      expect(result).toEqual('en')
+      let result = WithProvider.validateCookie('GLOBALS', { language: 'en' })
+      expect(result).toEqual({ language: 'en' })
     })
 
     it('returns correct language for "fr"', () => {
-      let result = WithProvider.validateCookie('language', 'fr')
-      expect(result).toEqual('fr')
+      let result = WithProvider.validateCookie('GLOBALS', { language: 'fr' })
+      expect(result).toEqual({ language: 'fr' })
     })
 
     it('returns false for different language', () => {
-      let result = WithProvider.validateCookie('language', 'portuguese')
+      let result = WithProvider.validateCookie('GLOBALS', {
+        language: 'portuguese',
+      })
       expect(result).toBe(false)
     })
 
-    let invalidVals = [0, false, { language: 'en' }, ['en'], null, '']
+    let invalidVals = [0, false, {}, ['en'], null, '']
     invalidVals.map(v => {
-      it(`throws error for global field with a non-empty string value: ${v}`, () => {
+      it(`throws error for global field with a non-empty object: ${JSON.stringify(
+        v,
+      )}`, () => {
         expect(() => {
-          WithProvider.validateCookie('language', v)
-        }).toThrowError(/^validate: `val` must be a non-empty string$/)
+          WithProvider.validateCookie('GLOBALS', v)
+        }).toThrowError(/^validate: `val` must be a non-empty object/)
       })
     })
   })
@@ -294,17 +298,23 @@ describe('WithProvider', () => {
       const WithProviderValidate = withProvider(FakeComponentWithValidate)
 
       it('returns false if WrappedComponent does not have `fields` or `validate`', () => {
-        let result = EmptyWithProvider.validateCookie('field', 'value')
+        let result = EmptyWithProvider.validateCookie('page', {
+          field: 'value',
+        })
         expect(result).toBe(false)
       })
 
       it('returns false if WrappedComponent does not have `validate`', () => {
-        let result = WithProviderFields.validateCookie('field', 'value')
+        let result = WithProviderFields.validateCookie('page', {
+          field: 'value',
+        })
         expect(result).toBe(false)
       })
 
       it('returns false if WrappedComponent does not have `fields`', () => {
-        let result = WithProviderValidate.validateCookie('field', 'value')
+        let result = WithProviderValidate.validateCookie('page', {
+          field: 'value',
+        })
         expect(result).toBe(false)
       })
     })
@@ -330,7 +340,9 @@ describe('WithProvider', () => {
         it(`returns false for regular field with a non-empty object value: ${JSON.stringify(
           v,
         )}`, () => {
-          expect(WithProvider.validateCookie('page', v)).toBe(false)
+          expect(() => {
+            WithProvider.validateCookie('page', v)
+          }).toThrowError(/^validate: `val` must be a non-empty object/)
         })
       })
 

--- a/web/src/components/FederalBanner.js
+++ b/web/src/components/FederalBanner.js
@@ -47,7 +47,7 @@ const FederalBanner = ({ context = {} }) => (
     <div className="svg-container canada-flag">
       <GoCSignature
         width="250px"
-        lang={context.store.language}
+        lang={context.store.GLOBALS.language}
         flag={theme.colour.white}
         text={theme.colour.white}
         focusable="false"

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -115,10 +115,9 @@ const Footer = ({ topBarBackground, i18n, context = {} }) => (
         <a href={i18n._('https://digital.canada.ca/legal/terms/')}>
           <Trans>Terms</Trans>
           {context.store &&
-          context.store.language &&
-          context.store.language === 'fr' ? (
-            ''
-          ) : (
+          context.store.GLOBALS &&
+          context.store.GLOBALS.language &&
+          context.store.GLOBALS.language === 'fr' ? null : (
             <span className={visuallyhiddenMobile}> and Conditions</span>
           )}
         </a>
@@ -128,7 +127,7 @@ const Footer = ({ topBarBackground, i18n, context = {} }) => (
         <img
           src={CanadaWordmark}
           alt={
-            context.store.language === 'en'
+            context.store.GLOBALS.language === 'en'
               ? 'Symbol of the Government of Canada'
               : 'Symbole du gouvernement du Canada'
           }

--- a/web/src/components/LanguageSwitcher.js
+++ b/web/src/components/LanguageSwitcher.js
@@ -47,7 +47,9 @@ class LanguageSwitcher extends React.Component {
     super(props)
     this.getNewLanguage = this.getNewLanguage.bind(this)
 
-    let { context: { store: { language = '' } = {} } = {} } = props
+    let {
+      context: { store: { GLOBALS: { language = '' } = {} } = {} } = {},
+    } = props
 
     this.state = {
       language,
@@ -82,7 +84,7 @@ class LanguageSwitcher extends React.Component {
             e.preventDefault()
             const lang = this.getNewLanguage()
             this.setState({ language: lang }, () =>
-              setStore('language', this.state.language),
+              setStore('GLOBALS', { language: this.state.language }),
             )
             logEvent('Navigation', 'Toggle Language', lang)
           }}

--- a/web/src/components/__tests__/LanguageSwitcher.test.js
+++ b/web/src/components/__tests__/LanguageSwitcher.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import { LanguageSwitcherBase as LanguageSwitcher } from '../LanguageSwitcher'
 
 export const getStore = lang => ({
-  store: { language: lang },
+  store: { GLOBALS: { language: lang } },
   setStore: () => {},
 })
 

--- a/web/src/context.js
+++ b/web/src/context.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 export const contextDefault = {
-  store: { language: 'en' },
+  store: { GLOBALS: { language: 'en' } },
   setStore: null,
 }
 

--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -1,3 +1,5 @@
+import merge from 'deepmerge'
+
 const inTenMinutes = () => new Date(new Date().getTime() + 10 * 60 * 1000)
 const inOneDay = () => new Date(new Date().getTime() + 1 * 24 * 60 * 60 * 1000)
 
@@ -33,7 +35,7 @@ export const setSSRCookie = (res, key, val, prevCookie) => {
   let newCookie = { [key]: val }
 
   // create new cookie by merging with previous values
-  let cookie = { ...prevCookie, ...newCookie }
+  let cookie = merge(prevCookie, newCookie)
 
   setStoreCookie(res.cookie.bind(res), cookie)
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -186,7 +186,8 @@ class CalendarPage extends Component {
 
   componentDidUpdate(prevProps) {
     if (
-      this.props.context.store.language !== prevProps.context.store.language
+      this.props.context.store.GLOBALS.language !==
+      prevProps.context.store.GLOBALS.language
     ) {
       this.changeMonth()
     }
@@ -220,7 +221,9 @@ class CalendarPage extends Component {
 
   changeMonth(month = this.state.month) {
     let {
-      context: { store: { language: locale = 'en' } = {} } = {},
+      context: {
+        store: { GLOBALS: { language: locale = 'en' } = {} } = {},
+      } = {},
     } = this.props
 
     const days = getDaysOfWeekForLocation(undefined, month)
@@ -277,7 +280,12 @@ class CalendarPage extends Component {
 
   render() {
     let {
-      context: { store: { calendar = {}, language: locale = 'en' } = {} } = {},
+      context: {
+        store: {
+          calendar = {},
+          GLOBALS: { language: locale = 'en' } = {},
+        } = {},
+      } = {},
     } = this.props
 
     // we aren't going to check for a no-js submission because currently nothing happens when someone presses "review request"
@@ -421,7 +429,12 @@ class NoJS extends Component {
 
   render() {
     let {
-      context: { store: { calendar = {}, language: locale = 'en' } = {} } = {},
+      context: {
+        store: {
+          calendar = {},
+          GLOBALS: { language: locale = 'en' } = {},
+        } = {},
+      } = {},
     } = this.props
     let errorsNoJS = {}
 

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -87,9 +87,10 @@ class LandingPage extends React.Component {
       this.props &&
       this.props.context &&
       this.props.context.store &&
-      this.props.context.store.language
+      this.props.context.store.GLOBALS &&
+      this.props.context.store.GLOBALS.language
     ) {
-      locale = this.props.context.store.language
+      locale = this.props.context.store.GLOBALS.language
     }
     return (
       <Layout

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -140,13 +140,13 @@ server
     return res.redirect('/confirmation')
   })
   .get('/clear', (req, res) => {
-    let language = getStoreCookie(req.cookies, 'language') || 'en'
+    let language = getStoreCookie(req.cookies, 'GLOBALS').language || 'en'
 
     res.clearCookie('store')
     res.redirect(`/cancel?language=${language}`)
   })
   .get('/*', async (req, res) => {
-    let language = getStoreCookie(req.cookies, 'language') || 'en'
+    let language = getStoreCookie(req.cookies, 'GLOBALS').language || 'en'
     if (req.url === '/') {
       /* check if we have a cached version of the homepage */
       let cachedIndex = cache.get(`index_${language}`)

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -6,6 +6,7 @@ import { contextDefault, Context } from './context'
 import { I18nProvider } from 'lingui-react'
 import { catalogs, linguiDev } from './utils/linguiUtils'
 import { trimInput } from './utils/cleanInput'
+import merge from 'deepmerge'
 
 const _whitelist = ({ val, fields }) => {
   /*
@@ -92,7 +93,7 @@ function withProvider(WrappedComponent) {
         this.setState(
           state => ({
             context: {
-              store: { ...state.context.store, ...newState },
+              store: merge(state.context.store, newState),
               setStore: state.context.setStore,
             },
           }),

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -132,14 +132,25 @@ function withProvider(WrappedComponent) {
     }
 
     static get globalFields() {
-      return ['language']
+      return ['language', 'location']
     }
 
     static validate(values) {
       let errors = {}
-      if (!['en', 'fr'].includes(values.language)) {
+      if (
+        'language' in values && // values.language exists (even if set to falsey value)
+        !['en', 'fr'].includes(values.language) // language is either 'en' or 'fr'
+      ) {
         errors.language = true
       }
+
+      if (
+        'location' in values && // values.location exists (even if set to falsey value)
+        !['montreal', 'vancouver'].includes(values.location) // location is either 'montreal' or 'vancouver'
+      ) {
+        errors.location = true
+      }
+
       return errors
     }
 

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -121,7 +121,7 @@ function withProvider(WrappedComponent) {
       return (
         <Context.Provider value={this.state.context}>
           <I18nProvider
-            language={this.state.context.store.language}
+            language={this.state.context.store.GLOBALS.language}
             catalogs={catalogs}
             development={linguiDev}
           >

--- a/web/src/withProvider.js
+++ b/web/src/withProvider.js
@@ -64,7 +64,7 @@ function withProvider(WrappedComponent) {
         let language = WithProvider.getDefaultLanguageFromHeader(req.headers)
         // if default language found, set a new cookie
         newCookie = language
-          ? setSSRCookie(res, 'language', language, prevCookie)
+          ? setSSRCookie(res, 'GLOBALS', { language }, prevCookie)
           : newCookie
       }
 
@@ -158,7 +158,7 @@ function withProvider(WrappedComponent) {
           // eslint-disable-next-line security/detect-object-injection
           if (queryKey === WithProvider.globalFields[j]) {
             // eslint-disable-next-line security/detect-object-injection
-            return { key: queryKey, val: query[queryKey] }
+            return { key: 'GLOBALS', val: { [queryKey]: query[queryKey] } }
           }
         }
       }
@@ -182,23 +182,25 @@ function withProvider(WrappedComponent) {
 
     static validateCookie(key, val = null) {
       /*
-      validation method for both server-side and client-side cookies
-      returns either a sanitised `val` object else false
-      */
+          validation method for both server-side and client-side cookies
+          returns either a sanitised `val` object else false
+          */
 
       if (typeof key !== 'string' || !key.length) {
         throw new Error('validate: `key` must be a non-empty string')
       }
 
-      // check if a global setting
-      if (WithProvider.globalFields.includes(key)) {
-        // val must be a string
-        if (typeof val !== 'string' || !val.length) {
-          throw new Error('validate: `val` must be a non-empty string')
-        }
+      if (!_isNonEmptyObject(val)) {
+        throw new Error('validate: `val` must be a non-empty object')
+      }
 
+      // check if a global setting
+      if (
+        key === 'GLOBALS' &&
+        WithProvider.globalFields.includes(Object.keys(val)[0]) // get first key passed-in values
+      ) {
         // have to pass the key in as well since this value is a string
-        let errors = WithProvider.validate({ [key]: val })
+        let errors = WithProvider.validate(val)
 
         // return the value if no validation errors
         return !Object.keys(errors).length ? val : false
@@ -212,7 +214,6 @@ function withProvider(WrappedComponent) {
         fields &&
         fields.length && // there are fields explicitly defined
         typeof validate === 'function' && // there is a validate function passed-in
-        _isNonEmptyObject(val) && // val is a non-empty object
         Object.keys(val).some(k => fields.includes(k)) // at least one query param key exists in fields
       ) {
         // whitelist query keys so that arbitrary keys aren't saved to the store

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2800,6 +2800,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"


### PR DESCRIPTION
Note: this is a *WIP* PR while the tests are b0rked but it's pretty well finished.

***

This PR changes our internal data store structure a bit:

- adds a new `GLOBALS` key for global value (like language, and now location)
  - (Incidentally, the definition of a global value is that it can be set from any page)
- Adds `location` as a global value
- Lets us set multiple global values at once
- Explicitly ignores extra params we don't expect
  - ie, this will now work: 
  - `/?utm_source=BELA%20email&utm_medium=email&location=montreal&language=fr`

This PR does not:
- hook up any interface to `location` -- it can only be set via a query param at present
- use `location` for anything -- we're just setting a value 