### PR TITLE
Make Beta tag the same width as FIP flag

### DIFF
--- a/src/components/PhaseBanner.js
+++ b/src/components/PhaseBanner.js
@@ -16,7 +16,7 @@ const beta = css`
   ${badge};
   background-color: #006de4;
   height: 1.3rem;
-  padding: 0.2rem ${theme.spacing.sm} 0.2rem ${theme.spacing.sm};
+  padding: 0.2rem 0.55rem 0.2rem 0.55rem;
 `
 
 const alpha = css`


### PR DESCRIPTION
Noticed something I'd missed from an old issue: #186 

Specifically:

> BETA tag width should be the same as the flag in FIP 
> The text to the right of the BETA tag should be aligned with "Govt. of Canada" in the FIP above

This is a tiny update, just changes the width on the beta banner. Doesn't stay the same size as the flag on 400% zoom but on most screens it's good.

| old | new |
|-----|-----|
| flag is not aligned with beta tag | flag _is_ aligned with beta tag |
|  <img width="1502" alt="screen shot 2018-10-01 at 4 31 05 pm" src="https://user-images.githubusercontent.com/2454380/46314857-b14bc080-c599-11e8-9448-6c953b355a2b.png">   |  <img width="1502" alt="screen shot 2018-10-01 at 4 31 07 pm" src="https://user-images.githubusercontent.com/2454380/46314858-b27ced80-c599-11e8-9f26-69fe7084f245.png">   |


