### PR TITLE
Add a check for window before using scrollTo

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -21,6 +21,7 @@ import {
 } from '../utils/calendarDates'
 import parse from 'date-fns/parse'
 import { logEvent } from '../utils/analytics'
+import { windowExists } from '../utils/windowExists'
 
 const dayPickerDefault = css`
   /* DayPicker styles */
@@ -506,7 +507,6 @@ class Calendar extends Component {
 
   componentDidMount() {
     if (this.threeDatesArePicked && this.props.input.value.length === 3) {
-      // window.scrollTo(0, this.removeDateContainer.offsetTop)
       this.removeDateContainer.focus()
     }
   }
@@ -568,8 +568,9 @@ class Calendar extends Component {
         })
 
         this.errorContainer.focus()
-
-        window.scrollTo(0, this.errorContainer.offsetTop - 20)
+        if (windowExists()) {
+          window.scrollTo(0, this.errorContainer.offsetTop - 20)
+        }
 
         logEvent('Calendar', 'Select', 'Error: More than 3 days')
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -249,7 +249,10 @@ class CalendarPage extends Component {
     const submitErrors = this.validate(values)
 
     if (Object.keys(submitErrors).length) {
-      window.scrollTo(0, this.errorContainer.offsetTop - 20)
+      if (windowExists()) {
+        window.scrollTo(0, this.errorContainer.offsetTop - 20)
+      }
+
       this.errorContainer.focus()
 
       logEvent(

--- a/web/src/pages/RegistrationPage.js
+++ b/web/src/pages/RegistrationPage.js
@@ -143,7 +143,10 @@ class RegistrationPage extends React.Component {
     const submitErrors = this.validate(values, true)
 
     if (Object.keys(submitErrors).length) {
-      window.scrollTo(0, this.errorContainer.offsetTop - 20)
+      if (windowExists()) {
+        window.scrollTo(0, this.errorContainer.offsetTop - 20)
+      }
+
       this.errorContainer.focus()
 
       trackRegistrationErrors(submitErrors)


### PR DESCRIPTION
Not all environments have access to the window object.

Our unit tests for instance don't have access.

This fixes errors being thrown in the tests
```
console.error node_modules/jsdom/lib/jsdom/virtual-console.js:29
    Error: Not implemented: window.scrollTo
```