### PR TITLE
Fix table of contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We redesigned the letter to make it clearer and simpler to understand, and it is
 * [Technical overview](#technical-overview-)
   * [Use of third-party services](#use-of-third-party-services-)
   * [Automated tests](#automated-tests-)
-* [Setup](#setup-)
+* [Setup](#setup)
 * [Startup](#startup-)
 * [Running the tests ‍](#running-the-tests-)
 * [Additional documentation](#additional-documentation-)

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ We redesigned the letter to make it clearer and simpler to understand, and it is
 
 ## Table of contents
 
-* [Technical overview](#technical-overview-)
-  * [Use of third-party services](#use-of-third-party-services-)
+* [Technical overview](#technical-overview)
+  * [Use of third-party services](#use-of-third-party-services)
   * [Automated tests](#automated-tests-)
 * [Setup](#setup)
-* [Startup](#startup-)
-* [Running the tests ‍](#running-the-tests-)
-* [Additional documentation](#additional-documentation-)
-  * [Location setup](#location-setup-)
-  * [Translations](#translations-)
-  * [Feature flags](#feature-flags-)
-  * [Error tracking procedures](#error-tracking-procedures-)
-  * [Upgrading package dependencies](#upgrading-package-dependencies-)
+* [Startup](#startup)
+* [Running the tests ‍](#running-the-tests)
+* [Additional documentation](#additional-documentation)
+  * [Location setup](#location-setup)
+  * [Translations](#translations)
+  * [Feature flags](#feature-flags)
+  * [Error tracking procedures](#error-tracking-procedures)
+  * [Upgrading package dependencies](#upgrading-package-dependencies)
 
 
-## Technical overview 💻
+## Technical overview
 
 The Rescheduler is a full-stack JavaScript application that uses [React](https://reactjs.org/) to build the frontend and the [After.js](https://github.com/jaredpalmer/after.js) framework for the app scaffolding. After.js integrates [React Router](https://reacttraining.com/react-router/) for its routing logic and uses [Razzle](https://github.com/jaredpalmer/razzle) to return server-rendered HTML to the browser. Additionally, we are using [React Context](https://reactjs.org/docs/context.html) as our app-wide data store from which we can hydrate our components.
 
@@ -34,7 +34,7 @@ The Rescheduler aims to make rescheduling an appointment as simple as possible. 
 - There is no external database
 - Our one external API call is to [Amazon's Simple Email Service (SES)](https://aws.amazon.com/ses/) (via [Nodemailer](https://github.com/cds-snc/ircc-rescheduler/blob/c4e7d56ac183fb9b555e047a4ef82fff0c1b866b/src/email/sendmail.js#L35-L37)) to send confirmation of requests to users and local immigration offices
 
-### Use of third-party services 📮
+### Use of third-party services
 
 We use several third-party services for easier development as well as tracking our application out in the wild.
 
@@ -45,7 +45,7 @@ We use several third-party services for easier development as well as tracking o
   - Additionally, [when our container starts up](https://github.com/cds-snc/ircc-rescheduler/blob/master/entrypoint.sh#L4), the source files from the build (ie, the compiled bundle files) [are uploaded to Sentry](https://github.com/cds-snc/ircc-rescheduler/blob/master/package.json#L28) and tagged as the latest release ([docs here](https://docs.sentry.io/clients/javascript/sourcemaps/)). Errors caught in each environment are sent back to Sentry with information about the release they came from, and—because we have uploaded our sourcemaps—Sentry is often able to identify the root of the error for easier debugging.
 - [Google Analytics](https://marketingplatform.google.com/about/analytics/) logs data on pageviews and user behaviour in our production service
 
-### Automated tests 👩‍🔬
+### Automated tests
 
 All new pull requests on GitHub have a suite of tests run against them.
 
@@ -57,7 +57,7 @@ All new pull requests on GitHub have a suite of tests run against them.
 - [Cypress](https://www.cypress.io/): End-to-end behaviour-driven tests that build the app and then run through desired user flows
 
 
-## Setup ⚙️
+## Setup
 
 There’s a bunch of environment variables you’ll need to get our super cool app up and running. [Razzle](https://github.com/jaredpalmer/razzle) accepts a bunch of pre-defined environment variables. It also accepts user-defined variables so long as they are prefixed with `RAZZLE_`.
 
@@ -133,7 +133,7 @@ SENTRY_AUTH_TOKEN='notARealAuthToken'
 ```
 
 
-## Startup 🚀
+## Startup
 
 #### Install dependencies
 
@@ -156,7 +156,7 @@ This is what is run on the server once deployed, so testing against this version
 
 Yes! Now shoot over to [localhost:3004](http://localhost:3004) and try to contain your excitement.
 
-## Running the tests 🏃
+## Running the tests
 
 We have a whole whack of tests, so buckle up.
 
@@ -175,19 +175,19 @@ We have a whole whack of tests, so buckle up.
 *Note: the tests we run on CI are [documented above](#automated-tests-).*
 
 
-## Additional documentation 📝
+## Additional documentation
 
-### [Location setup 🌎](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/location-setup.md)
+### [Location setup](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/location-setup.md)
 Documentation on how to add new locations or modify dates or contact information for existing locations.
 
-### [Translations 🇨🇦](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/translations.md)
+### [Translations](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/translations.md)
 Documentation on how to add new locations or modify configuration for existing locations (for example, available dates or contact information).
 
-### [Feature flags 🏁](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/feature-flags.md)
+### [Feature flags](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/feature-flags.md)
 Feature flags can be used to when merging new code into master before it is completed and ready for release to production. New features can be made visible in some environments (ie, local or staging) but hidden in others (ie, production).
 
-### [Error tracking procedures 🚫](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/error-tracking.md)
+### [Error tracking procedures](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/error-tracking.md)
 Outlines the procedures we follow for resolving captured errors. Also describes some of the metadata we capture and send to Sentry.
 
-### [Upgrading package dependencies 📦](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/upgrade.md)
+### [Upgrading package dependencies](https://github.com/cds-snc/ircc-rescheduler/blob/master/docs/upgrade.md)
 Outlines the procedures we follow for upgrading packages, which we were doing once per (two-week) sprint. Also outlines the process we followed for tracking down vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Reschedule a Citizenship Test service overview 🙅🗓
+# Reschedule a Citizenship Test service overview
 
 This is a service that allows users to reschedule their language tests during the citizenship process. This service was designed and developed by the [Canadian Digital Service](https://digital.canada.ca/), and is now owned and maintained by [Immigration, Refugees, and Citizenship Canada (IRCC)](https://www.canada.ca/en/immigration-refugees-citizenship.html).
 


### PR DESCRIPTION
The 'Setup' link wasn't working in the current `master`. Fixed by removing emoji and suffixed `-` (dash) from the link. 

Removed other emojis to give the sections more predictable links (they were admittedly super cute, but made the predicting the GitHub generated links harder).