### PR TITLE
Fix horizontal padding throughout the app

### DIFF
--- a/src/components/FederalBanner.js
+++ b/src/components/FederalBanner.js
@@ -3,13 +3,14 @@ import Flag from './gocSignature/Flag'
 import English from './gocSignature/English'
 import French from './gocSignature/French'
 import { css } from 'emotion'
-import { theme, mediaQuery } from '../styles'
+import { theme, horizontalPadding, mediaQuery } from '../styles'
 import LanguageSwitcher from './LanguageSwitcher'
 import Language from './Language'
 
 const container = css`
-  padding: ${theme.spacing.lg} ${theme.spacing.xxxl} ${theme.spacing.md}
-    ${theme.spacing.xxxl};
+  ${horizontalPadding};
+  padding-top: ${theme.spacing.lg};
+  padding-bottom: ${theme.spacing.md};
   width: auto;
   justify-content: space-between;
   background-color: ${theme.colour.black};
@@ -19,8 +20,7 @@ const container = css`
   display: -moz-box;
 
   ${mediaQuery.sm(css`
-    padding: ${theme.spacing.md} ${theme.spacing.xl} ${theme.spacing.md}
-      ${theme.spacing.xl};
+    padding-top: ${theme.spacing.md};
   `)};
 `
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,14 +4,21 @@ import { Trans, withI18n } from '@lingui/react'
 import CanadaWordmark from '../assets/CanadaWordmark.svg'
 import styled from '@emotion/styled'
 import { css } from 'emotion'
-import { theme, mediaQuery, visuallyhiddenMobile } from '../styles'
+import {
+  theme,
+  horizontalPadding,
+  mediaQuery,
+  visuallyhiddenMobile,
+} from '../styles'
 import { getEmail } from '../locations'
 import Language from './Language'
 import { NavLink } from 'react-router-dom'
 
 const footer = css`
+  ${horizontalPadding};
   background-color: ${theme.colour.white};
-  padding: ${theme.spacing.xl} ${theme.spacing.xxxl};
+  padding-top: ${theme.spacing.xl};
+  padding-bottom: ${theme.spacing.xl};
   display: flex;
   justify-content: space-between;
   position: relative;
@@ -47,13 +54,11 @@ const footer = css`
 
   ${mediaQuery.md(css`
     align-items: center;
-    padding: ${theme.spacing.xl} ${theme.spacing.xxxl} ${theme.spacing.xl}
-      ${theme.spacing.xxxl};
   `)};
 
   ${mediaQuery.sm(css`
-    padding: ${theme.spacing.md} ${theme.spacing.xl} ${theme.spacing.lg}
-      ${theme.spacing.xl};
+    padding-top: ${theme.spacing.md};
+    padding-bottom: ${theme.spacing.lg};
   `)};
 `
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css, injectGlobal } from 'emotion'
-import { theme, mediaQuery, Content } from '../styles'
+import { theme, mediaQuery, content } from '../styles'
 import PageHeader from './PageHeader'
 import FederalBanner from './FederalBanner'
 import Footer from './Footer'
@@ -92,7 +92,7 @@ class Layout extends React.Component {
   }
 
   render() {
-    const { contact = true } = this.props
+    const { contact = true, contentClass = '' } = this.props
     return (
       <div>
         <ErrorBoundary
@@ -109,9 +109,13 @@ class Layout extends React.Component {
             <PageHeader>{this.props.header}</PageHeader>
           </div>
           <main role="main">
-            <Content className={this.props.contentClass || ''}>
+            <div
+              className={css`
+                ${content} ${contentClass}
+              `}
+            >
               {this.props.children}
-            </Content>
+            </div>
           </main>
           <Footer contact={contact} topBarBackground="black" />
         </ErrorBoundary>

--- a/src/components/PageHeader.js
+++ b/src/components/PageHeader.js
@@ -1,30 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'emotion'
-import { theme, mediaQuery } from '../styles'
+import { theme, horizontalPadding, mediaQuery } from '../styles'
 import { Trans, withI18n } from '@lingui/react'
 import PhaseBanner from './PhaseBanner'
 
 const bigBanner = css`
+  ${horizontalPadding};
   background-color: ${theme.colour.blue};
   color: ${theme.colour.white};
-  padding: ${theme.spacing.lg} ${theme.spacing.xxxl};
-
-  ${mediaQuery.sm(css`
-    padding-left: ${theme.spacing.xl};
-    padding-right: ${theme.spacing.xl};
-  `)};
+  padding-top: ${theme.spacing.lg};
+  padding-bottom: ${theme.spacing.lg};
 `
 
 const skinnyBanner = css`
+  ${horizontalPadding};
   background-color: ${theme.colour.blue};
   color: ${theme.colour.white};
-  padding: ${theme.spacing.sm} ${theme.spacing.xxxl} 0.55rem
-    ${theme.spacing.xxxl};
-
-  ${mediaQuery.sm(css`
-    padding: ${theme.spacing.sm} ${theme.spacing.xl} 0.55rem ${theme.spacing.xl};
-  `)};
+  padding-top: ${theme.spacing.sm};
+  padding-bottom: 0.55rem;
 
   div {
     margin-bottom: 0;

--- a/src/styles.js
+++ b/src/styles.js
@@ -158,14 +158,25 @@ const contentSpacing = css`
   `)};
 `
 
-export const Content = styled.div`
-  padding: ${theme.spacing.xl} ${theme.spacing.xxxl} ${theme.spacing.xxl}
-    ${theme.spacing.xxxl};
+export const horizontalPadding = css`
+  padding-left: ${theme.spacing.xxxl};
+  padding-right: ${theme.spacing.xxxl};
+
+  ${mediaQuery.sm(css`
+    padding-left: ${theme.spacing.xl};
+    padding-right: ${theme.spacing.xl};
+  `)};
+`
+
+export const content = css`
+  ${horizontalPadding};
+  padding-top: ${theme.spacing.xl};
+  padding-bottom: ${theme.spacing.xxl};
   width: 100%;
   background-color: ${theme.colour.white};
   box-sizing: border-box;
   ${mediaQuery.sm(css`
-    padding: ${theme.spacing.xl};
+    padding-bottom: ${theme.spacing.xl};
   `)};
 
   > form {


### PR DESCRIPTION
After upgrading to emotion 10, our horizontal padding media queries broke for the main content but not for other parts of the app (for example, the header and footer were fine). This meant that on a phone, the main content would be pushed into the middle: you would have to scroll for longer, and in a few places some words were getting cut off.

So I've collected all the horizontal padding rules together and applied them uniformly.

Now they will all work or they will all break as a team.

## Screenshots


| before | after |
|--------|-------|
| main content is not lined up with header  | main content is flush with header  |
| <img width="512" alt="screen shot 2018-12-24 at 12 49 17 pm" src="https://user-images.githubusercontent.com/2454380/50404816-790fe480-077a-11e9-8f00-9cde72649270.png">  | <img width="512" alt="screen shot 2018-12-24 at 12 49 11 pm" src="https://user-images.githubusercontent.com/2454380/50404815-77deb780-077a-11e9-9067-520f9cf3b72a.png"> |


