### PR TITLE
Calendar Contrast - Day Cells

### DIFF
--- a/web/src/styles.js
+++ b/web/src/styles.js
@@ -45,7 +45,7 @@ export const theme = {
     blue: '#335075',
     red: '#E8112D',
     greenLight: '#70B48F',
-    greenLighter: '#CBE7D9',
+    greenLighter: '#b9dac7',
     green: '#00823B',
     greenDark: '#00692f',
     redFIP: '#FF0000',


### PR DESCRIPTION
Updates calendar day cell background colour to help users with inverted screens with contrast turned way up.

@emanelfy here's the review link https://ircc-development-pr-489.herokuapp.com/calendar