### PR TITLE
Enforce subdomain

### DIFF
--- a/web/cypress/integration/main/force-redirect.spec.js
+++ b/web/cypress/integration/main/force-redirect.spec.js
@@ -1,0 +1,39 @@
+context('Force redirect', () => {
+  it('should force redirect from "local" dev server', () => {
+    cy.visit('http://rescheduler-dev.vcap.me:3004')
+    cy.url().should('include', 'vancouver')
+  })
+
+  it('should force redirect from "local" live server', () => {
+    cy.visit('http://rescheduler-dev.vcap.me:3004')
+    cy.url().should('include', 'vancouver')
+  })
+
+  it('should force not redirect if on "not found" page', () => {
+    cy.visit('http://rescheduler-dev.vcap.me:3004/not-found')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Page not found.')
+  })
+
+  it('should force not redirect if not on 500 page', () => {
+    cy.visit('http://rescheduler-dev.vcap.me:3004/500')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Server Error.')
+  })
+
+  it('should force redirect from "local" live server with UTM', () => {
+    cy.visit(
+      'http://rescheduler.vcap.me:3004?utm_source=BELA%20email&utm_medium=email',
+    )
+    cy.url().should('include', 'vancouver')
+  })
+
+  it("should force redirect if sub-domain isn't whitelisted", () => {
+    cy.visit('http://test.rescheduler-dev.vcap.me:3004')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Page not found.')
+  })
+})

--- a/web/src/server.js
+++ b/web/src/server.js
@@ -104,7 +104,7 @@ const getPrimarySubdomain = function(req, res, next) {
   */
 
   if (forceRedirect(req)) {
-    return res.redirect(`https://vancouver.${process.env.RAZZLE_SITE_URL}`)
+    return res.redirect(`${protocol}://vancouver.${process.env.RAZZLE_SITE_URL}`)
   }
 
   /* If domain isn't on the whitelist and we're not on the not-found or 500 page */


### PR DESCRIPTION
When a user is visiting the website using the staging or live url + the base sub-domain we need to redirect to a proper location sub-domain.

Later we will 404 the use of the base sub-domain but this case needs to be handled for existing links.

**Testing manually :**
Use: http://rescheduler-dev.vcap.me:3004 & http://rescheduler.vcap.me:3004

