### PR TITLE
Remove "ensure receiving email" logic on every request

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,6 @@ import bodyParser from 'body-parser'
 import {
   getPrimarySubdomain,
   ensureLocation,
-  ensureReceivingEmail,
   setRavenContext,
 } from './utils/serverUtils'
 import { handleSubmitEmail } from './email/handleSubmitEmail'
@@ -34,7 +33,6 @@ server
   .use(getPrimarySubdomain)
   .use(setRavenContext)
   .use(ensureLocation)
-  .use(ensureReceivingEmail)
   .use(cookieParser())
   .use(bodyParser.urlencoded({ extended: false }))
   .post('/submit', handleSubmitEmail)

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -1,4 +1,4 @@
-import { setGlobalLocation, getReceivingEmail, whitelist } from '../locations'
+import { setGlobalLocation, whitelist } from '../locations'
 import gitHash from './gitHash'
 import path from 'path'
 import Raven from 'raven'
@@ -78,11 +78,6 @@ const _ensureBody = (req, res, next, cb) => {
 export const ensureLocation = (req, res, next) => {
   /* If we don't have a location string being passed in, something is wrong */
   return _ensureBody(req, res, next, () => setGlobalLocation(req.subdomain))
-}
-
-export const ensureReceivingEmail = (req, res, next) => {
-  /* If we don't have a receiving email, something isn't configured properly */
-  return _ensureBody(req, res, next, getReceivingEmail)
 }
 
 const getStacktraceData = data => {


### PR DESCRIPTION
Since the email that we want to send the request to will vary location by location, it is possible we might get into a position where we try to send an email but don't have one configured.

However, the logic needed to do this check has become increasingly cumbersome. For example,
- we want to check if we are in prod or staging
- if staging, we want to check for the 'test' email env var
- if prod, we want to check for the location being set
- and now we would also have to check if we are at the root domain or not

We could either keep piling logic into our `getReceivingEmail` method, OR, accepting the risk, we could remove the check we do on every request.

This means that a potential missing email would only be discovered when someone is about to submit a request rather than on app startup which would result in a bad experience.

However:
- when this happens we throw an error and it ends up in Sentry
    - we have never seen this happen in Sentry except on developer laptops
- we have since added tests whereby all location files need to have an email defined

So I think we can safely remove this check.