### PR TITLE
Stop infinite loop for startup errors

### DIFF
--- a/web/src/email/sendmail.js
+++ b/web/src/email/sendmail.js
@@ -14,6 +14,16 @@ if (process.env.NODE_ENV !== 'test') {
     throw new Error('process.env.RAZZLE_SENDING_ADDRESS was not found')
   if (!process.env.RAZZLE_SITE_URL)
     throw new Error('process.env.RAZZLE_SITE_URL was not found')
+  if (
+    process.env.RAZZLE_STAGE &&
+    process.env.RAZZLE_STAGE !== 'production' &&
+    !process.env.RAZZLE_IRCC_TEST_RECEIVING_ADDRESS
+  )
+    throw new Error(
+      `process.env.RAZZLE_STAGE is set to ${
+        process.env.RAZZLE_STAGE
+      } but process.env.RAZZLE_IRCC_TEST_RECEIVING_ADDRESS was not found`,
+    )
 }
 
 export const getMailer = async () => {

--- a/web/src/locations/index.js
+++ b/web/src/locations/index.js
@@ -75,7 +75,7 @@ export const getReceivingEmail = (location = getGlobalLocation()) => {
     return process.env.RAZZLE_IRCC_TEST_RECEIVING_ADDRESS
   }
 
-  if (location && location.receivingEmail && !process.env.RAZZLE_STAGE) {
+  if (location && location.receivingEmail) {
     return location.receivingEmail
   }
 

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -93,13 +93,13 @@ const getPrimarySubdomain = function(req, res, next) {
 }
 
 const _ensureBody = (req, res, next, cb) => {
-  if (req.path === '/error') return next()
+  if (req.path === '/500') return next()
 
   try {
     cb()
   } catch (e) {
     Raven.captureException(e)
-    return res.redirect('/error')
+    return res.redirect('/500')
   }
 
   return next()

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -92,32 +92,27 @@ const getPrimarySubdomain = function(req, res, next) {
   next()
 }
 
-const ensureLocation = (req, res, next) => {
+const _ensureBody = (req, res, next, cb) => {
+  if (req.path === '/error') return next()
+
   try {
-    /*
-    At this point we should have a location
-     */
-    getGlobalLocation(req.subdomain)
+    cb()
   } catch (e) {
     Raven.captureException(e)
     return res.redirect('/error')
   }
 
-  next()
+  return next()
+}
+
+const ensureLocation = (req, res, next) => {
+  /* If we don't have a location string being passed in, something is wrong */
+  return _ensureBody(req, res, next, () => getGlobalLocation(req.subdomain))
 }
 
 const ensureReceivingEmail = (req, res, next) => {
-  /*
-  If we don't have a receivingEmail something
-  isn't configured properly
-  */
-  try {
-    getReceivingEmail()
-    next()
-  } catch (e) {
-    Raven.captureException(e)
-    return res.redirect('/error')
-  }
+  /* If we don't have a receiving email, something isn't configured properly */
+  return _ensureBody(req, res, next, getReceivingEmail)
 }
 
 server


### PR DESCRIPTION
In our middleware, we will throw an error if there is no location string or if there is no receiving email address shown.

On the landing page, if we hit an error, it would redirect to the error page.
Unfortunately, the error page would also encounter the same error.

This meant that we would end up with an infinite loop if we ran into any of these.

This commit generalises some of the code, and helps mitigate infinite error loops. **Line 100 is the operative one**: `if (req.path === '/error') return next()`

*Note: this doesn't get us out of the woods because we can still have the location string taking down the app if it's not there at all, but it helps.*