### PR TITLE
Adds ability to have blocked days on the calendar

### DIFF
--- a/web/src/locations/vancouver.js
+++ b/web/src/locations/vancouver.js
@@ -10,6 +10,7 @@ export const vancouver = {
     nov: ['tues', 'wed'],
     dec: ['tues', 'wed'],
   },
+  blocked: '', // use CSV format => 2018-10-02, 2018-10-03, 2018-11-21
 }
 
 export const getEmail = (location = vancouver) => {

--- a/web/src/utils/__tests__/calendarDates.test.js
+++ b/web/src/utils/__tests__/calendarDates.test.js
@@ -8,6 +8,7 @@ import {
   getInitialMonth,
   checkLocationDays,
   getDaysOfWeekForLocation,
+  dateSetFromString,
 } from '../calendarDates'
 
 describe('Utilities functions CalendarDates.js', () => {
@@ -114,5 +115,20 @@ describe('Utilities functions CalendarDates.js', () => {
     )
 
     expect(result).toEqual([4, 5, 6])
+  })
+
+  it('Creates a dateset', () => {
+    const set = dateSetFromString('2018-10-02, 2018-10-03')
+    expect(set.has('2018-10-03')).toEqual(true)
+  })
+
+  it('Handles when no date string is passed in', () => {
+    const set = dateSetFromString()
+    expect(set.has('2018-10-03')).toEqual(false)
+  })
+
+  it('Handles single date string', () => {
+    const set = dateSetFromString('2018-10-03')
+    expect(set.has('2018-10-03')).toEqual(true)
   })
 })

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -87,11 +87,7 @@ export const firstValidDay = (location = vancouver, date) => {
   return parse(addDays(date, i))
 }
 
-const isValidDayForLocation = (
-  location = {},
-  month = '',
-  date = new Date(),
-) => {
+const isValidDayForLocation = (location, month = '', date = new Date()) => {
   // eslint-disable-next-line security/detect-object-injection
   if (location && location.recurring[month]) {
     const result = checkLocationDays(location, month, date)
@@ -168,6 +164,9 @@ const getAllowedDays = (
 
 export const checkLocationDays = (location, month, date) => {
   let valid = false
+
+  const dateSet = dateSetFromString(location.blocked)
+
   // eslint-disable-next-line security/detect-object-injection
   location.recurring[month].forEach(day => {
     /* 
@@ -175,8 +174,11 @@ export const checkLocationDays = (location, month, date) => {
       isMonday, isTuesday
     */
     const result = isDayValid(day, date)
+    const dateFormatted = format(date, 'YYYY-MM-DD')
 
-    if (result.valid) {
+    // checks to see if a day is valid and that it's not blocked
+    // weekends are blocked automatically
+    if (result.valid && !dateSet.has(dateFormatted)) {
       valid = result.valid
     }
   })
@@ -303,4 +305,20 @@ export const getShortMonthName = (date = new Date()) => {
 
 export const yearMonthDay = date => {
   return format(date, 'YYYY-MM-DD')
+}
+
+/*--------------------------------------------*
+ * Dates from CSV string
+ * '2018-10-17, 2018-11-06, 2018-11-07'
+ *--------------------------------------------*/
+
+export const dateSetFromString = dates => {
+  if (!dates) return new Set()
+  dates = dates.split(',')
+
+  dates = dates.map(date => {
+    return date.trim()
+  })
+
+  return new Set(dates)
 }


### PR DESCRIPTION
This adds a 'blocked' property to the location object to block off calendar days

export const test_location = {
  recurring: {
    ...
  },
  blocked: '2018-10-02, 2018-10-03, 2018-11-21', // use CSV format => 2018-10-02, 2018-10-03, 2018-11-21
}

If the property exists the CSV string will be parsed and dates blocked on those values
<hr>
Adds utility method to parse a CSV string of dates

dateSetFromString takes a 'user entered' date string  i.e. 2018-10-17, 2018-11-06, 2018-11-07
and creates a new JavaScript set.

This will be used for checking if a given date is in the list set.has('2018-10-17')