### PR TITLE
404 requests to root domain

### DIFF
--- a/cypress/integration/main/force-redirect.spec.js
+++ b/cypress/integration/main/force-redirect.spec.js
@@ -1,33 +1,39 @@
 context('Force redirect', () => {
-  it('should force not redirect if on "not found" page', () => {
+  it('should not redirect on "not found" page', () => {
     cy.visit('http://rescheduler-dev.vcap.me:3004/not-found')
     cy.get('h1')
       .eq(0)
       .should('contain', 'Page not found.')
   })
 
-  it('should force not redirect if not on 500 page', () => {
+  it('should not redirect if not on 500 page', () => {
     cy.visit('http://rescheduler-dev.vcap.me:3004/500')
     cy.get('h1')
       .eq(0)
       .should('contain', 'Something went wrong.')
   })
 
-  it('should force redirect from "local" dev server', () => {
+  it('should redirect to "not found" from root', () => {
     cy.visit('http://rescheduler-dev.vcap.me:3004')
-    cy.url().should('include', 'vancouver')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Page not found.')
   })
 
-  it('should force redirect from "local" live server', () => {
-    cy.visit('http://rescheduler-dev.vcap.me:3004')
-    cy.url().should('include', 'vancouver')
+  it('should redirect to "not found" from root plus invalid path', () => {
+    cy.visit('http://rescheduler-dev.vcap.me:3004/elephant')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Page not found.')
   })
 
-  it('should force redirect from "local" live server with UTM', () => {
+  it('should redirect to "not found" from root plus UTM', () => {
     cy.visit(
       'http://rescheduler.vcap.me:3004?utm_source=BELA%20email&utm_medium=email',
     )
-    cy.url().should('include', 'vancouver')
+    cy.get('h1')
+      .eq(0)
+      .should('contain', 'Page not found.')
   })
 
   it("should force redirect if sub-domain isn't whitelisted", () => {

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -37,16 +37,6 @@ export const notPageMatch = (url, pageName) => {
   return url.indexOf(pageName) === -1
 }
 
-export const forceRedirect = req => {
-  if (req.subdomain.startsWith('rescheduler')) {
-    if (notPageMatch(req.path, 'not-found') && notPageMatch(req.path, '500')) {
-      return true
-    }
-  }
-
-  return false
-}
-
 export const getPrimarySubdomain = function(req, res, next) {
   req.subdomain = req.subdomains.slice(-1).pop()
 
@@ -54,20 +44,8 @@ export const getPrimarySubdomain = function(req, res, next) {
 
   // handle localhost
   if (!req.subdomain) {
-    // default to vancouver for now
+    // default to vancouver
     req.subdomain = 'vancouver'
-  }
-
-  /*
-    If no sub-domain is found
-    force redirect to vancouver sub-domain on staging and prod
-    note: this is temporary to handle existing vancouver traffic / links
-    */
-
-  if (forceRedirect(req)) {
-    return res.redirect(
-      `${protocol}://vancouver.${process.env.RAZZLE_SITE_URL}`,
-    )
   }
 
   /* If domain isn't on the whitelist and we're not on the not-found or 500 page */


### PR DESCRIPTION
Previously, we had only one location to serve, so we had one root url where people would reschedule.

Once we needed more locations, we introduced the notion of subdomains as the way we would decide on your location.

Since we needed to support people who still had the original URL, we were redirecting all traffic to the root domain to the Vancouver subdomain, since anyone with the original URL would have been coming from Vancouver.

Now, anyone coming to the root URL (rescheduler.cds-snc.ca) gets redirected to a 404 page rather than the Vancouver start page.

Outcome: less logic in the app. Slightly (very slightly) easier to grep all the url-sniffing logic we wrote in `serverUtils`.