### PR TITLE
Build container latest long-term support node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:lts-alpine
 MAINTAINER Dave Samojlenko <dave.samojlenko@cds-snc.ca>
 
 ARG PAPER_FILE_NUMBER_PATTERN


### PR DESCRIPTION
Since `alpine` is pretty general, we want to at least make sure we're on a long-term support version of node.

Node release numbers can be found here: https://nodejs.org/en/download/releases/
Tags for the official node Docker image can be found here: https://hub.docker.com/_/node/
