### PR TITLE
Removed dependency on aws credentials

### DIFF
--- a/src/email/sendmail.js
+++ b/src/email/sendmail.js
@@ -6,10 +6,6 @@ import { getReceivingEmail } from '../locations'
 if (process.env.NODE_ENV !== 'test') {
   if (!process.env.RAZZLE_AWS_REGION)
     throw new Error('process.env.RAZZLE_AWS_REGION was not found')
-  if (!process.env.RAZZLE_AWS_SECRET_ACCESS_KEY)
-    throw new Error('process.env.RAZZLE_AWS_SECRET_ACCESS_KEY was not found')
-  if (!process.env.RAZZLE_AWS_ACCESS_KEY_ID)
-    throw new Error('process.env.AWS_ACCESS_KEY_ID was not found')
   if (!process.env.RAZZLE_SENDING_ADDRESS)
     throw new Error('process.env.RAZZLE_SENDING_ADDRESS was not found')
   if (!process.env.RAZZLE_SITE_URL)
@@ -28,8 +24,6 @@ if (process.env.NODE_ENV !== 'test') {
 
 export const getMailer = async () => {
   AWS.config.update({
-    accessKeyId: process.env.RAZZLE_AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.RAZZLE_AWS_SECRET_ACCESS_KEY,
     region: process.env.RAZZLE_AWS_REGION,
   })
   const mailer = nodemailer.createTransport({


### PR DESCRIPTION
*Don't merge until new infrastructure is deployed.*

Updated infrastructure removes the need for the app to have access to AWS credentials in the environment.  Once it's deployed, this change can be merged.

