### PR TITLE
Update calendar date focus colours

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -201,7 +201,7 @@ const dayPickerDefault = css`
       outline: 0px white solid;
 
       &:focus {
-        outline: 3px solid ${theme.colour.focus};
+        outline: 3px solid ${theme.colour.black};
         outline-offset: -2px;
       }
       &:hover {
@@ -215,7 +215,8 @@ const dayPickerDefault = css`
       background: white;
 
       &:focus {
-        outline: 3px solid ${theme.colour.lightGrey};
+        outline-style: dashed;
+        outline-color: ${theme.colour.grey};
         outline-offset: -2px;
       }
     }


### PR DESCRIPTION
Previously, [our yellow focus ring wasn't high-enough contrast against the light green background](https://contrast-ratio.com/#rgb%28255%2C%20191%2C%2071%29-on-rgb%28185%2C%20218%2C%20199%29).

This one was tricky because we have 3 possible colours:
- a light green background when a day is not selected: ```#B9DAC7```
- a medium green background when a day is hovered: ```#70B48F```
- a darker green background when a day is selected: ```#1E874D```

Tested a few combos using http://jxnblk.com/colorable/demos/matrix/ and found that dark colours work fine. So the new focus ring for the days is black: ```#000000```.

Then changed the focus ring for disabled days to grey+dashed to visually de-emphasize it.

## gif 


| before | after |
|--------|-------|
| ![cal-1](https://user-images.githubusercontent.com/2454380/47922632-e47dba00-de8d-11e8-898b-5398cef05924.gif)   |  ![cal-2](https://user-images.githubusercontent.com/2454380/47922634-e5aee700-de8d-11e8-8920-7649c571dfd1.gif)  |





