### PR TITLE
Skip puppeteer tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
       # run tests!
       - run: yarn a11y:test
-      - run: yarn test:full
+      - run: yarn test
       - run: yarn lint
       - run: yarn extract && yarn compile --strict
       - run: yarn ci:prod

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ We redesigned the letter to make it clearer and simpler to understand, and it is
 
 ## Table of contents
 
-* [Technical overview 💻](#technical-overview-)
-  * [Use of third-party services 📮](#use-of-third-party-services-)
-  * [Automated tests 👩‍🔬](#automated-tests-)
-* [Setup ⚙️](#setup-)
-* [Startup 🚀](#startup-)
-* [Running the tests 🏃‍](#running-the-tests-)
-* [Additional documentation 📝](#additional-documentation-)
-  * [Location setup 🌎](#location-setup-)
-  * [Translations 🇨🇦](#translations-)
-  * [Feature flags 🏁](#feature-flags-)
-  * [Error tracking procedures 🚫](#error-tracking-procedures-)
-  * [Upgrading package dependencies 📦](#upgrading-package-dependencies-)
+* [Technical overview](#technical-overview-)
+  * [Use of third-party services](#use-of-third-party-services-)
+  * [Automated tests](#automated-tests-)
+* [Setup](#setup-)
+* [Startup](#startup-)
+* [Running the tests ‍](#running-the-tests-)
+* [Additional documentation](#additional-documentation-)
+  * [Location setup](#location-setup-)
+  * [Translations](#translations-)
+  * [Feature flags](#feature-flags-)
+  * [Error tracking procedures](#error-tracking-procedures-)
+  * [Upgrading package dependencies](#upgrading-package-dependencies-)
 
 
 ## Technical overview 💻


### PR DESCRIPTION
Something about our setup keeps failing these specific tests on CircleCI, so PR builds and releases keep failing.

There have been a couple attempts to ameliorate this in the past but these tests continue to fail intermittently.

Biting the bullet and removing them from CircleCI.

They can still be run locally with `yarn test:full`