### PR TITLE
Use http as redirect protocol if running locally

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -51,12 +51,12 @@ RAZZLE_STAGE='development'
 
 These options are set locally, whether running in development (`yarn dev`) or production (`yarn start`) modes. They are never deployed to the server.
 
-- `RAZZLE_COOKIE_HTTP`: Secure cookies will only served over `https` connections. Since we develop locally on `http`, we need this variable set to `true` so that we can save data between pages.
+- `RAZZLE_IS_HTTP`: Secure cookies will only served over `https` connections. Similarly, when we do redirects on the server and we need the full domain string, we need to know if we're on `https` or `http`. Since we develop locally on `http`, but run our production site on `https`, we need this variable set to `true` so that we can save data between pages and redirect to the right address.
 
 ##### sample `web/.env.local` file
 
 ```
-RAZZLE_COOKIE_HTTP=true
+RAZZLE_IS_HTTP=true
 ```
 
 #### 3. `web/.env.production`

--- a/web/src/cookies.js
+++ b/web/src/cookies.js
@@ -6,7 +6,7 @@ export const setStoreCookie = (setCookieFunc, cookie, options = {}) => {
 
   let defaults = {
     secure:
-      !process.env.RAZZLE_COOKIE_HTTP && process.env.NODE_ENV === 'production',
+      !process.env.RAZZLE_IS_HTTP && process.env.NODE_ENV === 'production',
     expires:
       process.env.NODE_ENV === 'production' ? inOneDay() : inTenMinutes(),
   }

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -86,7 +86,10 @@ const getPrimarySubdomain = function(req, res, next) {
     req.url.indexOf('not-found') === -1
   ) {
     // redirect to generic not found page
-    return res.redirect(`https://${process.env.RAZZLE_SITE_URL}/not-found`)
+    const protocol = process.env.RAZZLE_IS_HTTP ? 'http' : 'https'
+    return res.redirect(
+      `${protocol}://${process.env.RAZZLE_SITE_URL}/not-found`,
+    )
   }
 
   next()


### PR DESCRIPTION
So this is a best-guess.

If we're running locally, we're probably on 3004.
If that's in the site URL, we want to stay on HTTP.

**Other option that occurred to me:**
Might be better to re-use the `RAZZLE_COOKIE_HTTP` var since that one is only for HTTP environments.