### PR TITLE
Announce dates as unavailable

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -20,8 +20,10 @@ import {
   getDisabledDays,
   getDaysOfWeekForLocation,
   getMonthName,
+  notInDateRange,
 } from '../utils/calendarDates'
 import parse from 'date-fns/parse'
+
 import { logEvent } from '../utils/analytics'
 import { windowExists } from '../utils/windowExists'
 import { FeatureFlag } from './FeatureFlag'
@@ -512,7 +514,19 @@ const renderDayBoxes = ({
 
 // format aria-label for Day cell
 const formatDay = (day, locale) => {
-  return dateToHTMLString(day, locale)
+  const date = dateToHTMLString(day, locale)
+
+  let prepend = 'unavailable'
+
+  if (locale === 'fr') {
+    prepend = 'indisponible'
+  }
+
+  if (!notInDateRange(day)) {
+    return `${prepend} ${date}`
+  }
+
+  return date
 }
 
 const renderMonthName = ({ date, locale }) => {

--- a/web/src/locations/index.js
+++ b/web/src/locations/index.js
@@ -31,7 +31,7 @@ const LocationCache = (function() {
         throw an error
       */
       if (!location) {
-        if (process.env.NODE_ENV === 'test') {
+        if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
           location = 'vancouver'
         } else {
           location = 'undefined'

--- a/web/src/utils/calendarDates.js
+++ b/web/src/utils/calendarDates.js
@@ -87,7 +87,11 @@ export const firstValidDay = (location = getGlobalLocation(), date) => {
   return parse(addDays(date, i))
 }
 
-const isValidDayForLocation = (location, month = '', date = new Date()) => {
+const isValidDayForLocation = (
+  location = getGlobalLocation(),
+  month = '',
+  date = new Date(),
+) => {
   // eslint-disable-next-line security/detect-object-injection
   if (location && location.recurring[month]) {
     const result = checkLocationDays(location, month, date)
@@ -168,7 +172,11 @@ const getAllowedDays = (
   return mapped
 }
 
-export const checkLocationDays = (location, month, date) => {
+export const checkLocationDays = (
+  location = getGlobalLocation(),
+  month,
+  date,
+) => {
   let valid = false
 
   const dateSet = dateSetFromString(location.blocked)
@@ -311,6 +319,36 @@ export const getShortMonthName = (date = new Date()) => {
 
 export const yearMonthDay = date => {
   return format(date, 'YYYY-MM-DD')
+}
+
+/*--------------------------------------------*
+ * Utility functions to help mark 
+ * dates as unavailable
+ *--------------------------------------------*/
+
+const cachedEnabledDays = () => {
+  /* return a cache if we have one*/
+  if (cachedEnabledDays.cached) {
+    return cachedEnabledDays.cached
+  }
+
+  const mapped = {}
+  getEnabledDays().forEach(day => {
+    mapped[yearMonthDay(day)] = true
+  })
+
+  cachedEnabledDays.cached = mapped
+
+  return cachedEnabledDays.cached
+}
+
+export const notInDateRange = day => {
+  const days = cachedEnabledDays()
+  if (days[yearMonthDay(day)]) {
+    return true
+  }
+
+  return false
 }
 
 /*--------------------------------------------*


### PR DESCRIPTION
When using a screen reader dates were being read and than announce as dimmed when a date is disabled.  The user would need to listen to the entire date in order to find out if it was available.

This update announces disabled dates as "unavailable" prior to reading the date.