### PR TITLE
Remove contact link on generic not found page

### DIFF
--- a/web/cypress/integration/main/generic-not-found.spec.js
+++ b/web/cypress/integration/main/generic-not-found.spec.js
@@ -1,0 +1,21 @@
+context('Contact link on Not Found (404) page', () => {
+  it("should not have contact link", () => {
+    cy.visit('/not-found')
+    cy.get('#footer div a')
+      .eq(0)
+      .should('contain', 'Privacy')
+    cy.get('#footer a')
+      .eq(1)
+      .should('contain', 'Terms and Conditions')
+  })
+
+  it('should have a contact link', () => {
+    cy.visit('/some page')
+    cy.get('#footer div a')
+      .eq(0)
+      .should('contain', 'Contact')
+    cy.get('#footer a')
+      .eq(1)
+      .should('contain', 'Privacy')
+  })
+})

--- a/web/src/components/Footer.js
+++ b/web/src/components/Footer.js
@@ -6,6 +6,7 @@ import styled, { css } from 'react-emotion'
 import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
 import { getEmail } from '../locations'
 import Language from './Language'
+import { withRouter } from 'react-router'
 
 const footer = css`
   background-color: ${theme.colour.white};
@@ -100,14 +101,16 @@ const TopBar = styled.hr(
   props => ({ background: props.background }),
 )
 
-const Footer = ({ topBarBackground, i18n }) => (
+const Footer = ({ topBarBackground, i18n, match = { url: '' } }) => (
   <div>
     {topBarBackground ? <TopBar background={topBarBackground} /> : ''}
-    <footer className={footer}>
+    <footer id="footer" className={footer}>
       <div className={bottomLinks}>
-        <a href={`mailto:${getEmail()}`}>
-          <Trans>Contact</Trans>
-        </a>
+        {match.url !== '/not-found' && (
+          <a href={`mailto:${getEmail()}`}>
+            <Trans>Contact</Trans>
+          </a>
+        )}
         <a href={i18n._('https://www.canada.ca/en/transparency/privacy.html')}>
           <Trans>Privacy</Trans>
         </a>
@@ -143,8 +146,9 @@ const Footer = ({ topBarBackground, i18n }) => (
 Footer.propTypes = {
   topBarBackground: PropTypes.string,
   i18n: PropTypes.object,
+  match: PropTypes.object,
 }
 
-const FooterI18n = withI18n()(Footer)
+const FooterI18n = withI18n()(withRouter(Footer))
 
 export { FooterI18n as default, Footer as FooterBase }

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -86,10 +86,6 @@ const getPrimarySubdomain = function(req, res, next) {
     req.url.indexOf('not-found') === -1
   ) {
     // redirect to generic not found page
-    /*
-    Note: Will need to remove links i.e. contact etc..
-    so they don't end up at the wrong location
-    */
     return res.redirect(`https://${process.env.RAZZLE_SITE_URL}/not-found`)
   }
 


### PR DESCRIPTION
If redirecting from the server (i.e. no location found) we need to have a generic not found page.  This is needed to avoid people contacting an incorrect office.

Checks are based on a specific page name /not-found

Other 404 pages /some-page will be treated as a location not found page and still contain the contact link

## Pages

**/not-found**

<img width="614" alt="screen shot 2018-08-29 at 9 39 09 am" src="https://user-images.githubusercontent.com/62242/44792684-79082b00-ab72-11e8-8af3-f20a33188d37.png">

<hr>

**/some-missing-page**

<img width="459" alt="screen shot 2018-08-29 at 9 39 27 am" src="https://user-images.githubusercontent.com/62242/44792692-7c9bb200-ab72-11e8-9598-dabb53a8646d.png">

