### PR TITLE
Don't show "Phone -" on 500 page if no location

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -107,4 +107,7 @@ Contact.propTypes = {
   showEmail: PropTypes.bool,
 }
 
-export { Contact as default, TelLink }
+const ContactWrapper = ({ ...props }) =>
+  getPhone() ? <Contact {...props} /> : null
+
+export { ContactWrapper as default, Contact as ContactInfo, TelLink }

--- a/src/components/__tests__/Contact.test.js
+++ b/src/components/__tests__/Contact.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import Contact, { TelLink } from '../Contact'
-import { getEmail } from '../../locations'
+import ContactWrapper, { ContactInfo as Contact, TelLink } from '../Contact'
 
 describe('<TelLink />', () => {
   it('renders span and an anchor link', () => {
@@ -32,6 +31,10 @@ describe('<Contact />', () => {
   })
 
   it('renders with the email first and the telephone number second', () => {
+    const locations = require('../../locations')
+    locations.getEmail = jest.fn(() => 'paul@paul.ca')
+    locations.getEmailParts = jest.fn(() => ['paul', 'paul.ca'])
+
     const wrapper = shallow(
       <Contact>
         <h1>Get in touch ✉️</h1>
@@ -42,8 +45,8 @@ describe('<Contact />', () => {
       .find('p')
       .at(0)
       .find('a')
-    expect(emailLink.text()).toEqual(getEmail())
-    expect(emailLink.props().href).toEqual(`mailto:${getEmail()}`)
+    expect(emailLink.text()).toEqual('paul@paul.ca')
+    expect(emailLink.props().href).toEqual('mailto:paul@paul.ca')
 
     expect(
       wrapper
@@ -54,6 +57,10 @@ describe('<Contact />', () => {
   })
 
   it('renders with the email first and the telephone number second', () => {
+    const locations = require('../../locations')
+    locations.getEmail = jest.fn(() => 'paul@paul.ca')
+    locations.getEmailParts = jest.fn(() => ['paul', 'paul.ca'])
+
     const wrapper = shallow(
       <Contact phoneFirst={true}>
         <h1>Get in touch ✉️</h1>
@@ -72,7 +79,35 @@ describe('<Contact />', () => {
       .at(1)
       .find('a')
 
-    expect(emailLink.text()).toEqual(getEmail())
-    expect(emailLink.props().href).toEqual(`mailto:${getEmail()}`)
+    expect(emailLink.text()).toEqual('paul@paul.ca')
+    expect(emailLink.props().href).toEqual('mailto:paul@paul.ca')
+  })
+})
+
+describe('<ContactWrapper />', () => {
+  it('renders Contact information if phone number exists', () => {
+    const locations = require('../../locations')
+    locations.getPhone = jest.fn(() => false)
+
+    const wrapper = shallow(
+      <ContactWrapper>
+        <h1>Get in touch ✉️</h1>
+      </ContactWrapper>,
+    )
+
+    expect(wrapper.find('h1').length).toEqual(0)
+  })
+
+  it('does not render Contact information if no phone number exists', () => {
+    const locations = require('../../locations')
+    locations.getPhone = jest.fn(() => true)
+
+    const wrapper = shallow(
+      <ContactWrapper>
+        <h1>Get in touch ✉️</h1>
+      </ContactWrapper>,
+    )
+
+    expect(wrapper.find('h1').text()).toEqual('Get in touch ✉️')
   })
 })


### PR DESCRIPTION
Our root domain has no location set, so we don't have contact information to show users.

Right now, it will say `Phone —` but then not have a phone number.

Instead, we should omit the Contact output entirely if there is no contact info.

## Screenshots

| before | after |
|--------|-------|
|  when there is a location ('vancouver' in the URL string), there is a phone number.  |  When there is *no* location, there is no phone number to call.   |
|  <img width="1474" alt="screen shot 2018-12-20 at 2 39 35 pm" src="https://user-images.githubusercontent.com/2454380/50307032-3c37ab00-0465-11e9-9175-78a0c37dade7.png">  |   <img width="1474" alt="screen shot 2018-12-20 at 2 39 42 pm" src="https://user-images.githubusercontent.com/2454380/50307036-3cd04180-0465-11e9-9265-a773ed6ec14c.png">  |

This PR removes the `Phone —` line in the second screenshot.


