### PR TITLE
Add Content Security Policy and HSTS default headers

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -24,10 +24,8 @@ const server = express()
 const helmet = require('helmet')
 
 server
-  .use(helmet.frameguard({ action: 'deny' })) //// Sets "X-Frame-Options: DENY".
-  .use(helmet.noSniff()) // Sets "X-Content-Type-Options: nosniff".
-  .use(helmet.noCache()) // Set Cache-Control, Surrogate-Control, Pragma, and Expires to no.
-  .use(helmet.xssFilter()) // Sets "X-XSS-Protection: 1; mode=block".
+  .use(helmet()) // sets security-focused headers: https://helmetjs.github.io/
+  .use(helmet.frameguard({ action: 'deny' })) // Sets "X-Frame-Options: DENY".
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR || './public'))
   .use(getPrimarySubdomain)

--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,7 @@ import {
   getPrimarySubdomain,
   ensureLocation,
   setRavenContext,
+  cspConfig,
 } from './utils/serverUtils'
 import { handleSubmitEmail } from './email/handleSubmitEmail'
 import gitHash from './utils/gitHash'
@@ -26,6 +27,7 @@ const helmet = require('helmet')
 server
   .use(helmet()) // sets security-focused headers: https://helmetjs.github.io/
   .use(helmet.frameguard({ action: 'deny' })) // Sets "X-Frame-Options: DENY".
+  .use(helmet.contentSecurityPolicy({ directives: cspConfig }))
   .disable('x-powered-by')
   .use(express.static(process.env.RAZZLE_PUBLIC_DIR || './public'))
   .use(getPrimarySubdomain)

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -118,3 +118,18 @@ export const setRavenContext = (req, res, next) => {
 
   return next()
 }
+
+/* Content Security Policy config */
+
+export const cspConfig = {
+  defaultSrc: ["'self'"],
+  fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+  imgSrc: ["'self'", 'data:', 'https://www.google-analytics.com'],
+  scriptSrc: [
+    "'self'",
+    'https://cdn.ravenjs.com',
+    'https://www.google-analytics.com',
+    "'unsafe-inline'",
+  ],
+  styleSrc: ["'self'", 'https://fonts.googleapis.com', "'unsafe-inline'"],
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -57,6 +57,16 @@ describe('Server Side Rendering', () => {
     )
   })
 
+  it('has our expected Content Security Policy', async () => {
+    let response = await request(server).get('/')
+    expect(response.header['content-security-policy']).toEqual(
+      "default-src 'self'; font-src 'self' https://fonts.gstatic.com; " +
+        "img-src 'self' data: https://www.google-analytics.com; " +
+        "script-src 'self' https://cdn.ravenjs.com https://www.google-analytics.com 'unsafe-inline'; " +
+        "style-src 'self' https://fonts.googleapis.com 'unsafe-inline'",
+    )
+  })
+
   it('doesn’t let on it’s an express app', async () => {
     let response = await request(server).get('/')
     expect(response.header['x-powered-by']).toBeUndefined()

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -20,7 +20,9 @@ describe('Server Side Rendering', () => {
 
   it('renders the calendar page at /calendar', async () => {
     let response = await request(server).get('/calendar')
-    expect(response.text).toMatch(/Make sure you stay available on all of the days you select/)
+    expect(response.text).toMatch(
+      /Make sure you stay available on all of the days you select/,
+    )
   })
 
   it('renders the review page at /review', async () => {
@@ -47,8 +49,16 @@ describe('Server Side Rendering', () => {
     let response = await request(server).get('/')
     expect(response.header['x-frame-options']).toEqual('DENY')
   })
-  it('has no-store protection', async () => {
+
+  it('has an HSTS header', async () => {
     let response = await request(server).get('/')
-    expect(response.header['surrogate-control']).toEqual('no-store')
+    expect(response.header['strict-transport-security']).toEqual(
+      'max-age=15552000; includeSubDomains',
+    )
+  })
+
+  it('doesn’t let on it’s an express app', async () => {
+    let response = await request(server).get('/')
+    expect(response.header['x-powered-by']).toBeUndefined()
   })
 })


### PR DESCRIPTION
Updated default headers with:

- a [Content Security Policy](https://helmetjs.github.io/docs/csp/)
- an [HSTS](https://helmetjs.github.io/docs/hsts/) header

And removed the `noCache` header as I don't think we need it.

Read more here:
- https://expressjs.com/en/advanced/best-practice-security.html#use-helmet
- https://helmetjs.github.io/docs/