### PR TITLE
Fix "Field must be used inside" warning

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -842,20 +842,22 @@ class Calendar extends Component {
                 </ul>
               </div>
             </div>
-            <div className={value.length ? datesLinkAfter : datesLinkBefore}>
-              <Field
-                type="checkbox"
-                name="availability"
-                id="availability"
-                value="notAvailable"
-                component={CheckboxAdapter}
-                label={
-                  <Trans>
-                    I cannot attend any of the available appointments
-                  </Trans>
-                }
-              />
-            </div>
+            {this.props.showAvailability && (
+              <div className={value.length ? datesLinkAfter : datesLinkBefore}>
+                <Field
+                  type="checkbox"
+                  name="availability"
+                  id="availability"
+                  value="notAvailable"
+                  component={CheckboxAdapter}
+                  label={
+                    <Trans>
+                      I cannot attend any of the available appointments
+                    </Trans>
+                  }
+                />
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -866,12 +868,14 @@ class Calendar extends Component {
 Calendar.defaultProps = {
   forceRender: () => {}, //used to for a parent re-render after clicking on a day
   changeMonth: () => {},
+  showAvailability: false,
 }
 
 Calendar.propTypes = {
   ...FieldAdapterPropTypes,
   dayLimit: PropTypes.number.isRequired,
   forceRender: PropTypes.func,
+  showAvailability: PropTypes.bool,
 }
 
 const CalendarAdapter = withI18n()(Calendar)

--- a/src/pages/CalendarPage.js
+++ b/src/pages/CalendarPage.js
@@ -317,6 +317,7 @@ class CalendarPage extends Component {
                     tabIndex={-1}
                     component={CalendarAdapter}
                     dayLimit={DAY_LIMIT}
+                    showAvailability={true}
                     forceRender={this.forceRender}
                     changeMonth={this.changeMonth}
                     month={month}


### PR DESCRIPTION
Tests have been outputting a nested field warning because the Calendar tests are not wrapped with the CalendarPage that contains the Form.

"Warning: Field must be used inside of a ReactFinalForm component"

This adds a new property to workaround the issue.