### PR TITLE
Add back in PORT configuration code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,33 @@ const server = http.createServer(app)
 let currentApp = app
 
 /* eslint-disable no-console */
-const port = process.env.PORT || 3000
-server.listen(port, error => {
+
+/*
+  This gets around the Razzle default port setting, which doesn't play nice with our container deploys.
+  Source: https://github.com/jaredpalmer/razzle/issues/356#issuecomment-366275253
+*/
+
+// bypass webpack.DefinePlugin
+const { env } = require('process')
+
+const port = () =>
+  parseInt(
+    env.RAZZLE_PORT ||
+      env.PORT ||
+      process.env.RAZZLE_PORT ||
+      process.env.PORT ||
+      3000,
+    10,
+  )
+
+const _port = port()
+
+server.listen(_port, error => {
   if (error) {
     console.log(error)
   }
 
-  console.log(`🚀 started on port ${port}`)
+  console.log(`🚀 started on port ${_port}`)
 })
 
 if (module.hot) {


### PR DESCRIPTION
This was originally removed because it was needed for Heroku.

However, I suspect that our container deployments need it as well, so I am adding it back in.