### PR TITLE
Remove respond by date

### DIFF
--- a/src/email/email-template.js
+++ b/src/email/email-template.js
@@ -1,4 +1,3 @@
-import { respondByDate } from '../utils/calendarDates'
 import { getEmail, getPhone } from '../locations'
 const inlineCss = require('inline-css')
 const fs = require('fs')
@@ -159,13 +158,9 @@ const renderAvailabilityExplanation = options => {
 
 export const buildParams = async options => {
   const {
-    selectedDays,
     availabilityExplanation,
     familyOption,
   } = options.formValues
-
-  options.formValues.respondByDate = respondByDate(selectedDays, 'en')
-  options.formValues.respondByDateFR = respondByDate(selectedDays, 'fr')
 
   // render selected dates or unavailability
   if (availabilityExplanation) {

--- a/src/utils/__tests__/calendarDates.test.js
+++ b/src/utils/__tests__/calendarDates.test.js
@@ -3,7 +3,6 @@ import {
   getEndDate,
   getStartMonth,
   yearMonthDay,
-  respondByDate,
   getMonthNameAndYear,
   getInitialMonth,
   checkLocationDays,
@@ -35,26 +34,6 @@ describe('Utilities functions CalendarDates.js', () => {
   it('gets start month', () => {
     const today = new Date('September 05, 2018')
     expect(yearMonthDay(getStartMonth(today))).toEqual('2018-10-01')
-  })
-
-  it('gets confirmation date', () => {
-    const selectedDays = ['2018-01-31', '2018-01-30', '2018-08-22']
-    expect(respondByDate(selectedDays, 'en')).toEqual('July 27, 2018')
-  })
-
-  it('gets confirmation date FR', () => {
-    const selectedDays = ['2018-01-31', '2018-01-30', '2018-08-22']
-    expect(respondByDate(selectedDays, 'fr')).toEqual('27 juillet 2018')
-  })
-
-  it('gets confirmation date if passed out of order', () => {
-    const selectedDays = ['2018-01-31', '2018-08-22', '2018-01-30']
-    expect(respondByDate(selectedDays, 'en')).toEqual('July 27, 2018')
-  })
-
-  it('returns null if selectedDays value(s) not passed', () => {
-    const selectedDays = []
-    expect(respondByDate(selectedDays, 'en')).toEqual(null)
   })
 
   it('defaults to startMonth if no dates are passed', () => {

--- a/src/utils/calendarDates.js
+++ b/src/utils/calendarDates.js
@@ -3,7 +3,6 @@ import addWeeks from 'date-fns/add_weeks'
 import parse from 'date-fns/parse'
 import startOfMonth from 'date-fns/start_of_month'
 import addDays from 'date-fns/add_days'
-import subWeeks from 'date-fns/sub_weeks'
 import format from 'date-fns/format'
 import eachDay from 'date-fns/each_day'
 import isPast from 'date-fns/is_past'
@@ -18,7 +17,6 @@ import { Trans } from '@lingui/react'
 
 const offsetStartWeeks = 5
 const offsetEndWeeks = 8
-const offsetRespondBy = 4 // weeks + respondByDate() will add 2 additional days
 
 export const toLocale = (date, options, locale) => {
   return makeGMTDate(format(date, 'YYYY-MM-DD')).toLocaleDateString(
@@ -262,23 +260,6 @@ export const sortSelectedDays = selectedDays => {
   let temp = selectedDays.slice()
   temp.sort((date1, date2) => date1.getTime() - date2.getTime())
   return temp
-}
-
-/*--------------------------------------------*
- * Response Date
- *--------------------------------------------*/
-
-export const respondByDate = (selectedDays = [], locale = 'fr') => {
-  selectedDays.sort()
-  if (!selectedDays[selectedDays.length - 1]) return null
-
-  const baseDate = addDays(
-    subWeeks(parse(selectedDays[selectedDays.length - 1]), offsetRespondBy),
-    2,
-  )
-
-  const options = { month: 'long', day: 'numeric', year: 'numeric' }
-  return toLocale(format(baseDate, 'YYYY-MM-DD'), options, locale)
 }
 
 /*--------------------------------------------*

--- a/src/withProvider.js
+++ b/src/withProvider.js
@@ -54,6 +54,7 @@ function withProvider(WrappedComponent) {
           newCookie = setSSRCookie(res, key, val, prevCookie)
 
           if (WrappedComponent.saveAfter) {
+            // eslint-disable-next-line security/detect-object-injection
             let { key: k, val: v } = WrappedComponent.saveAfter(prevCookie[key])
             if (k && v) {
               newCookie = setSSRCookie(res, k, v, newCookie)
@@ -99,8 +100,10 @@ function withProvider(WrappedComponent) {
         let newState = { [key]: obj }
 
         if (WrappedComponent.saveAfter) {
+          // eslint-disable-next-line security/detect-object-injection
           let { key: k, val: v } = WrappedComponent.saveAfter(newState[key])
           if (k && v) {
+            // eslint-disable-next-line security/detect-object-injection
             newState[k] = v
           }
         }


### PR DESCRIPTION
Respond by date is no longer in use to calculate when the user will receive a response by.

The new setup is coded into the templates based on the family option.