### PR TITLE
Move error out of LocationCache

### DIFF
--- a/web/src/locations/index.js
+++ b/web/src/locations/index.js
@@ -27,9 +27,7 @@ const LocationCache = (function() {
         if (process.env.NODE_ENV === 'test') {
           location = 'vancouver'
         } else {
-          throw new Error(
-            'LocationCache.getLocation: `location` must be a non-empty string',
-          )
+          location = 'undefined'
         }
       }
       _setLocation(location)
@@ -45,6 +43,14 @@ const LocationCache = (function() {
 
 export const getGlobalLocation = subdomain => {
   return LocationCache.getLocation(subdomain)
+}
+
+export const setGlobalLocation = subdomain => {
+  if (!subdomain) {
+    throw new Error('setGlobalLocation: `subdomain` must be a non-empty string')
+  }
+
+  return getGlobalLocation(subdomain)
 }
 
 export const getEmail = (location = getGlobalLocation()) => {

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -17,7 +17,7 @@ import {
   cleanDates,
   sendMail,
 } from './email/sendmail'
-import { getGlobalLocation, getReceivingEmail } from '../src/locations'
+import { setGlobalLocation, getReceivingEmail } from '../src/locations'
 import gitHash from './utils/gitHash'
 import Raven from 'raven'
 Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {
@@ -110,7 +110,7 @@ const _ensureBody = (req, res, next, cb) => {
 
 const ensureLocation = (req, res, next) => {
   /* If we don't have a location string being passed in, something is wrong */
-  return _ensureBody(req, res, next, () => getGlobalLocation(req.subdomain))
+  return _ensureBody(req, res, next, () => setGlobalLocation(req.subdomain))
 }
 
 const ensureReceivingEmail = (req, res, next) => {


### PR DESCRIPTION
With the Error being thrown in LocationCache, any call in the application could potentially trigger it depending on the order of code execution. This means that we could end up in a scenario where _every_ page triggers the same error forever.

It's possible to be much more prescriptive about this.

- We want to set the location once upfront.
- If no location string exists and if no location has been saved already then we want to thrown an error

Removed the `throw new Error` from LocationCache and put it into a new function called `setGlobalLocation`, which is called at the very beginning when the app starts up.

If en error is thrown there, then we go to the 500 page.
Once we're on the 500 page, we won't throw the `LocationCache` error anymore so hopefully we no longer have to worry about  infinite loops that send 70k error messages to sentry.

What we want is to set the location once, and then throw an error once if it's not configured properly.