### PR TITLE
Update email templates to handle availability explanation

### DIFF
--- a/web/cypress/fixtures/user.json
+++ b/web/cypress/fixtures/user.json
@@ -1,7 +1,7 @@
 
 {
 "fullName": "Leanne Graham",
-"email": "cdc@example.com",
+"email": "cds@example.com",
 "paperFileNumber": "123456",
 "reason": "workOrSchool",
 "explanation": "On business trip!",

--- a/web/email_templates/applicant-plain.html
+++ b/web/email_templates/applicant-plain.html
@@ -7,7 +7,7 @@ We received your request for a new citizenship appointment.
 Individuals to be rescheduled:
 ${fullName} ${familyOption}
 
-These are the days you selected:
+${datesLabel}
 ${datesPlain}
 
 What happens next?
@@ -26,7 +26,7 @@ Nous avons bien reçu votre demande de nouveau rendez-vous d’examen de citoyen
 Les individus qui doivent être reportés :
 ${fullName} ${familyOption}
 
-Voici les journées que vous avez sélectionnées :
+${datesLabelFR}
 ${datesPlainFR}
 
 Quelles sont les étapes suivantes?

--- a/web/email_templates/applicant-rich.html
+++ b/web/email_templates/applicant-rich.html
@@ -32,7 +32,6 @@
     padding-top: 10px;
     max-width: 750px;
   }
-
 </style>
 <div class="wrap">
   <p>
@@ -41,42 +40,41 @@
   <p class="margin-top">Hello ${fullName},</p>
   <p>We received your request for a new citizenship appointment.</p>
   <div id="family-option">
-      <h3>Individuals to be rescheduled:</h3>
-            <p>${fullName} ${familyOption} </p>
+    <h3>Individuals to be rescheduled:</h3>
+    <p>${fullName} ${familyOption} </p>
   </div>
-      <h3>These are the days you selected:</h3>
-      <div>
-        ${datesHtml}
-      </div>
+  <h3>${datesLabel}</h3>
+  <div>
+    ${datesHtml}
+  </div>
 
-      <h3>What happens next?</h3>
-      <p><abbr title="Immigration, Refugees and Citizenship Canada">IRCC</abbr> will send you a new appointment. You will always be contacted at least 3 weeks before your appointment.</p>
+  <h3>What happens next?</h3>
+  ${whatHappensNext}
 
-      <h3>If you have any questions, please contact:</h3>
-      <p>${locationEmail}</p>
-      <p>${locationPhone}</p>
+  <h3>If you have any questions, please contact:</h3>
+  <p>${locationEmail}</p>
+  <p>${locationPhone}</p>
 
-      <hr />
-      <p class="margin-top">Bonjour ${fullName},</p>
-      <p>Nous avons bien reçu votre demande de nouveau rendez-vous d’examen de citoyenneté.</p>
+  <hr />
+  <p class="margin-top">Bonjour ${fullName},</p>
+  <p>Nous avons bien reçu votre demande de nouveau rendez-vous d’examen de citoyenneté.</p>
 
-      <h3>Les individus qui doivent être reportés :</h3>
-      <p>${fullName} ${familyOption} </p>
+  <h3>Les individus qui doivent être reportés :</h3>
+  <p>${fullName} ${familyOption} </p>
 
-      <h3>Voici les journées que vous avez sélectionnées :</h3>
-      <div>
-        ${datesHtmlFR}
-      </div>
+  <h3>${datesLabelFR}</h3>
+  <div>
+    ${datesHtmlFR}
+  </div>
 
-      <h3>Quelles sont les étapes suivantes?</h3>
-      <p><abbr title="Immigration, Réfugiés et Citoyenneté Canada">IRCC</abbr> vous enverrons les détails de votre nouveau rendez-vous. Nous communiquerons avec vous au moins 3 semaines avant votre rendez-vous.</p>
+  <h3>Quelles sont les étapes suivantes?</h3>
+  ${whatHappensNextFR}
+  <h3>Si vous avez des questions, communiquez avec:</h3>
+  <p>${locationEmail}</p>
+  <p>${locationPhone}</p>
 
-      <h3>Si vous avez des questions, communiquez avec:</h3>
-      <p>${locationEmail}</p>
-      <p>${locationPhone}</p>
-
-      <hr />
-      <div class="align-right">
-        <img width="150" src="cid:ircc-wordmark@cds" />
-      </div>
+  <hr />
+  <div class="align-right">
+    <img width="150" src="cid:ircc-wordmark@cds" />
+  </div>
 </div>

