### PR TITLE
Add some extra checks to WithProvider

### DIFF
--- a/web/src/__tests__/WithProvider.test.js
+++ b/web/src/__tests__/WithProvider.test.js
@@ -35,6 +35,23 @@ class FakeComponentWithFieldsAndValidate {
   constructor() {}
 }
 
+class FakeComponentWithMultipleFieldsAndValidate {
+  static get fields() {
+    return ['field1', 'field2']
+  }
+  static validate(values) {
+    let errors = {}
+    if (values.field1 !== 'value1') {
+      errors.field1 = true
+    }
+    if (values.field2 !== 'value2') {
+      errors.field2 = true
+    }
+    return errors
+  }
+  constructor() {}
+}
+
 describe('_isNonEmptyObject', () => {
   let invalidVals = [0, false, {}, ['value'], null, '', 'value']
   invalidVals.map(v => {
@@ -71,6 +88,12 @@ describe('WithProvider', () => {
     it('returns errors for some other value in its validation method', () => {
       let errors
       errors = WithProvider.validate({ language: 'portuguese' })
+      expect(errors).toEqual({ language: true })
+    })
+
+    it('returns errors for an empty language value', () => {
+      let errors
+      errors = WithProvider.validate({ language: '' })
       expect(errors).toEqual({ language: true })
     })
   })
@@ -371,6 +394,85 @@ describe('WithProvider', () => {
         expect(result2).toEqual({ field: '' })
         // check that the original value is still there
         expect(val2).toEqual({ field: 'wrong value' })
+      })
+    })
+
+    describe('WrappedComponent has multiple `fields` and `validate`', () => {
+      const WithProvider = withProvider(
+        FakeComponentWithMultipleFieldsAndValidate,
+      )
+      it('returns original object when validation passes', () => {
+        let result = WithProvider.validateCookie('page', {
+          field1: 'value1',
+          field2: 'value2',
+        })
+        expect(result).toEqual({
+          field1: 'value1',
+          field2: 'value2',
+        })
+      })
+      let vals = [
+        // only one valid key is passed in
+        {
+          val: { field1: 'value1' },
+          res: { field1: 'value1', field2: '' },
+        },
+        // only one invalid key is passed in
+        {
+          val: { field1: 'wrong value' },
+          res: { field1: '', field2: '' },
+        },
+        // two keys are passed in, one invalid
+        {
+          val: { field1: 'wrong value', field2: 'value2' },
+          res: { field1: '', field2: 'value2' },
+        },
+        // two keys are passed in, both invalid
+        {
+          val: { field1: 'wrong value', field2: 'wrong value 2' },
+          res: { field1: '', field2: '' },
+        },
+        // two keys are passed in, both empty
+        {
+          val: { field1: '', field2: '' },
+          res: { field1: '', field2: '' },
+        },
+        // two keys are passed in, both valid, plus an extra key
+        {
+          val: { field1: 'value1', field2: 'value2', badKey: 'wrong value' },
+          res: { field1: 'value1', field2: 'value2' },
+        },
+        // two keys are passed in, one valid, plus an extra key
+        {
+          val: {
+            field1: 'value1',
+            field2: 'wrong value',
+            badKey: 'wrong value 2',
+          },
+          res: { field1: 'value1', field2: '' },
+        },
+        // two keys are passed in, both invalid, plus an extra key
+        {
+          val: {
+            field1: 'wrong value',
+            field2: 'wrong value 2',
+            badKey: 'wrong value 3',
+          },
+          res: { field1: '', field2: '' },
+        },
+        // no valid keys are passed in
+        {
+          val: {
+            badKey: 'wrong value',
+          },
+          res: false,
+        },
+      ]
+      vals.map(({ val, res }) => {
+        it(`val: ${JSON.stringify(val)}, res: ${JSON.stringify(res)}`, () => {
+          let result = WithProvider.validateCookie('page', val)
+          expect(result).toEqual(res)
+        })
       })
     })
   })


### PR DESCRIPTION
Added some more tests to withProvider to verify that given inputs result in given outputs.

This was part of the work around adding global locations (which was closed: #388) but ultimately works independently of that.

Plus, we had some strange behaviour with these query params before so more tests === better.