### PR TITLE
Set global 'extra' context for raven

### DIFF
--- a/web/src/server.js
+++ b/web/src/server.js
@@ -12,6 +12,7 @@ import {
   getPrimarySubdomain,
   ensureLocation,
   ensureReceivingEmail,
+  setRavenContext,
 } from './utils/serverUtils'
 import { handleSubmitEmail } from './email/handleSubmitEmail'
 import gitHash from './utils/gitHash'
@@ -31,6 +32,7 @@ server
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR || './public'))
   .use(getPrimarySubdomain)
+  .use(setRavenContext)
   .use(ensureLocation)
   .use(ensureReceivingEmail)
   .use(cookieParser())

--- a/web/src/utils/serverUtils.js
+++ b/web/src/utils/serverUtils.js
@@ -141,11 +141,13 @@ export const setRavenContext = (req, res, next) => {
   const { headers: { host } = {}, subdomain, path } = req
 
   Raven.setContext({
-    extra: {
+    tags: {
       host,
       subdomain,
       path,
       stage: process.env.RAZZLE_STAGE,
+    },
+    extra: {
       release: getReleaseHash(),
     },
   })

--- a/web/src/utils/serverUtils.js
+++ b/web/src/utils/serverUtils.js
@@ -58,7 +58,7 @@ export const getPrimarySubdomain = function(req, res, next) {
     req.subdomain = 'vancouver'
   }
 
-  /* 
+  /*
     If no sub-domain is found
     force redirect to vancouver sub-domain on staging and prod
     note: this is temporary to handle existing vancouver traffic / links
@@ -130,7 +130,25 @@ const getStacktraceData = data => {
   return data
 }
 
+/* Raven config */
+
 Raven.config('https://a2315885b9c3429a918336c1324afa4a@sentry.io/1241616', {
   dataCallback: getStacktraceData,
   release: getReleaseHash,
 }).install()
+
+export const setRavenContext = (req, res, next) => {
+  const { headers: { host } = {}, subdomain, path } = req
+
+  Raven.setContext({
+    extra: {
+      host,
+      subdomain,
+      path,
+      stage: process.env.RAZZLE_STAGE,
+      release: getReleaseHash(),
+    },
+  })
+
+  return next()
+}


### PR DESCRIPTION
For our manually triggered Raven errors (ie, `Raven.captureException` or `Raven.captureMessage`), Raven isn't capturing all the contextual data automatically, the way it does when it captures a `throw new Error` event.

What this means is that we have a lot of errors showing up in sentry because our tests trigger them, but we're not able to at-a-glance know when they're coming from our production application.

By setting a global context.extra, all exceptions and messages captured will have the following useful context:
- `tags`
  - the url host name
  - the subdomain
  - the url path
  - the RAZZLE_STAGE env var
- `extra`
  - the release string


**Note: since the context is only getting set on server reloads, the req.path will not be up to date unless the error happens on the first page. I think this is fine, but just so we know.**

## screenshot (new tags highlighted in red)

![sentry io_canadian-digital-service_ircc-rescheduler_issues_675614634__query is_unresolved](https://user-images.githubusercontent.com/2454380/45894140-8abca700-bd9b-11e8-9ce1-f89955f2b61f.png)