--- a/web/src/email/email-template.js
+++ b/web/src/email/email-template.js
@@ -100,11 +100,11 @@ const renderMarkup = async options => {
   ])
 }
 
-export const buildParams = async options => {
-  const { selectedDays } = options.formValues
-
-  options.formValues.respondByDate = respondByDate(selectedDays, 'en')
-  options.formValues.respondByDateFR = respondByDate(selectedDays, 'fr')
+const renderSelectedDays = options => {
+  const selectedDays = options.formValues.selectedDays
+  options.formValues.datesLabel = 'These are the days you selected:'
+  options.formValues.datesLabelFR =
+    'Voici les journées que vous avez sélectionnées:'
 
   // add line breaks to dates available
   options.formValues.datesHtml = datesMarkup(
@@ -128,6 +128,42 @@ export const buildParams = async options => {
     humanReadable(selectedDays, 'fr'),
     '\r\n',
   )
+
+  options.formValues.whatHappensNext =
+    '<p><abbr title="Immigration, Refugees and Citizenship Canada">IRCC</abbr> will send you a new appointment. You will always be contacted at least 3 weeks before your appointment.</p>'
+
+  options.formValues.whatHappensNextFR =
+    '<p><abbr title="Immigration, Réfugiés et Citoyenneté Canada">IRCC</abbr> vous enverrons les détails de votre nouveau rendez-vous. Nous communiquerons avec vous au moins 3 semaines avant votre rendez-vous.</p>'
+}
+
+const renderAvailabilityExplanation = options => {
+  const availability = options.formValues.availabilityExplanation
+  options.formValues.datesLabel = 'When are you unavailable?'
+  options.formValues.datesLabelFR = 'Quand êtes-vous indisponible?'
+  options.formValues.datesHtml = availability
+  options.formValues.datesHtmlFR = availability
+  options.formValues.datesPlain = availability
+  options.formValues.datesPlainFR = availability
+
+  options.formValues.whatHappensNext =
+    '<p>You should plan to attend your existing appointment until we contact you. This may take 1 week.</p>'
+
+  options.formValues.whatHappensNextFR =
+    '<p>Vous devriez prévoir assister à votre rendez-vous actuel jusqu’à ce que nous communiquions avec vous. Cela pourrait prendre jusqu’à une semaine.</p>'
+}
+
+export const buildParams = async options => {
+  const { selectedDays, availabilityExplanation } = options.formValues
+
+  options.formValues.respondByDate = respondByDate(selectedDays, 'en')
+  options.formValues.respondByDateFR = respondByDate(selectedDays, 'fr')
+
+  // render selected dates or unavailability
+  if (availabilityExplanation) {
+    renderAvailabilityExplanation(options)
+  } else {
+    renderSelectedDays(options)
+  }
 
   options.formValues.locationEmail = getEmail()
   options.formValues.locationPhone = getPhone()

--- a/web/src/pages/ReviewPage.js
+++ b/web/src/pages/ReviewPage.js
@@ -104,6 +104,7 @@ class ReviewPage extends React.Component {
             selectedDays={days}
             availabilityExplanation={explanationPage}
           />
+          {/* Note: if updating this text don't forget to update the email templates */}
           <Reminder>
             {explanationPage ? (
               <Trans>


### PR DESCRIPTION
With the addition of https://github.com/cds-snc/ircc-rescheduler/pull/438 the email templates need to handle either selected days or the availability explanation.  This updates handles the new scenarios and is backwards compatible with the existing setup.

## Testing
To test locally run update the cypress user fixture to your email address and run "validation-error.spec" (Full Run-through including validation errors).  To test with an availability explanation add an explanation manually i.e. 

```
options.formValues.availabilityExplanation = "Hey this works!"

if (
    typeof options.formValues.availabilityExplanation !== 'undefined' &&
    options.formValues.availabilityExplanation !== ''
  ) {
    renderAvailabilityExplanation(options)
  } else {
    renderSelectedDays(options)
  }

...
``` 

Sample user email:
<img width="394" alt="screen shot 2018-09-12 at 1 25 48 pm" src="https://user-images.githubusercontent.com/62242/45442285-9c14fd80-b68f-11e8-9043-63a98deaa35f.png">

