### PR TITLE
Don't activate GA unless RAZZLE_STAGE is production

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -79,7 +79,7 @@ injectGlobal`
 
 class Layout extends React.Component {
   componentDidMount() {
-    if (process.env.NODE_ENV === 'production' && process.env.RAZZLE_GA_ID) {
+    if (process.env.RAZZLE_STAGE === 'production' && process.env.RAZZLE_GA_ID) {
       if (window && !window.GA_INITIALIZED) {
         initGA(process.env.RAZZLE_GA_ID)
         window.GA_INITIALIZED = true


### PR DESCRIPTION
NODE_ENV is set to production in various places, but RAZZLE_STAGE is only set to production on our prod server.

We don't want GA views being logged from staging or ci, so this is a better check for that.