### PR TITLE
Preserved line breaks

### DIFF
--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -183,7 +183,7 @@ const Summary = ({
         summaryLabel={i18n && `${i18n._('Change')} ${i18n._('Availability')}`}
       />
     ) : (
-      <SummaryRow
+      <TextAreaSummaryRow
         summaryHeader={<Trans>Availability</Trans>}
         summaryBody={availabilityExplanation}
         summaryLink={'/explanation#explanationPage-label'}

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -47,7 +47,7 @@ const SummaryBody = styled.div`
   word-wrap: break-word;
 `
 
-const SummaryFamilyBody = styled(SummaryBody)`
+const SummaryBodyWhiteSpace = styled(SummaryBody)`
   white-space: pre-line;
 `
 
@@ -79,8 +79,9 @@ export const SummaryRow = ({
   <Row>
     <SummaryHeader>
       <SummaryH2>{summaryHeader}</SummaryH2>
-      {summaryLink === '/register#familyOption-label' ? (
-        <SummaryFamilyBody>{summaryBody}</SummaryFamilyBody>
+      {summaryLink === '/register#familyOption-label' ||
+      '/explanation#explanationPage-label' ? (
+        <SummaryBodyWhiteSpace>{summaryBody}</SummaryBodyWhiteSpace>
       ) : (
         <SummaryBody>{summaryBody}</SummaryBody>
       )}

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -47,6 +47,10 @@ const SummaryBody = styled.div`
   word-wrap: break-word;
 `
 
+const SummaryFamilyBody = styled(SummaryBody)`
+  white-space: pre-line;
+`
+
 const SummaryLink = styled.div`
   position: absolute;
   bottom: ${theme.spacing.md};
@@ -75,7 +79,11 @@ export const SummaryRow = ({
   <Row>
     <SummaryHeader>
       <SummaryH2>{summaryHeader}</SummaryH2>
-      <SummaryBody>{summaryBody}</SummaryBody>
+      {summaryLink === '/register#familyOption-label' ? (
+        <SummaryFamilyBody>{summaryBody}</SummaryFamilyBody>
+      ) : (
+        <SummaryBody>{summaryBody}</SummaryBody>
+      )}
     </SummaryHeader>
     {summaryLink === '/register#explanation-label' ||
     summaryLink === '/explanation#explanationPage-label' ? (
@@ -134,6 +142,7 @@ const Summary = ({
     />
     {familyOption && (
       <SummaryRow
+        className="test"
         summaryHeader={<Trans>Family members</Trans>}
         summaryBody={familyOption}
         summaryLink={'/register#familyOption-label'}

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -89,12 +89,15 @@ export const SummaryRow = ({
     </SummaryLink>
   </Row>
 )
-SummaryRow.propTypes = {
+
+const summaryRowProps = {
   summaryHeader: PropTypes.object.isRequired,
   summaryBody: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   summaryLink: PropTypes.string.isRequired,
   summaryLabel: PropTypes.string,
 }
+
+SummaryRow.propTypes = summaryRowProps
 
 export const TextAreaSummaryRow = ({
   summaryHeader,
@@ -115,12 +118,8 @@ export const TextAreaSummaryRow = ({
     </SummaryLinkExplanation>
   </Row>
 )
-TextAreaSummaryRow.propTypes = {
-  summaryHeader: PropTypes.object.isRequired,
-  summaryBody: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  summaryLink: PropTypes.string.isRequired,
-  summaryLabel: PropTypes.string,
-}
+
+TextAreaSummaryRow.propTypes = summaryRowProps
 
 const Summary = ({
   fullName,

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -79,30 +79,43 @@ export const SummaryRow = ({
   <Row>
     <SummaryHeader>
       <SummaryH2>{summaryHeader}</SummaryH2>
-      {summaryLink === '/register#familyOption-label' ||
-      '/explanation#explanationPage-label' ? (
-        <SummaryBodyWhiteSpace>{summaryBody}</SummaryBodyWhiteSpace>
-      ) : (
-        <SummaryBody>{summaryBody}</SummaryBody>
-      )}
+      <SummaryBody>{summaryBody}</SummaryBody>
     </SummaryHeader>
-    {summaryLink === '/register#explanation-label' ||
-    summaryLink === '/explanation#explanationPage-label' ? (
-      <SummaryLinkExplanation>
-        <NavLink to={summaryLink} aria-label={summaryLabel}>
-          <Trans>Change</Trans>
-        </NavLink>
-      </SummaryLinkExplanation>
-    ) : (
-      <SummaryLink>
-        <NavLink to={summaryLink} aria-label={summaryLabel}>
-          <Trans>Change</Trans>
-        </NavLink>
-      </SummaryLink>
-    )}
+
+    <SummaryLink>
+      <NavLink to={summaryLink} aria-label={summaryLabel}>
+        <Trans>Change</Trans>
+      </NavLink>
+    </SummaryLink>
   </Row>
 )
 SummaryRow.propTypes = {
+  summaryHeader: PropTypes.object.isRequired,
+  summaryBody: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  summaryLink: PropTypes.string.isRequired,
+  summaryLabel: PropTypes.string,
+}
+
+export const TextAreaSummaryRow = ({
+  summaryHeader,
+  summaryBody,
+  summaryLink,
+  summaryLabel,
+}) => (
+  <Row>
+    <SummaryHeader>
+      <SummaryH2>{summaryHeader}</SummaryH2>
+      <SummaryBodyWhiteSpace>{summaryBody}</SummaryBodyWhiteSpace>
+    </SummaryHeader>
+
+    <SummaryLinkExplanation>
+      <NavLink to={summaryLink} aria-label={summaryLabel}>
+        <Trans>Change</Trans>
+      </NavLink>
+    </SummaryLinkExplanation>
+  </Row>
+)
+TextAreaSummaryRow.propTypes = {
   summaryHeader: PropTypes.object.isRequired,
   summaryBody: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   summaryLink: PropTypes.string.isRequired,
@@ -142,8 +155,7 @@ const Summary = ({
       }
     />
     {familyOption && (
-      <SummaryRow
-        className="test"
+      <TextAreaSummaryRow
         summaryHeader={<Trans>Family members</Trans>}
         summaryBody={familyOption}
         summaryLink={'/register#familyOption-label'}
@@ -156,7 +168,7 @@ const Summary = ({
       summaryLink={'/register#reason-header'}
       summaryLabel={i18n && `${i18n._('Change')} ${i18n._('Reason')}`}
     />
-    <SummaryRow
+    <TextAreaSummaryRow
       summaryHeader={<Trans>Explanation</Trans>}
       summaryBody={explanation}
       summaryLink={'/register#explanation-label'}

--- a/web/src/components/__tests__/Summary.test.js
+++ b/web/src/components/__tests__/Summary.test.js
@@ -64,17 +64,21 @@ describe('<Summary />', () => {
     )
 
     const numOfSummaryRows = wrapper.find('SummaryRow')
+    const numOfTextSummaryRows = wrapper.find('TextAreaSummaryRow')
 
-    expect(numOfSummaryRows.length).toBe(6)
+    expect(numOfSummaryRows.length).toBe(5)
+    expect(numOfTextSummaryRows.length).toBe(1)
     expect(numOfSummaryRows.at(0).prop('summaryBody')).toEqual('Test1')
     expect(numOfSummaryRows.at(1).prop('summaryBody')).toEqual('test@test.com')
     expect(numOfSummaryRows.at(2).prop('summaryBody')).toEqual('12346789')
     expect(numOfSummaryRows.at(3).prop('summaryBody').props.id).toEqual(
       'Travel',
     )
-    expect(numOfSummaryRows.at(4).prop('summaryBody')).toEqual('feeling lazy')
+    expect(numOfTextSummaryRows.at(0).prop('summaryBody')).toEqual(
+      'feeling lazy',
+    )
     expect(
-      numOfSummaryRows.at(5).prop('summaryBody').props.selectedDays,
+      numOfSummaryRows.at(4).prop('summaryBody').props.selectedDays,
     ).toMatchObject(selectedDays)
   })
 })


### PR DESCRIPTION
## This PR consists of the following:
Our site is currently performing like this:

| TextArea Input | ReviewPage Output |
|----------------|-------------------|
|    ![screen shot 2018-09-14 at 18 04 52](https://user-images.githubusercontent.com/30609058/45577193-c0680a00-b848-11e8-8acc-b565db779660.png) | ![screen shot 2018-09-14 at 18 05 06](https://user-images.githubusercontent.com/30609058/45577191-bfcf7380-b848-11e8-8a37-0137db04970d.png) |

We want to be preserving the line breaks on the familyOption row of the Summary component

## New CSS applied to preserve line breaks on the familyOption row

| TextArea Input | ReviewPage Output |
|----------------|-------------------|
|  ![screen shot 2018-09-14 at 18 04 52](https://user-images.githubusercontent.com/30609058/45577193-c0680a00-b848-11e8-8acc-b565db779660.png)  | ![screen shot 2018-09-14 at 18 05 00](https://user-images.githubusercontent.com/30609058/45577192-bfcf7380-b848-11e8-92f3-4b04e7eb3ade.png) |

## New CSS applied to preserve line breaks on the Explanation row

| TextArea Input | ReviewPage Output |
|----------------|-------------------|
|  ![screen shot 2018-09-14 at 18 09 01](https://user-images.githubusercontent.com/30609058/45577324-6a479680-b849-11e8-8037-175d704d7a1f.png) | ![screen shot 2018-09-14 at 18 08 53](https://user-images.githubusercontent.com/30609058/45577325-6a479680-b849-11e8-8133-1e158cdac6f7.png) |

## This PR addresses [Issue #424](https://github.com/cds-snc/ircc-rescheduler/issues/424)