### PR TITLE
Limit emails sent by tests

### DIFF
--- a/web/cypress/integration/main/form-bela-params.spec.js
+++ b/web/cypress/integration/main/form-bela-params.spec.js
@@ -6,6 +6,6 @@ context('Full Run-through with Bela params', () => {
   })
 
   it('should be able to fill in a profile and reach the confirmation page', () => {
-    fullRun(cy)
+    fullRun(cy, 'en', false)
   })
 })

--- a/web/cypress/integration/main/form.spec-fr.js
+++ b/web/cypress/integration/main/form.spec-fr.js
@@ -1,11 +1,11 @@
 import { fullRun } from './full-run'
 
-context('Full Run-through', () => {
+context('Full Run-through FR', () => {
   beforeEach(() => {
     cy.visit('/')
   })
 
   it('should be able to fill in a profile and reach the confirmation page', () => {
-    fullRun(cy, 'fr')
+    fullRun(cy, 'fr', false)
   })
 })

--- a/web/cypress/integration/main/form.spec.js
+++ b/web/cypress/integration/main/form.spec.js
@@ -1,11 +1,11 @@
 import { fullRun } from './full-run'
 
-context('Full Run-through', () => {
+context('Full Run-through EN', () => {
   beforeEach(() => {
     cy.visit('/')
   })
 
   it('should be able to fill in a profile and reach the confirmation page', () => {
-    fullRun(cy)
+    fullRun(cy, 'en', false)
   })
 })

--- a/web/cypress/integration/main/full-run.js
+++ b/web/cypress/integration/main/full-run.js
@@ -1,4 +1,4 @@
-export const fullRun = (cy, locale = 'en') => {
+export const fullRun = (cy, locale = 'en', sendMail = false) => {
   let startText = 'Start now'
 
   if (locale === 'fr') {
@@ -53,7 +53,12 @@ export const fullRun = (cy, locale = 'en') => {
       cy.get('main').should('contain', data.explanation)
     })
 
-    cy.get('#review-form').submit({ force: true })
+    // we don't need to send emails for all the tests
+    if (sendMail) {
+      cy.get('#review-form').submit({ force: true })
+    } else {
+      cy.visit('/confirmation')
+    }
 
     // should hit the confirm page now
     cy.url().should('contain', '/confirmation')

--- a/web/cypress/integration/main/validation-error-query-params.spec.js
+++ b/web/cypress/integration/main/validation-error-query-params.spec.js
@@ -69,11 +69,6 @@ context(
           cy.get('main').should('contain', val),
         )
       })
-
-      cy.get('#review-form').submit({ force: true })
-
-      // should hit the confirm page now
-      cy.url().should('contain', '/confirmation')
     })
   },
 )


### PR DESCRIPTION
The tests are firing multiple emails every time there is a PR.  This limits the emails sent per run down to a single test that does a full run with validation errors.

Ideally with less emails being sent if something is off we'll notice sooner.

@pcraig3 ultimately it would be nice to find something that would verify receipt to an inbox.  Looking to at least cut down on the noise for now.  