### PR TITLE
Use env var for site url / redirect

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,8 @@
     "RAZZLE_IRCC_RECEIVING_ADDRESS": { "required": true },
     "RAZZLE_PAPER_FILE_NUMBER_PATTERN": { "required": true },
     "RAZZLE_PUBLIC_DIR": { "required": true },
-    "RAZZLE_SENDING_ADDRESS": { "required": true }
+    "RAZZLE_SENDING_ADDRESS": { "required": true },
+    "RAZZLE_SITE_URL": { "required": true }
   },
   "formation": {},
   "addons": [],

--- a/web/README.md
+++ b/web/README.md
@@ -28,7 +28,7 @@ These options are set in all environments (except during tests).
 
 - `RAZZLE_SENDING_ADDRESS`: Requests will be marked as sent from this email address. Must be [verified by SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html). Required on startup.
 
-- `RAZZLE_SITE_URL`: Used by [`inline-css`](https://www.npmjs.com/package/inline-css) to generate links in emails. Leaving this blank (`' '`) is recommended. Required on startup.
+- `RAZZLE_SITE_URL`: URL to be used for things such as redirects.
 
 - `RAZZLE_STAGE`: Used to introspect where the app is running. One of `production`, `staging`, or `development`.
 
@@ -43,7 +43,7 @@ RAZZLE_AWS_REGION=some-region-1
 RAZZLE_AWS_SECRET_ACCESS_KEY=someAccessKey
 RAZZLE_IRCC_RECEIVING_ADDRESS=your.name@example.com
 RAZZLE_SENDING_ADDRESS=justin@canada.ca
-RAZZLE_SITE_URL=' '
+RAZZLE_SITE_URL=rescheduler-dev.cds-snc.ca
 RAZZLE_STAGE='development'
 ```
 

--- a/web/src/email/sendmail.js
+++ b/web/src/email/sendmail.js
@@ -13,6 +13,8 @@ if (process.env.NODE_ENV !== 'test') {
     throw new Error('process.env.RAZZLE_IRCC_RECEIVING_ADDRESS was not found')
   if (!process.env.RAZZLE_SENDING_ADDRESS)
     throw new Error('process.env.RAZZLE_SENDING_ADDRESS was not found')
+  if (!process.env.RAZZLE_SITE_URL)
+    throw new Error('process.env.RAZZLE_SITE_URL was not found')
 }
 
 export const getMailer = async () => {

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -89,11 +89,7 @@ const getPrimarySubdomain = function(req, res, next) {
     Note: Will need to remove links i.e. contact etc..
     so they don't end up at the wrong location
     */
-
-    // Todo: Would rather not introduce another env variable here
-    // hard code for testing
-    return res.redirect('https://rescheduler-dev.cds-snc.ca/not-found')
-    //return res.redirect(process.env.SITE_URL + '/not-found')
+    return res.redirect(process.env.RAZZLE_SITE_URL + '/not-found')
   }
 
   next()

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -89,7 +89,7 @@ const getPrimarySubdomain = function(req, res, next) {
     Note: Will need to remove links i.e. contact etc..
     so they don't end up at the wrong location
     */
-    return res.redirect(process.env.RAZZLE_SITE_URL + '/not-found')
+    return res.redirect(`https://${process.env.RAZZLE_SITE_URL}/not-found`)
   }
 
   next()


### PR DESCRIPTION
This update makes use of the existing RAZZLE_SITE_URL env variable.  We'll need to update that to allow the site to redirect to a "generic" not found and maybe error page as needed.

@pcraig3 to be discussed should we keep the "base domain" alive to host generic pages (no location etc... needed)?