### PR TITLE
Subdomains

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -65,7 +65,8 @@
     "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1",
     "react-router-hash-link": "^1.2.0",
-    "validatorjs": "^3.14.2"
+    "validatorjs": "^3.14.2",
+    "wildcard-subdomains": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^16.4.11",

--- a/web/src/pages/FourOhFourPage.js
+++ b/web/src/pages/FourOhFourPage.js
@@ -27,10 +27,16 @@ class FourOhFourPage extends React.Component {
         <p>
           <Trans>Return to the home page to reschedule your appointment.</Trans>
         </p>
-        <NavLink className="chevron-link" to="/">
-          <Chevron dir="left" />
-          <Trans>Home</Trans>
-        </NavLink>
+        {/* 
+          If the page name is not-found use the page as a generic 
+          not found page i.e. no location
+        */}
+        {this.props.match.url !== '/not-found' && (
+          <NavLink className="chevron-link" to="/">
+            <Chevron dir="left" />
+            <Trans>Home</Trans>
+          </NavLink>
+        )}
       </Layout>
     )
   }

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -83,7 +83,7 @@ const getPrimarySubdomain = function(req, res, next) {
 
   if (
     !domainOptions.whitelist.includes(req.subdomain) &&
-    req.url !== '/not-found'
+    req.url.indexOf('not-found') === -1
   ) {
     // redirect to generic not found page
     /*
@@ -91,8 +91,10 @@ const getPrimarySubdomain = function(req, res, next) {
     so they don't end up at the wrong location 
     */
 
-    // Todo: Would rather not introduce another env variable here  
-    return res.redirect(process.env.SITE_URL + '/not-found')
+    // Todo: Would rather not introduce another env variable here
+    // hard code for testing
+    return res.redirect('https://rescheduler-dev.cds-snc.ca/not-found')
+    //return res.redirect(process.env.SITE_URL + '/not-found')
   }
 
   next()

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -71,14 +71,14 @@ const captureMessage = (title = '', validate) => {
   })
 }
 
-const domainOptions = { namespace: '', whitelist: ['van', 'cal', 'mtrl'] }
+const domainOptions = { namespace: '', whitelist: ['vancouver', 'calgary'] }
 
 const getPrimarySubdomain = function(req, res, next) {
   req.subdomain = req.subdomains.slice(-1).pop()
 
   if (!req.subdomain) {
     // default to vancouver for now
-    req.subdomain = 'van'
+    req.subdomain = 'vancouver'
   }
 
   if (

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -18,6 +18,7 @@ import {
   sendMail,
 } from './email/sendmail'
 import gitHash from './utils/gitHash'
+import wildcardSubdomains from 'wildcard-subdomains'
 import Raven from 'raven'
 Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {
   dataCallback: function(data) {
@@ -70,6 +71,33 @@ const captureMessage = (title = '', validate) => {
   })
 }
 
+const domainOptions = { namespace: '', whitelist: ['van', 'cal', 'mtrl'] }
+
+const getPrimarySubdomain = function(req, res, next) {
+  req.subdomain = req.subdomains.slice(-1).pop()
+
+  if (!req.subdomain) {
+    // default to vancouver for now
+    req.subdomain = 'van'
+  }
+
+  if (
+    !domainOptions.whitelist.includes(req.subdomain) &&
+    req.url !== '/not-found'
+  ) {
+    // redirect to generic not found page
+    /*
+    Note: Will need to remove links i.e. contact etc..
+    so they don't end up at the wrong location 
+    */
+
+    // Todo: Would rather not introduce another env variable here  
+    return res.redirect(process.env.SITE_URL + '/not-found')
+  }
+
+  next()
+}
+
 server
   .use(helmet.frameguard({ action: 'deny' })) //// Sets "X-Frame-Options: DENY".
   .use(helmet.noSniff()) // Sets "X-Content-Type-Options: nosniff".
@@ -77,6 +105,8 @@ server
   .use(helmet.xssFilter()) // Sets "X-XSS-Protection: 1; mode=block".
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR || './public'))
+  .use(wildcardSubdomains(domainOptions))
+  .use(getPrimarySubdomain)
   .use(cookieParser())
   .use(bodyParser.urlencoded({ extended: false }))
   .post('/submit', async (req, res) => {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -9780,6 +9780,10 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+wildcard-subdomains@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wildcard-subdomains/-/wildcard-subdomains-1.1.0.tgz#f983727551b8cec6c7bd8795f8ccc14296aba22b"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"


### PR DESCRIPTION
## Initial Subdomain setup

Sets up the server to handle locations via subdomain.

For local testing use vcap.me:3004 i.e. http://mtrl.vcap.me:3004

Valid subdomains have been whitelisted.

```
const domainOptions = { namespace: '', whitelist: ['van', 'cal', 'mtrl'] }
```

1. If a subdomain is found but is not on the list it will redirect.
2. If no subdomain is found for now it will default to Vancouver.