### PR TITLE
Modify calendar arrow display

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Trans, withI18n } from '@lingui/react'
 import FieldAdapterPropTypes from './_Field'
 import DayPicker, { DateUtils, LocaleUtils } from 'react-day-picker'
-import { css, keyframes } from 'emotion'
+import { css } from 'emotion'
 import Time, { makeGMTDate, dateToHTMLString } from './Time'
 import ErrorMessage from './ErrorMessage'
 import { theme, mediaQuery, incrementColor, focusRing } from '../styles'
@@ -18,7 +18,6 @@ import {
   sortSelectedDays,
   getDisabledDays,
   getDaysOfWeekForLocation,
-  getMonthName,
   notInDateRange,
   isFirstAvailableDay,
   isLastAvailableDay,

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -30,24 +30,6 @@ import { windowExists } from '../utils/windowExists'
 import { CheckboxAdapter } from '../components/forms/MultipleChoice'
 import { Field } from 'react-final-form'
 
-const jiggle = keyframes`
-10%, 60% {
-  transform: translate3d(-1px, 0, 0);
-}
-
-20%{
-  transform: translate3d(2px, 0, 0);
-}
-
-30%, 40% , 50% {
-  transform: translate3d(-2px, 0, 0);
-}
-
-40%, 60% {
-  transform: translate3d(2px, 0, 0);
-}
-`
-
 const dayPickerDefault = css`
   /* DayPicker styles */
 
@@ -122,6 +104,15 @@ const dayPickerDefault = css`
     left: 0.5rem;
     top: 0.5rem;
     background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiBmaWxsPSIjMDA4MjNiIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA5LjQyIDE1LjYyIj48dGl0bGU+bGVmdEFycm93PC90aXRsZT48ZyBpZD0iTGF5ZXJfMiIgZGF0YS1uYW1lPSJMYXllciAyIj48ZyBpZD0iTGF5ZXJfMS0yIiBkYXRhLW5hbWU9IkxheWVyIDEtMiI+PHBhdGggZD0iTTIuNzksNy44MWw1LjYzLDcuMzFINi4yNUwuNjMsNy44MSw2LjI1LjVIOC4zN1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMCkiLz48cGF0aCBkPSJNNiwwSDkuNDJsLTYsNy44MSw2LDcuODFINkwwLDcuODFaTTcuMzYsMUg2LjQ5TDEuMjYsNy44MWw1LjIzLDYuODFoLjkzTDIuMTYsNy44MVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAgMCkiLz48L2c+PC9nPjwvc3ZnPg==');
+  }
+
+  .DayPicker-NavButton--next {
+    right: 0.4rem;
+    top: 0.3rem;
+    background-size: 43%;
+    padding: 15px;
+    background-color: green;
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZlcnNpb249IjEuMSIgaWQ9ImNhbC1hcnJvdy1yaWdodCIgZmlsbD0iI2ZmZiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHZpZXdCb3g9IjAgMCA5LjQgMTUuNiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgOS40IDE1LjY7IiB4bWw6c3BhY2U9InByZXNlcnZlIj48ZyBpZD0iTGF5ZXJfMiI+PGcgaWQ9IkxheWVyXzEtMiI+PHBhdGggZD0iTTYuNiw3LjhMMSwwLjVoMi4ybDUuNiw3LjNsLTUuNiw3LjNIMUw2LjYsNy44eiIvPjxwYXRoIGQ9Ik0zLjQsMTUuNkgwbDYtNy44TDAsMGgzLjRsNiw3LjhMMy40LDE1LjZ6IE0yLjEsMTQuNmgwLjlsNS4yLTYuOEwyLjksMUgybDUuMyw2LjhMMi4xLDE0LjZ6Ii8+PC9nPjwvZz48L3N2Zz4=);
   }
 
   .DayPicker-NavButton--interactionDisabled {
@@ -703,15 +694,6 @@ class Calendar extends Component {
       ? this.state.daysOfWeek
       : getDaysOfWeekForLocation(undefined, initialMonth)
 
-    let arrowAnimate = ``
-
-    if (
-      getMonthName(initialMonth) === getMonthName(this.props.month) &&
-      !this.props.calDisabled
-    ) {
-      arrowAnimate = `animation: ${jiggle} 5s ease-in-out infinite;`
-    }
-
     const weekdayStyles = css`
       ${dayPickerDefault};
 
@@ -729,13 +711,6 @@ class Calendar extends Component {
       .DayPicker-Day--disabled:nth-of-type(${dayOfWeek1}),
       .DayPicker-Day--disabled:nth-of-type(${dayOfWeek2}) {
         background: white;
-      }
-
-      .DayPicker-NavButton--next {
-        right: 0.5rem;
-        top: 0.5rem;
-        background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIxLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9ImNhbC1hcnJvdy1yaWdodCIgZmlsbD0iIzAwODIzYiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiCgkgdmlld0JveD0iMCAwIDkuNCAxNS42IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA5LjQgMTUuNjsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8ZyBpZD0iTGF5ZXJfMiI+Cgk8ZyBpZD0iTGF5ZXJfMS0yIj4KCQk8cGF0aCBkPSJNNi42LDcuOEwxLDAuNWgyLjJsNS42LDcuM2wtNS42LDcuM0gxTDYuNiw3Ljh6Ii8+CgkJPHBhdGggZD0iTTMuNCwxNS42SDBsNi03LjhMMCwwaDMuNGw2LDcuOEwzLjQsMTUuNnogTTIuMSwxNC42aDAuOWw1LjItNi44TDIuOSwxSDJsNS4zLDYuOEwyLjEsMTQuNnoiLz4KCTwvZz4KPC9nPgo8L3N2Zz4K');
-        ${arrowAnimate};
       }
     `
 

--- a/src/withProvider.js
+++ b/src/withProvider.js
@@ -54,6 +54,7 @@ function withProvider(WrappedComponent) {
           newCookie = setSSRCookie(res, key, val, prevCookie)
 
           if (WrappedComponent.saveAfter) {
+            // eslint-disable-next-line security/detect-object-injection
             let { key: k, val: v } = WrappedComponent.saveAfter(prevCookie[key])
             if (k && v) {
               newCookie = setSSRCookie(res, k, v, newCookie)
@@ -99,8 +100,10 @@ function withProvider(WrappedComponent) {
         let newState = { [key]: obj }
 
         if (WrappedComponent.saveAfter) {
+          // eslint-disable-next-line security/detect-object-injection
           let { key: k, val: v } = WrappedComponent.saveAfter(newState[key])
           if (k && v) {
+            // eslint-disable-next-line security/detect-object-injection
             newState[k] = v
           }
         }


### PR DESCRIPTION
Replaces https://github.com/cds-snc/ircc-rescheduler/pull/486

<img width="10" src="https://user-images.githubusercontent.com/62242/46102161-ad83fc80-c19b-11e8-8aae-af44d5dd58fb.gif"> @emanelfy can you provide further direction on this?  i.e. do we want the arrow tight to the edges (less padding around the month).

<img width="487" alt="screen shot 2018-09-26 at 2 48 03 pm" src="https://user-images.githubusercontent.com/62242/46101971-38b0c280-c19b-11e8-9844-e37bacffd5b2.png">

What should the previous month look like?
Also for the next months (Nov, Dec) what should the next arrow look like?


**Tab focused:**

<img width="511" alt="screen shot 2018-09-27 at 9 23 52 am" src="https://user-images.githubusercontent.com/62242/46150026-9bf13200-c239-11e8-8fcf-977bdfaf1a4c.png">


<img width="10" src="https://user-images.githubusercontent.com/62242/46102161-ad83fc80-c19b-11e8-8aae-af44d5dd58fb.gif"> Preview link https://ircc-development-pr-496.herokuapp.com/calendar .


