### PR TITLE
Add another sandbox flag to puppeteer

### DIFF
--- a/src/pages/__tests__/NoJS-familyErrorCheck.test.js
+++ b/src/pages/__tests__/NoJS-familyErrorCheck.test.js
@@ -18,7 +18,7 @@ beforeAll(async () => {
   page.setJavaScriptEnabled(false)
 })
 
-describe('NoJS Flow Family Error check', () => {
+describe('NoJS Flow Family Error check 1', () => {
   it('Has error if family member checkbox is checked but textarea is empty', async () => {
     await page.goto(`${baseUrl}/clear`)
     await page.goto(`${baseUrl}/register`)
@@ -63,51 +63,54 @@ describe('NoJS Flow Family Error check', () => {
       e => e.innerHTML,
     )
     expect(familyOptionError).toContain('You left this blank')
-  }, 200000),
-    it('Has error if family member checkbox is NOT checked but textarea has a value', async () => {
-      await page.goto(`${baseUrl}/clear`)
-      await page.goto(`${baseUrl}/register`)
+  }, 200000)
+})
 
-      let user = user_en
+describe('NoJS Flow Family Error check 2', () => {
+  it('Has error if family member checkbox is NOT checked but textarea has a value', async () => {
+    await page.goto(`${baseUrl}/clear`)
+    await page.goto(`${baseUrl}/register`)
 
-      if (fr) {
-        user = user_fr
-        await page.click('#language-toggle')
-      }
+    let user = user_en
 
-      // register page
-      if (!fr) {
-        const html = await page.$eval('h1', e => e.innerHTML)
-        expect(html).toEqual('First, provide some basic information:')
-      }
+    if (fr) {
+      user = user_fr
+      await page.click('#language-toggle')
+    }
 
-      const fullName = await page.$eval('#fullName-header', e => e.innerHTML)
+    // register page
+    if (!fr) {
+      const html = await page.$eval('h1', e => e.innerHTML)
+      expect(html).toEqual('First, provide some basic information:')
+    }
 
-      let label = 'Full name'
+    const fullName = await page.$eval('#fullName-header', e => e.innerHTML)
 
-      if (fr) {
-        label = 'Nom complet'
-      }
+    let label = 'Full name'
 
-      /* There is a familyOption value but nothing for familyCheck */
-      expect(fullName).toBe(label)
-      await page.type('#fullName', user.fullName)
-      await page.type('#email', user.email)
-      await page.type('#paperFileNumber', user.paperFileNumber)
-      // await page.click('#familyCheck')
-      await page.type('#familyOption', user.familyOption)
-      await page.click('#reason-2')
-      await page.type('#explanation', user.explanation)
-      await clickAndWait(page, '#register-form button')
+    if (fr) {
+      label = 'Nom complet'
+    }
 
-      const familyCheckError = await page.$eval(
-        '#familyCheck-error',
-        e => e.innerHTML,
-      )
-      expect(familyCheckError).toContain(
-        'You must click ‘I need to reschedule my family too’',
-      )
-    }, 200000)
+    /* There is a familyOption value but nothing for familyCheck */
+    expect(fullName).toBe(label)
+    await page.type('#fullName', user.fullName)
+    await page.type('#email', user.email)
+    await page.type('#paperFileNumber', user.paperFileNumber)
+    // await page.click('#familyCheck')
+    await page.type('#familyOption', user.familyOption)
+    await page.click('#reason-2')
+    await page.type('#explanation', user.explanation)
+    await clickAndWait(page, '#register-form button')
+
+    const familyCheckError = await page.$eval(
+      '#familyCheck-error',
+      e => e.innerHTML,
+    )
+    expect(familyCheckError).toContain(
+      'You must click ‘I need to reschedule my family too’',
+    )
+  }, 200000)
 })
 
 afterAll(() => {

--- a/src/pages/__tests__/puppeteer-config.js
+++ b/src/pages/__tests__/puppeteer-config.js
@@ -9,7 +9,7 @@ export const isDebugging = () => {
 
   return process.env.NOJS && process.env.NOJS === 'debug'
     ? debugging_mode
-    : { args: ['--no-sandbox'] }
+    : { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
 }
 
 export const user_fr = {


### PR DESCRIPTION
These family check tests are pretty frequently causing errors in our deploy process, even through they run fine locally.

I've looked it up and there are a few issues on github where people add this extra argument when it runs on CI. Also I've split out the two family tests from each other. 

Maybe one of these will resolve our issue.

There's nothing wrong with the test, so I don't want to turn it off.