### PR TITLE
Add Language component to application

### DIFF
--- a/web/src/components/FederalBanner.js
+++ b/web/src/components/FederalBanner.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import withContext from '../withContext'
-import { contextPropTypes } from '../context'
 import { GoCSignature } from '@cdssnc/gcui'
 import { css } from 'react-emotion'
 import { theme, mediaQuery } from '../styles'
 import LanguageSwitcher from './LanguageSwitcher'
+import Language from './Language'
 
 const container = css`
   padding: ${theme.spacing.lg} ${theme.spacing.xxxl} ${theme.spacing.md}
@@ -42,24 +41,23 @@ const container = css`
   `)};
 `
 
-const FederalBanner = ({ context = {} }) => (
+const FederalBanner = () => (
   <div className={container}>
     <div className="svg-container canada-flag">
-      <GoCSignature
-        width="250px"
-        lang={context.store.language}
-        flag={theme.colour.white}
-        text={theme.colour.white}
-        focusable="false"
+      <Language
+        render={language => (
+          <GoCSignature
+            width="250px"
+            lang={language}
+            flag={theme.colour.white}
+            text={theme.colour.white}
+            focusable="false"
+          />
+        )}
       />
     </div>
     <LanguageSwitcher />
   </div>
 )
-FederalBanner.propTypes = {
-  ...contextPropTypes,
-}
 
-const FederalBannerContext = withContext(FederalBanner)
-
-export { FederalBannerContext as default, FederalBanner as FederalBannerBase }
+export default FederalBanner

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -1,12 +1,11 @@
 import React from 'react'
-import withContext from '../withContext'
-import { contextPropTypes } from '../context'
 import PropTypes from 'prop-types'
 import { Trans, withI18n } from '@lingui/react'
 import CanadaWordmark from '../assets/CanadaWordmark.svg'
 import styled, { css } from 'react-emotion'
 import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
 import { getEmail } from '../locations'
+import Language from './Language'
 
 const footer = css`
   background-color: ${theme.colour.white};
@@ -101,7 +100,7 @@ const TopBar = styled.hr(
   props => ({ background: props.background }),
 )
 
-const Footer = ({ topBarBackground, i18n, context = {} }) => (
+const Footer = ({ topBarBackground, i18n }) => (
   <div>
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
     <footer className={footer}>
@@ -114,34 +113,38 @@ const Footer = ({ topBarBackground, i18n, context = {} }) => (
         </a>
         <a href={i18n._('https://digital.canada.ca/legal/terms/')}>
           <Trans>Terms</Trans>
-          {context.store &&
-          context.store.language &&
-          context.store.language === 'fr' ? (
-            ''
-          ) : (
-            <span className={visuallyhiddenMobile}> and Conditions</span>
-          )}
+          <Language
+            render={language =>
+              language === 'fr' ? null : (
+                <span className={visuallyhiddenMobile}> and Conditions</span>
+              )
+            }
+          />
         </a>
       </div>
 
       <div className="svg-container">
-        <img
-          src={CanadaWordmark}
-          alt={
-            context.store.language === 'en'
-              ? 'Symbol of the Government of Canada'
-              : 'Symbole du gouvernement du Canada'
-          }
+        <Language
+          render={language => (
+            <img
+              src={CanadaWordmark}
+              alt={
+                language === 'en'
+                  ? 'Symbol of the Government of Canada'
+                  : 'Symbole du gouvernement du Canada'
+              }
+            />
+          )}
         />
       </div>
     </footer>
   </div>
 )
 Footer.propTypes = {
-  ...contextPropTypes,
   topBarBackground: PropTypes.string,
+  i18n: PropTypes.object,
 }
 
-const FooterContext = withContext(withI18n()(Footer))
+const FooterI18n = withI18n()(Footer)
 
-export { FooterContext as default, Footer as FooterBase }
+export { FooterI18n as default, Footer as FooterBase }

--- a/web/src/components/Language.js
+++ b/web/src/components/Language.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withContext from '../withContext'
+import { contextPropTypes } from '../context'
+
+class Language extends React.Component {
+  render() {
+    let { context: { store: { language = 'en' } = {} } = {} } = this.props
+    return <React.Fragment>{this.props.render(language)}</React.Fragment>
+  }
+}
+Language.propTypes = {
+  ...contextPropTypes,
+  render: PropTypes.func.isRequired,
+}
+
+export default withContext(Language)

--- a/web/src/components/__tests__/FederalBanner.test.js
+++ b/web/src/components/__tests__/FederalBanner.test.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { FederalBannerBase as FederalBanner } from '../FederalBanner'
-import { getStore } from './LanguageSwitcher.test.js'
+import FederalBanner from '../FederalBanner'
 
 describe('<FederalBanner />', () => {
   it('renders', () => {
-    const federalBanner = shallow(<FederalBanner context={getStore('en')} />)
+    const federalBanner = shallow(<FederalBanner />)
     expect(federalBanner.find('.svg-container').length).toBe(1)
   })
 })

--- a/web/src/components/__tests__/Footer.test.js
+++ b/web/src/components/__tests__/Footer.test.js
@@ -1,28 +1,26 @@
 import React from 'react'
 import { mount, render } from 'enzyme'
 import { FooterBase as Footer } from '../Footer'
-import { getStore } from './LanguageSwitcher.test.js'
 import { i18n } from '@lingui/core'
 import { getEmail } from '../../locations'
+import { Context } from '../../context'
 
 describe('<Footer />', () => {
   it('renders footer', () => {
-    const footer = render(<Footer context={getStore('en')} i18n={i18n} />)
+    const footer = render(<Footer i18n={i18n} />)
     expect(footer.find('footer').length).toBe(1)
     expect(footer.find('hr').length).toBe(0)
   })
 
   it('renders footer with topBar', () => {
     // have to use 'mount' instead of 'shallow' to render nested components
-    const footer = mount(
-      <Footer topBarBackground="black" context={getStore('en')} i18n={i18n} />,
-    )
+    const footer = mount(<Footer topBarBackground="black" i18n={i18n} />)
     expect(footer.find('footer').length).toBe(1)
     expect(footer.find('hr').length).toBe(1)
   })
 
   it('renders footer with IRCC email in contact information', () => {
-    const footer = render(<Footer context={getStore('en')} i18n={i18n} />)
+    const footer = render(<Footer i18n={i18n} />)
     expect(footer.find('footer').length).toBe(1)
     expect(
       footer
@@ -33,7 +31,7 @@ describe('<Footer />', () => {
   })
 
   it('renders "and Conditions" in English', () => {
-    const footer = mount(<Footer context={getStore('en')} i18n={i18n} />)
+    const footer = mount(<Footer i18n={i18n} />)
     expect(
       footer
         .find('a')
@@ -43,7 +41,12 @@ describe('<Footer />', () => {
   })
 
   it('renders without "and Conditions" in French', () => {
-    const footer = mount(<Footer context={getStore('fr')} i18n={i18n} />)
+    console.error = jest.fn() // eslint-disable-line no-console
+    const footer = mount(
+      <Context.Provider value={{ store: { language: 'fr' } }}>
+        <Footer i18n={i18n} />
+      </Context.Provider>,
+    )
     expect(
       footer
         .find('a')
@@ -53,7 +56,11 @@ describe('<Footer />', () => {
   })
 
   it('renders with Canadawordmark in French with corresponding alt attr', () => {
-    const footer = mount(<Footer context={getStore('fr')} i18n={i18n} />)
+    const footer = mount(
+      <Context.Provider value={{ store: { language: 'fr' } }}>
+        <Footer i18n={i18n} />
+      </Context.Provider>,
+    )
     expect(footer.find('img').length).toBe(1)
     expect(footer.find('img').prop('alt')).toEqual(
       'Symbole du gouvernement du Canada',
@@ -61,7 +68,7 @@ describe('<Footer />', () => {
   })
 
   it('renders with Canadawordmark in English with corresponding alt attr', () => {
-    const footer = mount(<Footer context={getStore('en')} i18n={i18n} />)
+    const footer = mount(<Footer i18n={i18n} />)
     expect(footer.find('img').length).toBe(1)
     expect(footer.find('img').prop('alt')).toEqual(
       'Symbol of the Government of Canada',

--- a/web/src/components/__tests__/Language.test.js
+++ b/web/src/components/__tests__/Language.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import Language from '../Language'
+import { Context } from '../../context'
+
+describe('<Language />', () => {
+  it('returns language string passed-in the context', () => {
+    const wrapper = mount(
+      <Context.Provider value={{ store: { language: 'fr' } }}>
+        <Language render={language => <span>Language: {language}</span>} />
+      </Context.Provider>,
+    )
+    expect(wrapper.find('span').text()).toBe('Language: fr')
+  })
+
+  it('returns default language "en" when no language string exists in context', () => {
+    const wrapper = mount(
+      <Context.Provider value={{ store: {} }}>
+        <Language render={language => <span>Language: {language}</span>} />
+      </Context.Provider>,
+    )
+    expect(wrapper.find('span').text()).toBe('Language: en')
+  })
+
+  it('returns default language "en" when no context has been set', () => {
+    const wrapper = mount(
+      <Language render={language => <span>Language: {language}</span>} />,
+    )
+    expect(wrapper.find('span').text()).toBe('Language: en')
+  })
+})

--- a/web/src/context.js
+++ b/web/src/context.js
@@ -9,7 +9,7 @@ export const contextDefault = {
 export const contextPropTypes = {
   context: PropTypes.shape({
     store: PropTypes.object.isRequired,
-    setStore: PropTypes.func.isRequired,
+    setStore: PropTypes.func,
   }),
 }
 

--- a/web/src/pages/CalendarPage.js
+++ b/web/src/pages/CalendarPage.js
@@ -199,7 +199,7 @@ class CalendarPage extends Component {
     this.changeMonth()
   }
 
-  /* 
+  /*
   Check if the form was redirected from the server
   */
 
@@ -384,7 +384,7 @@ class CalendarPage extends Component {
                     }}
                   >
                     <ErrorMessage
-                      message={err ? err : ''}
+                      message={err ? err : null}
                       id="fewerDays-error"
                     />
                   </div>
@@ -475,9 +475,7 @@ class NoJS extends Component {
           <ErrorList message={errorsNoJS.selectedDays}>
             <a href="#selectedDays-form">Calendar</a>
           </ErrorList>
-        ) : (
-          ''
-        )}
+        ) : null}
         {/*
           the first checkbox / radio on the page doesn't have its CSS applied correctly
           so this is a dummy checkbox that nobody should ever see

--- a/web/src/pages/LandingPage.js
+++ b/web/src/pages/LandingPage.js
@@ -9,8 +9,7 @@ import { buttonStyles } from '../components/forms/Button'
 import { Trans } from '@lingui/react'
 import rightArrow from '../assets/rightArrow.svg'
 import { getStartMonthName, getEndMonthName } from '../utils/calendarDates'
-import withContext from '../withContext'
-import { contextPropTypes } from '../context'
+import Language from '../components/Language'
 
 const contentClass = css`
   p {
@@ -86,16 +85,6 @@ const landingArrow = css`
 
 class LandingPage extends React.Component {
   render() {
-    let locale = 'en'
-
-    if (
-      this.props &&
-      this.props.context &&
-      this.props.context.store &&
-      this.props.context.store.language
-    ) {
-      locale = this.props.context.store.language
-    }
     return (
       <Layout
         contentClass={contentClass}
@@ -140,8 +129,15 @@ class LandingPage extends React.Component {
                 <Trans>3 days</Trans>
               </strong>{' '}
               <Trans>you’re available between </Trans>{' '}
-              {getStartMonthName(new Date(), locale)} <Trans>and</Trans>{' '}
-              {getEndMonthName(new Date(), locale)}.
+              <Language
+                render={locale => (
+                  <React.Fragment>
+                    {getStartMonthName(new Date(), locale)} <Trans>and</Trans>{' '}
+                    {getEndMonthName(new Date(), locale)}
+                  </React.Fragment>
+                )}
+              />
+              .
             </p>
           </div>
 
@@ -172,8 +168,7 @@ class LandingPage extends React.Component {
 }
 
 LandingPage.propTypes = {
-  ...contextPropTypes,
   ...matchPropTypes,
 }
 
-export default withContext(LandingPage)
+export default LandingPage


### PR DESCRIPTION
Started working on this earlier as an offshoot of #388, but then left it for a while.

## Create a Language component 

React context contains pretty much all of the session data we have throughout the app, but it's not always easy to get.

If all we need is the language string, wrapping another component in `Language`, and passing the language string as a render prop is quite a bit easier than doing a large object destructure every time.

Usage looks like:

```js
<Language
  render={(language) => (<span>The language is {language}</span>) } 
/>
```