### PR TITLE
Update no js pattern for yarn test

### DIFF
--- a/web/jest-no-js.config.js
+++ b/web/jest-no-js.config.js
@@ -7,6 +7,6 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
     'NoJS.test.js',
-    'NoJS-family.test.js',
+    'NoJS-*',
   ],
 }


### PR DESCRIPTION
Running yarn test locally is failing the NoJS tests. We shouldn't be including the NoJS tests for that test run.  Use a wildcard when looking for the NoJs tests.

Thinking for CI we should split them out into separate runs.  Running nojs:tests  as a separate step.

