### PR TITLE
Calendar Contrast - Day Cells

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -45,7 +45,7 @@ export const theme = {
     blue: '#335075',
     red: '#E8112D',
     greenLight: '#70B48F',
-    greenLighter: '#CBE7D9',
+    greenLighter: '#B9DAC7',
     green: '#00823B',
     greenDark: '#00692f',
     redFIP: '#FF0000',


### PR DESCRIPTION
Replaces https://github.com/cds-snc/ircc-rescheduler/pull/489

Updates calendar day cell background colour to help users with inverted screens with contrast turned way up.