### PR TITLE
Prepend a comma and space to familyOption string in emails

### DIFF
--- a/web/email_templates/applicant-plain.html
+++ b/web/email_templates/applicant-plain.html
@@ -5,7 +5,7 @@ Hello ${fullName},
 We received your request for a new citizenship appointment.
 
 Individuals to be rescheduled:
-${fullName} ${familyOption}
+${fullName}${familyOption}
 
 ${datesLabel}
 ${datesPlain}
@@ -24,7 +24,7 @@ Bonjour ${fullName},
 Nous avons bien reçu votre demande de nouveau rendez-vous d’examen de citoyenneté.
 
 Les individus qui doivent être reportés :
-${fullName} ${familyOption}
+${fullName}${familyOption}
 
 ${datesLabelFR}
 ${datesPlainFR}

--- a/web/email_templates/applicant-rich.html
+++ b/web/email_templates/applicant-rich.html
@@ -41,7 +41,7 @@
   <p>We received your request for a new citizenship appointment.</p>
   <div id="family-option">
     <h3>Individuals to be rescheduled:</h3>
-    <p>${fullName} ${familyOption} </p>
+    <p>${fullName}${familyOption}</p>
   </div>
   <h3>${datesLabel}</h3>
   <div>
@@ -60,7 +60,7 @@
   <p>Nous avons bien reçu votre demande de nouveau rendez-vous d’examen de citoyenneté.</p>
 
   <h3>Les individus qui doivent être reportés :</h3>
-  <p>${fullName} ${familyOption} </p>
+  <p>${fullName}${familyOption}</p>
 
   <h3>${datesLabelFR}</h3>
   <div>

--- a/web/email_templates/staff-plain.html
+++ b/web/email_templates/staff-plain.html
@@ -1,7 +1,7 @@
 Full name ${fullName}
 Email ${email}
 Paper file number ${paperFileNumber}
-Individuals to reschedule ${fullName} ${familyOption}
+Individuals to reschedule ${fullName}${familyOption}
 Reason for rescheduling ${reason}
 Explanation ${explanation}
 Availability ${datesPlain}

--- a/web/email_templates/staff-rich.html
+++ b/web/email_templates/staff-rich.html
@@ -66,7 +66,7 @@
 
         <div class="field">
             <div class="label">Individuals to reschedule</div>
-            <div>${fullName} ${familyOption}</div>
+            <div>${fullName}${familyOption}</div>
         </div>
 
         <div class="field">

--- a/web/src/email/email-template.js
+++ b/web/src/email/email-template.js
@@ -153,7 +153,11 @@ const renderAvailabilityExplanation = options => {
 }
 
 export const buildParams = async options => {
-  const { selectedDays, availabilityExplanation } = options.formValues
+  const {
+    selectedDays,
+    availabilityExplanation,
+    familyOption,
+  } = options.formValues
 
   options.formValues.respondByDate = respondByDate(selectedDays, 'en')
   options.formValues.respondByDateFR = respondByDate(selectedDays, 'fr')
@@ -164,6 +168,12 @@ export const buildParams = async options => {
   } else {
     renderSelectedDays(options)
   }
+
+  // if familyOption exists and does not start with ',', prepend a comma and a space
+  options.formValues.familyOption =
+    familyOption && !familyOption.startsWith(',')
+      ? `, ${familyOption}`
+      : familyOption
 
   options.formValues.locationEmail = getEmail()
   options.formValues.locationPhone = getPhone()


### PR DESCRIPTION
Previously, if your name was "Paul Craig" and your familyOption string was "Julia Craig, Kevin Craig" we would have:

- `Paul Craig Julia Craig, Kevin Craig`

Now we will have

- `Paul Craig, Julia Craig, Kevin Craig`

This doesn't solve every case, but I would assume it's an improvement in the vast majority of cases.

*Note: Since `options.formValues` is an object we keep in memory between function calls, we have to check that a comma and a space have not already been prepended.*

This closes #443 