### PR TITLE
Generate unique id attributes for cancel button svg titles

### DIFF
--- a/web/src/components/Calendar.js
+++ b/web/src/components/Calendar.js
@@ -497,6 +497,7 @@ const renderDayBoxes = ({
           >
             <div className={removeDate}>
               <MobileCancel
+                index={i}
                 circleColour={
                   errorMessage ? theme.colour.red : theme.colour.blackLight
                 }

--- a/web/src/components/MobileCancel.js
+++ b/web/src/components/MobileCancel.js
@@ -3,18 +3,20 @@ import PropTypes from 'prop-types'
 import { theme } from '../styles'
 
 const MobileCancel = ({
+  index,
   circleColour = theme.colour.blackLight,
   label = '',
 }) => {
+  let titleId = `titleId-${index}`
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       data-name="Layer 1"
       viewBox="0 0 21.62 21.62"
       role="img"
-      aria-labelledby="titleId"
+      aria-labelledby={titleId}
     >
-      <title id="titleId">{label}</title>
+      <title id={titleId}>{label}</title>
       <g data-name="Layer 2">
         <g data-name="Layer 1-2">
           <circle cx="10.81" cy="10.81" r="10.81" fill={circleColour} />
@@ -29,6 +31,7 @@ const MobileCancel = ({
 }
 
 MobileCancel.propTypes = {
+  index: PropTypes.number.isRequired,
   circleColour: PropTypes.string,
   label: PropTypes.string,
 }

--- a/web/src/components/__tests__/Calendar.test.js
+++ b/web/src/components/__tests__/Calendar.test.js
@@ -452,7 +452,7 @@ describe('renderDayBoxes', () => {
 
     let imgs = button.find('svg')
     expect(imgs.length).toBe(1)
-    expect(imgs.find('#titleId').text()).toEqual(label)
+    expect(imgs.find('#titleId-0').text()).toEqual(label)
   })
 
   it('renders days in french', () => {
@@ -467,16 +467,14 @@ describe('renderDayBoxes', () => {
     )
     let listItem = wrapper.find('ul li')
     expect(listItem.find('span').text()).toEqual('dimanche 3 novembre 1957')
-    
+
     let button = listItem.find('button')
     let label = 'Supprimer cette journée: dimanche 3 novembre 1957'
-    expect(button.props()['aria-label']).toEqual(
-      label,
-    )
+    expect(button.props()['aria-label']).toEqual(label)
 
     let imgs = button.find('svg')
     expect(imgs.length).toBe(1)
-    expect(imgs.find('#titleId').text()).toEqual(label)
+    expect(imgs.find('#titleId-0').text()).toEqual(label)
   })
 
   it('will block days on calendar', () => {


### PR DESCRIPTION
Flagged by axe: ids should be unique on a page and we were using duplicates for the <title> element inside of the "Remove day" button svg.

Looked into writing a pa11y test for this, but it was not going to be straightforward, so just going to add the fix by itself.

## screenshot from axe browser extension

![image 2](https://user-images.githubusercontent.com/2454380/46091352-a996b100-c180-11e8-95cd-72f9f808a541.png)
