### PR TITLE
Give focus to selected day box

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -751,9 +751,6 @@ class Calendar extends Component {
             tabIndex="-1"
             className={removeDateMessage}
             id="removeDateMessage"
-            ref={removeDateContainer => {
-              this.removeDateContainer = removeDateContainer
-            }}
           >
             <h2>
               <Trans>To change your selections, remove some days first</Trans>.
@@ -804,7 +801,13 @@ class Calendar extends Component {
             <div id="selectedDaysBox" style={{ display: 'flex' }}>
               <div className={value.length ? triangle : noDates} />
               <div className={value.length ? daySelection : noDates}>
-                <h3>
+                <h3
+                  tabIndex="-1"
+                  style={{ outline: 0 }}
+                  ref={removeDateContainer => {
+                    this.removeDateContainer = removeDateContainer
+                  }}
+                >
                   {value.length === 3 ? (
                     <Trans>Your 3 selected days:</Trans>
                   ) : value.length === 2 ? (

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -178,7 +178,7 @@ const Summary = ({
       <SummaryRow
         summaryHeader={<Trans>Availability</Trans>}
         summaryBody={<SelectedDayList selectedDays={selectedDays} />}
-        summaryLink={'/calendar#calendar-header'}
+        summaryLink={'/calendar#selected-day-box'}
         summaryLabel={i18n && `${i18n._('Change')} ${i18n._('Availability')}`}
       />
     ) : (

--- a/web/src/components/Summary.js
+++ b/web/src/components/Summary.js
@@ -178,7 +178,7 @@ const Summary = ({
       <SummaryRow
         summaryHeader={<Trans>Availability</Trans>}
         summaryBody={<SelectedDayList selectedDays={selectedDays} />}
-        summaryLink={'/calendar#selected-day-box'}
+        summaryLink={'/calendar#selectedDaysBox'}
         summaryLabel={i18n && `${i18n._('Change')} ${i18n._('Availability')}`}
       />
     ) : (


### PR DESCRIPTION
When coming back from the review page this will give focus to the selected day box to make it eaier to remove days before moving back to the calendar.